### PR TITLE
Stabilizes Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+deps/*
+install/*
+**/*.o
+**/*.so

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -6,11 +6,11 @@ cd deps
 ## DLPACK
 
 echo "Cloning dlpack"
-git clone https://github.com/dmlc/dlpack.git
+git clone --depth 1 https://github.com/dmlc/dlpack.git
 
 
 echo "Building Redis"
-git clone --branch 5.0 https://github.com/antirez/redis.git
+git clone --depth 1 --branch 5.0 https://github.com/antirez/redis.git
 cd redis
 make MALLOC=libc
 cd ..


### PR DESCRIPTION
Breaks the builder to cache-able stages and also reduces the depth of clone in get_deps.sh.

LD_LIBRARY_PATH export added to /etc/profile

Signed-off-by: Itamar Haber <itamar@redislabs.com>