### PR TITLE
Return single-line error in response. Free err details with RM_Free.

### DIFF
--- a/src/err.h
+++ b/src/err.h
@@ -19,6 +19,7 @@ typedef enum {
 typedef struct RAI_Error {
   RAI_ErrorCode code;
   char* detail;
+  char* detail_oneline;
 } RAI_Error;
 
 RAI_Error RAI_InitError();

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -474,7 +474,7 @@ int RedisAI_ModelSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     #ifdef RAI_PRINT_BACKEND_ERRORS
     printf("ERR: %s\n", err.detail);
     #endif
-    int ret = RedisModule_ReplyWithError(ctx, err.detail);
+    int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
     RAI_ClearError(&err);
     return ret;
   }
@@ -531,7 +531,7 @@ void *RedisAI_RunSession(void *arg) {
     #ifdef RAI_PRINT_BACKEND_ERRORS
     printf("ERR: %s\n", err.detail);
     #endif
-    int ret = RedisModule_ReplyWithError(ctx, err.detail);
+    int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
     RAI_ClearError(&err);
     return NULL;
   }
@@ -844,7 +844,7 @@ int RedisAI_ScriptRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
     #ifdef RAI_PRINT_BACKEND_ERRORS
     printf("ERR: %s\n", err.detail);
     #endif
-    int ret = RedisModule_ReplyWithError(ctx, err.detail);
+    int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
     RAI_ClearError(&err);
     return ret;
   }
@@ -918,12 +918,11 @@ int RedisAI_ScriptSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   RAI_Error err = RAI_InitError();
   script = RAI_ScriptCreate(device, scriptdef, &err);
 
-  // if (script == NULL){
   if (err.code != RAI_OK){
     #ifdef RAI_PRINT_BACKEND_ERRORS
     printf("ERR: %s\n", err.detail);
     #endif
-    int ret = RedisModule_ReplyWithError(ctx, err.detail);
+    int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
     RAI_ClearError(&err);
     return ret;
   }

--- a/test/basic_tests.py
+++ b/test/basic_tests.py
@@ -149,3 +149,18 @@ def test_run_mobilenet_multiproc(env):
     env.assertEqual(
         label, 'giant_panda'
     )
+
+def test_set_incorrect_script(env):
+    try:
+        env.execute_command('AI.SCRIPTSET', 'ket', 'CPU', 'return 1')
+    except Exception as e:
+        exception = e
+    env.assertEqual(type(exception), redis.exceptions.ResponseError)
+
+def test_set_correct_script(env):
+    script = '''
+       def foo(a, b):
+           return a + b
+    '''
+    env.execute_command('AI.SCRIPTSET', 'ket', 'CPU', script)
+


### PR DESCRIPTION
This PR should address #73, #74, #75
- changed `free` to `RedisModule_Free` in ClearError
- add tests for correct and incorrect scripts
- return single-line error messages from backends to avoid the Python client hanging