### PR TITLE
Bump dependencies to PyTorch 1.2 and TensorFlow 1.14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 SET(CMAKE_C_STANDARD 11)
 
-FIND_LIBRARY(TF_LIBRARIES NAMES tensorflow libtensorflow.so
+FIND_LIBRARY(TF_LIBRARIES NAMES tensorflow
              PATHS ${depsAbs}/libtensorflow/lib)
 IF (NOT TF_LIBRARIES)
     MESSAGE(FATAL_ERROR "Could not find tensorflow")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,10 @@ ENDIF()
 INSTALL(TARGETS redisai_torch LIBRARY DESTINATION backends/redisai_torch)
 INSTALL(DIRECTORY ${depsAbs}/libtorch/lib DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/redisai_torch)
 
+IF(${DEVICE} STREQUAL "gpu")
+  ADD_DEFINITIONS(-DRAI_ONNXRUNTIME_USE_CUDA)
+ENDIF()
+
 ADD_LIBRARY(redisai_onnxruntime SHARED $<TARGET_OBJECTS:redisai_onnxruntime_obj>)
 TARGET_LINK_LIBRARIES(redisai_onnxruntime ${ORT_LIBRARIES})
 SET_TARGET_PROPERTIES(redisai_onnxruntime PROPERTIES PREFIX "")

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04 AS builder
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04 AS builder
 
 ENV DEPS "build-essential git ca-certificates curl unzip wget libgomp1 patchelf"
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 AS builder
+FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04 AS builder
 
 ENV DEPS "build-essential git ca-certificates curl unzip wget libgomp1 patchelf"
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ redis-cli
 ```
 
 ## Building
-This will checkout and build and download the libraries for the backends (TensorFlow, PyTorch, ONNXRuntime) for your platform. Note that this requires CUDA to be installed.
+This will checkout and build and download the libraries for the backends (TensorFlow, PyTorch, ONNXRuntime) for your platform. Note that this requires CUDA 10.0 to be installed.
 
 ```sh
 bash get_deps.sh
 ```
+
 Alternatively, run the following to only fetch the CPU-only backends even on GPU machines.
 ```sh
 bash get_deps.sh cpu
@@ -106,8 +107,8 @@ RedisAI currently supports PyTorch (libtorch), Tensorflow (libtensorflow) and ON
 |:--------|:-------:|:----------:|:-------------:|
 | 0.1.0   | 1.0.1     | 1.12.0     | None          |
 | 0.2.1   | 1.0.1     | 1.12.0     | None          |
-| 0.3.1   | 1.1     | 1.12.0     | 0.4.0         |
-| master  | 1.1     | 1.12.0     | 0.5.0         |
+| 0.3.1   | 1.1.0     | 1.12.0     | 0.4.0         |
+| master  | 1.2.0     | 1.14.0     | 0.5.0         |
 
 
 ## Documentation

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -6,18 +6,18 @@ set -e
 [[ $VERBOSE == 1 ]] && set -x
 
 if [[ "$1" == "cpu" ]]; then
-	GPU=no
-	DEVICE=cpu
+  GPU=no
+  DEVICE=cpu
 elif [[ "$1" == "gpu" ]]; then
-	GPU=yes
-	DEVICE=gpu
+  GPU=yes
+  DEVICE=gpu
 else
-	GPU=${GPU:-no}
-	if [[ $GPU == 1 ]]; then
-		DEVICE=gpu
-	else
-		DEVICE=cpu
-	fi
+  GPU=${GPU:-no}
+  if [[ $GPU == 1 ]]; then
+    DEVICE=gpu
+  else
+    DEVICE=cpu
+  fi
 fi
 
 DEPS_DIR=$HERE/deps
@@ -39,19 +39,19 @@ ORT_PREFIX=${PREFIX}/onnxruntime
 if [[ ! -d dlpack ]]; then
     echo "Cloning dlpack ..."
     git clone --depth 1 https://github.com/dmlc/dlpack.git
-	echo "Done."
+    echo "Done."
 else
   echo "dlpack is in place."
 fi
 
 if [[ ! -d ${DLPACK_PREFIX}/include ]]; then
-	mkdir -p ${DLPACK_PREFIX}
-	ln -sf ${DEPS_DIR}/dlpack/include ${DLPACK_PREFIX}/include
+    mkdir -p ${DLPACK_PREFIX}
+    ln -sf ${DEPS_DIR}/dlpack/include ${DLPACK_PREFIX}/include
 fi
 
 ## TENSORFLOW
 
-TF_VERSION="1.12.0"
+TF_VERSION="1.14.0"
 
 [[ $FORCE == 1 ]] && rm -rf ${TF_PREFIX}
 
@@ -88,8 +88,7 @@ fi
 
 ## PYTORCH
 
-PT_VERSION="1.1.0"
-#PT_VERSION="latest"
+PT_VERSION="1.2.0"
 
 [[ $FORCE == 1 ]] && rm -rf ${TORCH_PREFIX}
 
@@ -132,16 +131,16 @@ if [[ ! -d ${TORCH_PREFIX} ]]; then
   echo "Done."
   
   if [[ "${PT_OS}" == "macos" ]]; then
-	echo "Installing MKL ..."
+    echo "Installing MKL ..."
     # also download mkl
     MKL_BUNDLE=mklml_mac_2019.0.3.20190220
     if [ ! -e "${MKL_BUNDLE}.tgz" ]; then
       wget -q "https://github.com/intel/mkl-dnn/releases/download/v0.18/${MKL_BUNDLE}.tgz"
     fi
     tar xzf ${MKL_BUNDLE}.tgz --no-same-owner --strip-components=1 -C ${TORCH_PREFIX}
-	mkdir -p ${ORT_PREFIX}
+    mkdir -p ${ORT_PREFIX}
     tar xzf ${MKL_BUNDLE}.tgz --no-same-owner --strip-components=1 -C ${ORT_PREFIX}
-	echo "Done."
+    echo "Done."
   fi
 else
   echo "librotch is in place."

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -102,7 +102,7 @@ if [[ ! -d ${TORCH_PREFIX} ]]; then
     if [[ "$1" == "cpu" ]]; then
       PT_BUILD="cpu"
     else
-      PT_BUILD="cu90"
+      PT_BUILD="cu100"
     fi
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     PT_OS="macos"

--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -265,7 +265,7 @@ RAI_Model *RAI_ModelCreateORT(RAI_Backend backend, RAI_Device device,
   }
 
   // TODO: we will need to propose a more dynamic way to request a specific provider,
-  // e.g. given the name, in ONNXRuntiem
+  // e.g. given the name, in ONNXRuntime
 #if RAI_ONNXRUNTIME_USE_CUDA
   if (device == RAI_DEVICE_GPU) {
     OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, 0);


### PR DESCRIPTION
Addresses #181

Both PyTorch 1.2.0 and TensorFlow 1.14.0 should be backward-compatible: tests with previously exported models pass.