### PR TITLE
Add libgomp1 as dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM redis AS builder
 
-ENV DEPS "build-essential git ca-certificates curl unzip wget"
+ENV DEPS "build-essential git ca-certificates curl unzip wget libgomp1"
 
 # install latest cmake
 ADD https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh /cmake-3.12.4-Linux-x86_64.sh

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 AS builder
 
-ENV DEPS "build-essential git ca-certificates curl unzip wget"
+ENV DEPS "build-essential git ca-certificates curl unzip wget libgomp1"
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 


### PR DESCRIPTION
This should address the current failure in docker edge
```
6:M 14 Jun 2019 00:00:49.355 # Module /usr/lib/redis/modules/redisai.so failed to load: libgomp.so.1: cannot open shared object file: No such file or directory
``` 