### PR TITLE
[add] changed RedisAI_Run_ThreadMain to only sleep if the last Pop was empty

### DIFF
--- a/src/redisai.c
+++ b/src/redisai.c
@@ -1042,12 +1042,13 @@ void *RedisAI_Run_ThreadMain(void *arg) {
 
     if (item) {
       RedisAI_RunSession(item->value);
+    } 
+    else {
+      // only sleep if the last Pop was empty
+      usleep(1000);
     }
-
     // release item (note: the callback does it; verify)
     // unblock (the callback does it)
-
-    usleep(1000);
   }
 }
 


### PR DESCRIPTION
comparing with the current master branch ( ae63a99b51f5e676d5e85654dde41d63522e4752 ), changing RedisAI_Run_ThreadMain to only sleep if the last Pop was empty. 

Used [aibench creditcard-fraud testcase](https://github.com/filipecosta90/aibench)

# Mean Rate inferences/sec ( from aibench_run_inference_redisai client )
 ( on OSS redis-server 5.0.5 )


Testcase | RedisAI Master OSS| RedisAI filipecosta90:perf-queuePop OSS | Difference (inferences/sec) | % improvement
-- | -- | -- | -- | --
aibench_run_inference_redisai | 888 | 16789.37 | 15901.37 | 1790.69%


# Inference query time improvements 

## Current master version results 
```bash
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Run complete after 100000 queries with 16 workers:
All queries                                                 :
+ Inference execution latency (statistical histogram):
	min:    16.20 ms,  mean:    18.03 ms, q25:    17.98 ms, med(q50):    18.04 ms, q75:    18.08 ms, q99:    18.17 ms, max:    27.84 ms, stddev:     0.09ms, sum: 1803.295 sec, count: 100000, timedOut count: 0

RedisAI Query - with AI.TENSORSET transacation datatype BLOB:
+ Inference execution latency (statistical histogram):
	min:    16.20 ms,  mean:    18.03 ms, q25:    17.98 ms, med(q50):    18.04 ms, q75:    18.08 ms, q99:    18.17 ms, max:    27.84 ms, stddev:     0.09ms, sum: 1803.295 sec, count: 100000, timedOut count: 0
```

## with changes

```bash
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Run complete after 100000 queries with 16 workers:
All queries                                                 :
+ Inference execution latency (statistical histogram):
	min:     0.21 ms,  mean:     0.95 ms, q25:     0.91 ms, med(q50):     0.95 ms, q75:     0.99 ms, q99:     1.11 ms, max:     2.67 ms, stddev:     0.07ms, sum: 94.990 sec, count: 100000, timedOut count: 0

RedisAI Query - with AI.TENSORSET transacation datatype BLOB:
+ Inference execution latency (statistical histogram):
	min:     0.21 ms,  mean:     0.95 ms, q25:     0.91 ms, med(q50):     0.95 ms, q75:     0.99 ms, q99:     1.11 ms, max:     2.67 ms, stddev:     0.07ms, sum: 94.990 sec, count: 100000, timedOut count: 0

```
