### PR TITLE
get_deps: use `deps` directory by default rather than platform specific

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             sudo ln -s /home/circleci/project/cmake-bin/bin/cmake /usr/local/bin/cmake
             echo `cmake --version`
             rm -rf /home/circleci/project/deps
-            DEPS_DIRECTORY=deps bash get_deps.sh cpu
+            bash get_deps.sh cpu
             git clone git://github.com/antirez/redis.git --branch 5.0
             (cd redis && make malloc=libc -j4 && sudo make install)
 

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -5,13 +5,9 @@ set -x
 BASE_DIRECTORY=`pwd`
 
 # Allow different deps for different platforms:
-PLATNAME=${OSTYPE}
-if [ -e /etc/debian-version ]; then
-    PLATNAME=${PLATNAME}-deb
-fi
 
 if [ -z "$DEPS_DIRECTORY" ]; then
-  DEPS_DIRECTORY=${BASE_DIRECTORY}/deps-${PLATNAME}
+  DEPS_DIRECTORY=${BASE_DIRECTORY}/deps
 fi
 
 mkdir -p ${DEPS_DIRECTORY}


### PR DESCRIPTION
one