### PR TITLE
fixing memory leak on RAI_ModelCreateTF and RAI_ModelRunTF when status != TF_OK due to unfreed error message

### DIFF
--- a/src/redisai.c
+++ b/src/redisai.c
@@ -1049,6 +1049,8 @@ void *RedisAI_Run_ThreadMain(void *arg) {
 
     if (item) {
       RedisAI_RunSession(item->value);
+      RedisModule_Free(item);
+      
     } 
     else {
       // only sleep if the last Pop was empty


### PR DESCRIPTION
addresses #209 .

valgrind output after solving the unfreed error message memory. ( same test priorly pointed towards 780,780 bytes lost on RM_Strdup within `RedisModule_Strdup(TF_Message(status))` )
```
59740:M 08 Sep 2019 05:35:59.991 # User requested shutdown...
59740:M 08 Sep 2019 05:35:59.994 # Redis is now ready to exit, bye bye...
--59740:0:schedule VG_(sema_down): read returned -4
==59740== 
==59740== HEAP SUMMARY:
==59740==     in use at exit: 675,574,160 bytes in 3,638,298 blocks
==59740==   total heap usage: 11,277,530 allocs, 7,639,232 frees, 4,435,264,496 bytes allocated
==59740== 
==59740== 7 bytes in 1 blocks are definitely lost in loss record 30 of 77,668
==59740==    at 0x10025EAD5: malloc (in /usr/local/Cellar/valgrind/HEAD-60ab74a/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==59740==    by 0x100019738: zmalloc (zmalloc.c:99)
==59740==    by 0x100019A85: zstrdup (zmalloc.c:210)
==59740==    by 0x1000A7F34: RM_Strdup (module.c:341)
==59740==    by 0x1015AE3F4: RAI_ModelCreateTF (tensorflow.c:274)
==59740==    by 0x1015923B5: RAI_ModelCreate (model.c:219)
==59740==    by 0x101589419: RedisAI_ModelSet_RedisCommand (redisai.c:581)
==59740==    by 0x1000A87CC: RedisModuleCommandDispatcher (module.c:542)
==59740==    by 0x100010C25: call (server.c:2439)
==59740==    by 0x100011A99: processCommand (server.c:2733)
==59740==    by 0x100025E95: processInputBuffer (networking.c:1470)
==59740==    by 0x1000260AA: processInputBufferAndReplicate (networking.c:1505)
==59740== 
==59740== 8 bytes in 1 blocks are definitely lost in loss record 167 of 77,668
==59740==    at 0x10025EAD5: malloc (in /usr/local/Cellar/valgrind/HEAD-60ab74a/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==59740==    by 0x1010A5377: operator new(unsigned long) (in /usr/lib/libc++abi.dylib)
==59740==    by 0x104BC7A69: _GLOBAL__sub_I_client_context.cc (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x1001A4591: ImageLoaderMachO::doModInitFunctions(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x1001A4797: ImageLoaderMachO::doInitialization(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x10019FBE9: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740==    by 0x10019FB7F: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740==    by 0x10019ED72: ImageLoader::processInitializers(ImageLoader::LinkContext const&, unsigned int, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740==    by 0x10019EE04: ImageLoader::runInitializers(ImageLoader::LinkContext const&, ImageLoader::InitializerTimingList&) (in /usr/lib/dyld)
==59740==    by 0x100191CB1: dyld::runInitializers(ImageLoader*) (in /usr/lib/dyld)
==59740==    by 0x10019B3DB: dlopen_internal (in /usr/lib/dyld)
==59740==    by 0x1003C3D42: dlopen (in /usr/lib/system/libdyld.dylib)
==59740== 
==59740== 8 bytes in 1 blocks are definitely lost in loss record 168 of 77,668
==59740==    at 0x10025EAD5: malloc (in /usr/local/Cellar/valgrind/HEAD-60ab74a/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==59740==    by 0x1010A5377: operator new(unsigned long) (in /usr/lib/libc++abi.dylib)
==59740==    by 0x1089AE5DC: absl::container_internal::Sample() (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x1091317D1: absl::container_internal::raw_hash_set<absl::container_internal::FlatHashMapPolicy<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::unique_ptr<tensorflow::grappler::Vectorizer, std::__1::default_delete<tensorflow::grappler::Vectorizer> > >, absl::container_internal::StringHash, absl::container_internal::StringHashEq::Eq, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::unique_ptr<tensorflow::grappler::Vectorizer, std::__1::default_delete<tensorflow::grappler::Vectorizer> > > > >::initialize_slots() (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x10913118C: absl::container_internal::raw_hash_set<absl::container_internal::FlatHashMapPolicy<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::unique_ptr<tensorflow::grappler::Vectorizer, std::__1::default_delete<tensorflow::grappler::Vectorizer> > >, absl::container_internal::StringHash, absl::container_internal::StringHashEq::Eq, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::unique_ptr<tensorflow::grappler::Vectorizer, std::__1::default_delete<tensorflow::grappler::Vectorizer> > > > >::resize(unsigned long) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x1091310F5: absl::container_internal::raw_hash_set<absl::container_internal::FlatHashMapPolicy<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::unique_ptr<tensorflow::grappler::Vectorizer, std::__1::default_delete<tensorflow::grappler::Vectorizer> > >, absl::container_internal::StringHash, absl::container_internal::StringHashEq::Eq, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::unique_ptr<tensorflow::grappler::Vectorizer, std::__1::default_delete<tensorflow::grappler::Vectorizer> > > > >::prepare_insert(unsigned long) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x109130FDB: std::__1::pair<unsigned long, bool> absl::container_internal::raw_hash_set<absl::container_internal::FlatHashMapPolicy<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::unique_ptr<tensorflow::grappler::Vectorizer, std::__1::default_delete<tensorflow::grappler::Vectorizer> > >, absl::container_internal::StringHash, absl::container_internal::StringHashEq::Eq, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::unique_ptr<tensorflow::grappler::Vectorizer, std::__1::default_delete<tensorflow::grappler::Vectorizer> > > > >::find_or_prepare_insert<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x109130D54: tensorflow::grappler::VectorizerRegistry::Register(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::unique_ptr<tensorflow::grappler::Vectorizer, std::__1::default_delete<tensorflow::grappler::Vectorizer> >) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x1090CA09A: _GLOBAL__sub_I_cwise_op_vectorizer.cc (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x1001A4591: ImageLoaderMachO::doModInitFunctions(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x1001A4797: ImageLoaderMachO::doInitialization(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x10019FBE9: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740== 
==59740== 22 bytes in 2 blocks are definitely lost in loss record 7,026 of 77,668
==59740==    at 0x10025EAD5: malloc (in /usr/local/Cellar/valgrind/HEAD-60ab74a/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==59740==    by 0x100019738: zmalloc (zmalloc.c:99)
==59740==    by 0x100019A85: zstrdup (zmalloc.c:210)
==59740==    by 0x1000A7F34: RM_Strdup (module.c:341)
==59740==    by 0x1015AE34B: RAI_ModelCreateTF (tensorflow.c:269)
==59740==    by 0x1015923B5: RAI_ModelCreate (model.c:219)
==59740==    by 0x101589419: RedisAI_ModelSet_RedisCommand (redisai.c:581)
==59740==    by 0x1000A87CC: RedisModuleCommandDispatcher (module.c:542)
==59740==    by 0x100010C25: call (server.c:2439)
==59740==    by 0x100011A99: processCommand (server.c:2733)
==59740==    by 0x100025E95: processInputBuffer (networking.c:1470)
==59740==    by 0x1000260AA: processInputBufferAndReplicate (networking.c:1505)
==59740== 
==59740== 408 (40 direct, 368 indirect) bytes in 1 blocks are definitely lost in loss record 74,827 of 77,668
==59740==    at 0x10025EAD5: malloc (in /usr/local/Cellar/valgrind/HEAD-60ab74a/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==59740==    by 0x1010A5377: operator new(unsigned long) (in /usr/lib/libc++abi.dylib)
==59740==    by 0x1098BBE6B: _GLOBAL__sub_I_logging_ops.cc (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x1001A4591: ImageLoaderMachO::doModInitFunctions(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x1001A4797: ImageLoaderMachO::doInitialization(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x10019FBE9: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740==    by 0x10019FB7F: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740==    by 0x10019ED72: ImageLoader::processInitializers(ImageLoader::LinkContext const&, unsigned int, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740==    by 0x10019EE04: ImageLoader::runInitializers(ImageLoader::LinkContext const&, ImageLoader::InitializerTimingList&) (in /usr/lib/dyld)
==59740==    by 0x100191CB1: dyld::runInitializers(ImageLoader*) (in /usr/lib/dyld)
==59740==    by 0x10019B3DB: dlopen_internal (in /usr/lib/dyld)
==59740==    by 0x1003C3D42: dlopen (in /usr/lib/system/libdyld.dylib)
==59740== 
==59740== 960 (880 direct, 80 indirect) bytes in 1 blocks are definitely lost in loss record 77,433 of 77,668
==59740==    at 0x10025EAD5: malloc (in /usr/local/Cellar/valgrind/HEAD-60ab74a/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==59740==    by 0x1010A5377: operator new(unsigned long) (in /usr/lib/libc++abi.dylib)
==59740==    by 0x10944546D: tensorflow::LibHDFS::Load() (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x10944A9D2: std::__1::__function::__func<tensorflow::register_file_system::Register<tensorflow::HadoopFileSystem>::Register(tensorflow::Env*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::{lambda()#1}, std::__1::allocator<{lambda()#1}>, tensorflow::FileSystem* ()>::operator()() (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x101E79E49: tensorflow::FileSystemRegistryImpl::Register(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::function<tensorflow::FileSystem* ()>) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow_framework.1.14.0.dylib)
==59740==    by 0x101E7A876: tensorflow::Env::RegisterFileSystem(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::function<tensorflow::FileSystem* ()>) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow_framework.1.14.0.dylib)
==59740==    by 0x10944A8A1: tensorflow::register_file_system::Register<tensorflow::HadoopFileSystem>::Register(tensorflow::Env*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x10944AA70: _GLOBAL__sub_I_hadoop_file_system.cc (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow.1.14.0.dylib)
==59740==    by 0x1001A4591: ImageLoaderMachO::doModInitFunctions(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x1001A4797: ImageLoaderMachO::doInitialization(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x10019FBE9: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740==    by 0x10019FB7F: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740== 
==59740== 8,280 (88 direct, 8,192 indirect) bytes in 1 blocks are definitely lost in loss record 77,587 of 77,668
==59740==    at 0x10025EAD5: malloc (in /usr/local/Cellar/valgrind/HEAD-60ab74a/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==59740==    by 0x1010A5377: operator new(unsigned long) (in /usr/lib/libc++abi.dylib)
==59740==    by 0x101FE4664: google::protobuf::internal::OnShutdownRun(void (*)(void const*), void const*) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow_framework.1.14.0.dylib)
==59740==    by 0x101FD566E: google::protobuf::internal::InitSCCImpl(google::protobuf::internal::SCCInfoBase*) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow_framework.1.14.0.dylib)
==59740==    by 0x1020420C8: tensorflow::KernelDef::KernelDef() (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow_framework.1.14.0.dylib)
==59740==    by 0x101B645B4: tensorflow::KernelDefBuilder::KernelDefBuilder(char const*) (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow_framework.1.14.0.dylib)
==59740==    by 0x101B44E91: _GLOBAL__sub_I_dataset.cc (in /Users/filipeoliveria/redislabs/RedisAI/deps/macosx-x64-cpu/libtensorflow/lib/libtensorflow_framework.1.14.0.dylib)
==59740==    by 0x1001A4591: ImageLoaderMachO::doModInitFunctions(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x1001A4797: ImageLoaderMachO::doInitialization(ImageLoader::LinkContext const&) (in /usr/lib/dyld)
==59740==    by 0x10019FBE9: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740==    by 0x10019FB7F: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740==    by 0x10019FB7F: ImageLoader::recursiveInitialization(ImageLoader::LinkContext const&, unsigned int, char const*, ImageLoader::InitializerTimingList&, ImageLoader::UninitedUpwards&) (in /usr/lib/dyld)
==59740== 
==59740== LEAK SUMMARY:
==59740==    definitely lost: 1,053 bytes in 8 blocks
==59740==    indirectly lost: 8,640 bytes in 11 blocks
==59740==      possibly lost: 307,816,073 bytes in 874,793 blocks
==59740==    still reachable: 367,748,394 bytes in 2,763,486 blocks
==59740==                       of which reachable via heuristic:
==59740==                         newarray           : 40,760 bytes in 179 blocks
==59740==                         multipleinheritance: 3,456 bytes in 36 blocks
==59740==         suppressed: 0 bytes in 0 blocks
==59740== Reachable blocks (those to which a pointer was found) are not shown.
==59740== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==59740== 
==59740== For lists of detected and suppressed errors, rerun with: -s
==59740== ERROR SUMMARY: 6374 errors from 6372 contexts (suppressed: 1545 from 11)
```