### PR TITLE
Ensure buffers are allocated using the Redis allocator

### DIFF
--- a/src/backends/torch.c
+++ b/src/backends/torch.c
@@ -22,7 +22,7 @@ RAI_Model *RAI_ModelCreateTorch(RAI_Backend backend, RAI_Device device,
   }
 
   char* error_descr = NULL;
-  void* model = torchLoadModel(modeldef, modellen, dl_device, &error_descr);
+  void* model = torchLoadModel(modeldef, modellen, dl_device, &error_descr, RedisModule_Alloc);
 
   if (model == NULL) {
     RAI_SetError(error, RAI_EMODELCREATE, error_descr);
@@ -64,8 +64,8 @@ int RAI_ModelRunTorch(RAI_ModelRunCtx* mctx, RAI_Error *error) {
 
   char* error_descr = NULL;
   torchRunModel(mctx->model->model,
-                ninputs, inputs,
-                noutputs, outputs, &error_descr);
+                ninputs, inputs, noutputs, outputs,
+                &error_descr, RedisModule_Alloc);
 
   if (error_descr != NULL) {
     RAI_SetError(error, RAI_EMODELRUN, error_descr);
@@ -89,7 +89,7 @@ int RAI_ModelRunTorch(RAI_ModelRunCtx* mctx, RAI_Error *error) {
 
 int RAI_ModelSerializeTorch(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error) {
   char* error_descr = NULL;
-  torchSerializeModel(model->model, buffer, len, &error_descr);
+  torchSerializeModel(model->model, buffer, len, &error_descr, RedisModule_Alloc);
 
   if (*buffer == NULL) {
     RAI_SetError(error, RAI_EMODELSERIALIZE, error_descr);
@@ -115,7 +115,7 @@ RAI_Script *RAI_ScriptCreateTorch(RAI_Device device, const char *scriptdef, RAI_
   }
 
   char* error_descr = NULL;
-  void* script = torchCompileScript(scriptdef, dl_device, &error_descr);
+  void* script = torchCompileScript(scriptdef, dl_device, &error_descr, RedisModule_Alloc);
 
   if (script == NULL) {
     RAI_SetError(error, RAI_ESCRIPTCREATE, error_descr);
@@ -156,7 +156,9 @@ int RAI_ScriptRunTorch(RAI_ScriptRunCtx* sctx, RAI_Error* error) {
   }
 
   char* error_descr = NULL;
-  torchRunScript(sctx->script->script, sctx->fnname, nInputs, inputs, nOutputs, outputs, &error_descr);
+  torchRunScript(sctx->script->script, sctx->fnname,
+                 nInputs, inputs, nOutputs, outputs,
+                 &error_descr, RedisModule_Alloc);
 
   if (error_descr) {
     printf("F\n");

--- a/src/backends/torch.c
+++ b/src/backends/torch.c
@@ -26,7 +26,7 @@ RAI_Model *RAI_ModelCreateTorch(RAI_Backend backend, RAI_Device device,
 
   if (model == NULL) {
     RAI_SetError(error, RAI_EMODELCREATE, error_descr);
-    free(error_descr);
+    RedisModule_Free(error_descr);
     return NULL;
   }
 
@@ -69,14 +69,14 @@ int RAI_ModelRunTorch(RAI_ModelRunCtx* mctx, RAI_Error *error) {
 
   if (error_descr != NULL) {
     RAI_SetError(error, RAI_EMODELRUN, error_descr);
-    free(error_descr);
+    RedisModule_Free(error_descr);
     return 1;
   }
 
   for(size_t i=0 ; i<array_len(mctx->outputs) ; ++i) {
     if (outputs[i] == NULL) {
       RAI_SetError(error, RAI_EMODELRUN, "Model did not generate the expected number of outputs.");
-      free(error_descr);
+      RedisModule_Free(error_descr);
       return 1;
     }
     RAI_Tensor* output_tensor = RAI_TensorCreateFromDLTensor(outputs[i]);
@@ -93,7 +93,7 @@ int RAI_ModelSerializeTorch(RAI_Model *model, char **buffer, size_t *len, RAI_Er
 
   if (*buffer == NULL) {
     RAI_SetError(error, RAI_EMODELSERIALIZE, error_descr);
-    free(error_descr);
+    RedisModule_Free(error_descr);
     return 1;
   }
 
@@ -119,7 +119,7 @@ RAI_Script *RAI_ScriptCreateTorch(RAI_Device device, const char *scriptdef, RAI_
 
   if (script == NULL) {
     RAI_SetError(error, RAI_ESCRIPTCREATE, error_descr);
-    free(error_descr);
+    RedisModule_Free(error_descr);
     return NULL;
   }
 
@@ -163,7 +163,7 @@ int RAI_ScriptRunTorch(RAI_ScriptRunCtx* sctx, RAI_Error* error) {
   if (error_descr) {
     printf("F\n");
     RAI_SetError(error, RAI_ESCRIPTRUN, error_descr);
-    free(error_descr);
+    RedisModule_Free(error_descr);
     return 1;
   }
 

--- a/src/model.c
+++ b/src/model.c
@@ -93,9 +93,9 @@ static void RAI_Model_RdbSave(RedisModuleIO *io, void *value) {
   }
   RedisModule_SaveStringBuffer(io, buffer, len);
 
-  // if (buffer) {
-  //   RedisModule_Free(buffer);
-  // }
+  if (buffer) {
+    RedisModule_Free(buffer);
+  }
 }
 
 static void RAI_Model_AofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *value) {

--- a/util/libtorch_c/torch_c.h
+++ b/util/libtorch_c/torch_c.h
@@ -13,22 +13,24 @@ DLManagedTensor* torchNewTensor(DLDataType dtype, long ndims,
                                 int64_t* shape, int64_t* strides,
                                 char* data);
 
-void* torchCompileScript(const char* script, DLDeviceType device, char **error);
+void* torchCompileScript(const char* script, DLDeviceType device,
+                         char **error, void* (*alloc)(size_t));
 
 void* torchLoadModel(const char* model, size_t modellen, DLDeviceType device,
-                     char **error);
+                     char **error, void* (*alloc)(size_t));
 
 void torchRunScript(void* scriptCtx, const char* fnName,
                     long nInputs, DLManagedTensor** inputs,
                     long nOutputs, DLManagedTensor** outputs,
-                    char **error);
+                    char **error, void* (*alloc)(size_t));
 
 void torchRunModel(void* modelCtx,
                    long nInputs, DLManagedTensor** inputs,
                    long nOutputs, DLManagedTensor** outputs,
-                   char **error);
+                   char **error, void* (*alloc)(size_t));
 
-void torchSerializeModel(void* modelCtx, char **buffer, size_t *len, char **error);
+void torchSerializeModel(void* modelCtx, char **buffer, size_t *len,
+                         char **error, void* (*alloc)(size_t));
 
 void torchDeallocContext(void* ctx);
 


### PR DESCRIPTION
Make sure libtorch_c uses the Redis allocator for pointers that will be then freed with RedisModule_Free.

Should solve #125