### PR TITLE
Use dynamically sized arrays to avoid leak

### DIFF
--- a/src/backends/torch.c
+++ b/src/backends/torch.c
@@ -51,8 +51,10 @@ int RAI_ModelRunTorch(RAI_ModelRunCtx* mctx, RAI_Error *error) {
   size_t ninputs = array_len(mctx->inputs);
   size_t noutputs = array_len(mctx->outputs);
 
-  DLManagedTensor** inputs = RedisModule_Calloc(ninputs, sizeof(*inputs));
-  DLManagedTensor** outputs = RedisModule_Calloc(noutputs, sizeof(*outputs));
+  // DLManagedTensor** inputs = RedisModule_Calloc(ninputs, sizeof(*inputs));
+  // DLManagedTensor** outputs = RedisModule_Calloc(noutputs, sizeof(*outputs));
+  DLManagedTensor* inputs[ninputs];
+  DLManagedTensor* outputs[noutputs];
 
   for (size_t i=0 ; i<ninputs; ++i) {
     inputs[i] = &mctx->inputs[i].tensor->tensor;


### PR DESCRIPTION
The same thing is already done in TF and SCRIPT, but not in Torch run.
Thanks to @hhsecond for spotting this.