### PR TITLE
Add support for ONNXRuntime 0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,15 +39,6 @@ IF (NOT ORT_LIBRARIES)
     MESSAGE(FATAL_ERROR "Could not find ONNXRuntime")
 ENDIF()
 
-IF (APPLE)
-    FIND_LIBRARY(MKL_LIBRARIES NAMES mklml
-                 PATHS ${depsAbs}/onnxruntime/lib)
-    IF (NOT MKL_LIBRARIES)
-        MESSAGE(FATAL_ERROR "Could not find MKL for Mac")
-    ENDIF()
-    SET(TORCH_LIBRARIES "${MKL_LIBRARIES}")
-ENDIF()
-
 # Find Torch stuff and build our wrapper
 SET (Torch_DIR ${depsAbs}/libtorch/share/cmake/Torch)
 FIND_PACKAGE(Torch REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ INCLUDE_DIRECTORIES(${depsAbs}/onnxruntime/include)
 
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-SET(CMAKE_C_STANDARD 99)
+SET(CMAKE_C_STANDARD 11)
 
 FIND_LIBRARY(TF_LIBRARIES NAMES tensorflow libtensorflow.so
              PATHS ${depsAbs}/libtensorflow/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ PROJECT(RedisAI)
 
 IF (NOT DEPS_PATH)
     # dependencies are required!
-    MESSAGE(FATAL_ERROR "DEPS PATH Missing!")
+    SET(DEPS_PATH ../deps/install)
+    # MESSAGE(FATAL_ERROR "DEPS PATH Missing!")
 ENDIF()
 
 FUNCTION(ADD_LDFLAGS _TARGET NEW_FLAGS)

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -116,7 +116,7 @@ if [[ "${PT_OS}" == "macos" ]]; then
 fi
 
 ## ONNXRUNTIME
-ORT_VERSION="0.4.0"
+ORT_VERSION="0.5.0"
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
   if [[ "$1" == "cpu" ]]; then
     ORT_OS="linux-x64"

--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -4,10 +4,6 @@
 
 #include "onnxruntime_c_api.h"
 
-// TODO for getpid, remove when ONNXRuntime can read from stream
-#include <sys/types.h>
-#include <unistd.h>
-
 int RAI_InitBackendORT(int (*get_api_fn)(const char *, void *)) {
   get_api_fn("RedisModule_Alloc", ((void **)&RedisModule_Alloc));
   get_api_fn("RedisModule_Calloc", ((void **)&RedisModule_Calloc));
@@ -115,7 +111,13 @@ error:
 }
 
 RAI_Tensor* RAI_TensorCreateFromOrtValue(OrtValue* v, RAI_Error *error) {
-  if (!OrtIsTensor(v)) {
+  OrtStatus* status = NULL;
+
+  int is_tensor;
+  status = OrtIsTensor(v, &is_tensor);
+  if (status != NULL) goto error;
+
+  if (!is_tensor) {
     // TODO: if not tensor, flatten the data structure (sequence or map) and store it in a tensor.
     // If return value is string, emit warning.
     return NULL;
@@ -128,21 +130,22 @@ RAI_Tensor* RAI_TensorCreateFromOrtValue(OrtValue* v, RAI_Error *error) {
       .device_id = 0
   };
 
-  OrtStatus* status = NULL;
-
-  OrtTensorTypeAndShapeInfo* info = OrtCreateTensorTypeAndShapeInfo();
-  status = OrtGetTensorShapeAndType(v, &info);
-  if (status != NULL) {
-    goto error;
-  }
+  OrtTensorTypeAndShapeInfo* info;
+  status = OrtGetTensorTypeAndShape(v, &info);
+  if (status != NULL) goto error;
 
   {
-    size_t ndims = OrtGetNumOfDimensions(info);
+    size_t ndims;
+    status = OrtGetDimensionsCount(info, &ndims);
+    if (status != NULL) goto error;
 
     int64_t dims[ndims];
-    OrtGetDimensions(info, dims, ndims);
+    status = OrtGetDimensions(info, dims, ndims);
+    if (status != NULL) goto error;
 
-    enum ONNXTensorElementDataType ort_dtype = OrtGetTensorElementType(info);
+    enum ONNXTensorElementDataType ort_dtype;
+    status = OrtGetTensorElementType(info, &ort_dtype);
+    if (status != NULL) goto error;
 
     int64_t *shape = RedisModule_Calloc(ndims, sizeof(*shape));
     int64_t *strides = RedisModule_Calloc(ndims, sizeof(*strides));
@@ -160,11 +163,20 @@ RAI_Tensor* RAI_TensorCreateFromOrtValue(OrtValue* v, RAI_Error *error) {
 #ifdef RAI_COPY_RUN_OUTPUT
     char *ort_data;
     status = OrtGetTensorMutableData(v, (void **)&ort_data);
-    if (status != NULL)
-    {
+    if (status != NULL) {
+      RedisModule_Free(shape);
+      RedisModule_Free(strides);
       goto error;
     }
-    size_t len = dtype.bits * OrtGetTensorShapeElementCount(info);
+    size_t elem_count;
+    status = OrtGetTensorShapeElementCount(info, &elem_count);
+    if (status != NULL) {
+      RedisModule_Free(shape);
+      RedisModule_Free(strides);
+      goto error;
+    }
+
+    size_t len = dtype.bits * elem_count;
     char *data = RedisModule_Calloc(len, sizeof(*data));
     memcpy(data, ort_data, len);
 #endif
@@ -225,9 +237,15 @@ RAI_Model *RAI_ModelCreateORT(RAI_Backend backend, RAI_Device device,
   }
 
   // TODO: probably these options could be configured at the AI.CONFIG level
-  OrtSessionOptions* session_options = OrtCreateSessionOptions();
-  OrtSetSessionThreadPoolSize(session_options, 1);
-  OrtSetSessionGraphOptimizationLevel(session_options, 1);
+  OrtSessionOptions* session_options;
+  status = OrtCreateSessionOptions(&session_options);
+  if (status != NULL) goto error;
+
+  status = OrtSetSessionThreadPoolSize(session_options, 1);
+  if (status != NULL) goto error;
+
+  status = OrtSetSessionGraphOptimizationLevel(session_options, 1);
+  if (status != NULL) goto error;
 
   // TODO: we will need to propose a more dynamic way to request a specific provider,
   // e.g. given the name, in ONNXRuntiem
@@ -239,37 +257,9 @@ RAI_Model *RAI_ModelCreateORT(RAI_Backend backend, RAI_Device device,
 
   OrtSession* session;
 
-#define RAI_ONNX_NO_SESSION_FROM_ARRAY
-#ifdef RAI_ONNX_NO_SESSION_FROM_ARRAY
-  // NOTE This works as long as setting a model is mono-thread
-  // Since this solution is temporary until ONNXRuntime implements
-  // loading a model from a buffer, we'll keep this as is
-  char tmpfile[256];
-  FILE *fp;
-  snprintf(tmpfile, 256, "temp-%d.onnx", (int) getpid());
-  fp = fopen(tmpfile, "w");
-  if (!fp) {
-    RAI_SetError(error, RAI_EMODELCREATE, "ERR: cannot write ONNX tmp file\n");
-    return NULL;
-  }
-  size_t nwritten = fwrite(modeldef, sizeof(char), modellen, fp);
-  if (nwritten < modellen ||
-      fflush(fp) == EOF || 
-      fsync(fileno(fp)) == -1 ||
-      fclose(fp) == EOF) {
-    RAI_SetError(error, RAI_EMODELCREATE, "ERR: cannot flush or close ONNX tmp file\n");
-    return NULL;
-  }
-  status = OrtCreateSession(env, tmpfile, session_options, &session);
-#else
-  onnx_status = OrtCreateSessionFromArray(env, modeldef, modellen, session_options, &session);
-#endif
+  status = OrtCreateSessionFromArray(env, modeldef, modellen, session_options, &session);
 
   OrtReleaseSessionOptions(session_options);
-
-#ifdef RAI_ONNX_NO_SESSION_FROM_ARRAY
-  unlink(tmpfile);
-#endif
 
   if (status != NULL) {
     goto error;


### PR DESCRIPTION
Addresses #179 

Release notes for ONNXRuntime 0.5 are here: https://github.com/microsoft/onnxruntime/releases/tag/v0.5.0

Notable changes:
- we don't need to write the model to a tmp file and then load, but we load the model directly from a buffer
- support for CUDA 10 (at this point we should consider switching all backends to CUDA 10, I'll open and issue for that)
- there's initial support for OpenVINO executors (which in turn can control devices like the Intel Movidius, etc, see https://docs.openvinotoolkit.org)