### PR TITLE
Replicate results of run commands instead of verbatim

### DIFF
--- a/opt/Makefile
+++ b/opt/Makefile
@@ -134,7 +134,7 @@ ifneq ($(NO_LFS),1)
 endif
 	$(SHOW)set -e ;\
 	cd $(ROOT)/test ;\
-	python3 -m RLTest $(TEST_ARGS) --test basic_tests.py --module $(INSTALL_DIR)/redisai.so ;\
+	python3 -m RLTest $(TEST_ARGS) --test basic_tests.py --module $(INSTALL_DIR)/redisai.so --use-slaves ;\
 	python3 -m RLTest $(TEST_ARGS) --test  double-panda.py --module $(INSTALL_DIR)/redisai.so
 
 #----------------------------------------------------------------------------------------------

--- a/ramp.yml
+++ b/ramp.yml
@@ -5,7 +5,7 @@ description: Serving tensors and executing deep learning graphs
 homepage: https://oss.redislabs.com/redisai/
 license: GNU Affero General Public License v3.0
 command_line_args: ""
-min_redis_version: "5.0"
+min_redis_version: "5.0.7"
 min_redis_pack_version: "5.4"
 capabilities:
     - types

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -406,7 +406,6 @@ int RedisAI_TensorGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   else {
     RedisModule_ReplyWithError(ctx, "ERR unsupported dtype");
   }
-  RedisModule_Free(dtypestr);
 
   RedisModule_ReplyWithArray(ctx, ndims);
   for (long long i=0; i<ndims; i++) {

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -610,8 +610,6 @@ int RedisAI_ModelSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   RedisModule_ReplyWithSimpleString(ctx, "OK");
 
-  RedisModule_ReplicateVerbatim(ctx);
-
   return REDISMODULE_OK;
 }
 

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -14,6 +14,7 @@ RAI_Tensor* RAI_TensorCreateFromDLTensor(DLManagedTensor* dl_tensor);
 size_t RAI_TensorLength(RAI_Tensor* t);
 size_t RAI_TensorGetDataSize(const char* dataTypeStr);
 DLDataType RAI_TensorDataType(RAI_Tensor* t);
+void Tensor_DataTypeStr(DLDataType dtype, char **dtypestr);
 void RAI_TensorFree(RAI_Tensor* t);
 int RAI_TensorSetData(RAI_Tensor* t, const char* data, size_t len);
 int RAI_TensorSetValueFromLongLong(RAI_Tensor* t, long long i, long long val);

--- a/test/basic_tests.py
+++ b/test/basic_tests.py
@@ -102,6 +102,8 @@ def test_set_tensor(env):
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
+    time.sleep(0.1)
+
     for _ in con.reloadingIterator():
         env.assertExists('x')
 
@@ -243,6 +245,12 @@ def test_run_tf_model(env):
     values = tensor[-1]
     con.assertEqual(values, [b'4', b'9', b'4', b'9'])
 
+    if env.useSlaves:
+        con2 = env.getSlaveConnection()
+        time.sleep(0.1)
+        tensor2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')
+        con.assertEqual(tensor2, tensor)
+
     for _ in con.reloadingIterator():
         env.assertExists('m')
         env.assertExists('a')
@@ -343,6 +351,12 @@ def test_run_torch_model(env):
     tensor = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
     values = tensor[-1]
     con.assertEqual(values, [b'4', b'6', b'4', b'6'])
+
+    if env.useSlaves:
+        con2 = env.getSlaveConnection()
+        time.sleep(0.1)
+        tensor2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')
+        con.assertEqual(tensor2, tensor)
 
     for _ in con.reloadingIterator():
         env.assertExists('m')
@@ -450,6 +464,12 @@ def test_run_onnx_model(env):
 
     env.assertEqual(argmax, 1)
 
+    if env.useSlaves:
+        con2 = env.getSlaveConnection()
+        time.sleep(0.1)
+        tensor2 = con2.execute_command('AI.TENSORGET', 'b', 'VALUES')
+        con.assertEqual(tensor2, tensor)
+
     for _ in con.reloadingIterator():
         env.assertExists('m')
         env.assertExists('a')
@@ -489,6 +509,14 @@ def test_run_onnxml_model(env):
 
     env.assertEqual(float(linear_out[2][0]), -0.090524077415466309)
     env.assertEqual(logreg_out[2][0], 0)
+
+    if env.useSlaves:
+        con2 = env.getSlaveConnection()
+        time.sleep(0.1)
+        linear_out2 = con2.execute_command('AI.TENSORGET', 'linear_out', 'VALUES')
+        logreg_out2 = con2.execute_command('AI.TENSORGET', 'logreg_out', 'VALUES')
+        env.assertEqual(linear_out, linear_out2)
+        env.assertEqual(logreg_out, logreg_out2)
 
     for _ in con.reloadingIterator():
         env.assertExists('linear')
@@ -743,6 +771,8 @@ def test_set_correct_script(env):
 
     env.execute_command('AI.SCRIPTSET', 'ket', 'CPU', script)
 
+    time.sleep(0.1)
+
     for _ in env.reloadingIterator():
         env.assertExists('ket')
 
@@ -806,6 +836,14 @@ def test_run_script(env):
     tensor = env.execute_command('AI.TENSORGET', 'c', 'VALUES')
     values = tensor[-1]
     env.assertEqual(values, [b'4', b'6', b'4', b'6'])
+
+    time.sleep(0.1)
+
+    if env.useSlaves:
+        con2 = env.getSlaveConnection()
+        time.sleep(0.1)
+        tensor2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')
+        env.assertEqual(tensor2, tensor)
 
     for _ in env.reloadingIterator():
         env.assertExists('ket')


### PR DESCRIPTION
Adresses #84.
Replication of MODELRUN and SCRIPTRUN commands will not lead to re-executing the computation on the replicas, but just to setting the outputs on the replicas. Tests now include using replicas.