### PR TITLE
[add] added hasdata parameter to RAI_TensorCreate, which calls either…

### DIFF
--- a/src/redisai.c
+++ b/src/redisai.c
@@ -237,7 +237,7 @@ int RedisAI_TensorSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
     return RedisModule_WrongArity(ctx);
   }
 
-  int hasdata = !AC_IsAtEnd(&ac);
+  const int hasdata = !AC_IsAtEnd(&ac);
 
   const char* fmtstr;
   int datafmt;
@@ -253,65 +253,62 @@ int RedisAI_TensorSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
       return RedisModule_ReplyWithError(ctx, "ERR unsupported data format");
     }
   }
-
-  RAI_Tensor* t = RAI_TensorCreate(typestr, dims, ndims);
-  if (!t) {
+  const size_t nbytes = len * datasize;
+  size_t datalen;
+  const char *data;
+  RAI_Tensor *t = RAI_TensorCreate(typestr, dims, ndims, hasdata);
+  if (!t){
     return RedisModule_ReplyWithError(ctx, "ERR could not create tensor");
   }
-
-  if (hasdata && datafmt == REDISAI_DATA_BLOB) {
-    size_t nbytes = len * datasize;
-    size_t datalen;
-    const char* data;
-
+  switch (datafmt){
+  case REDISAI_DATA_BLOB:
     AC_GetString(&ac, &data, &datalen, 0);
-
-    if (datafmt == REDISAI_DATA_BLOB && datalen != nbytes) {
-      RAI_TensorFree(t);
+    if (datalen != nbytes){
       return RedisModule_ReplyWithError(ctx, "ERR data length does not match tensor shape and type");
     }
-
     RAI_TensorSetData(t, data, datalen);
-  }
-  else if (hasdata && datafmt == REDISAI_DATA_VALUES) {
-    if (argc != len + 4 + ndims) {
-      RAI_TensorFree(t);
+    break;
+  case REDISAI_DATA_VALUES:
+    if (argc != len + 4 + ndims){
       return RedisModule_WrongArity(ctx);
     }
-
     DLDataType datatype = RAI_TensorDataType(t);
 
     long i;
-    if (datatype.code == kDLFloat) {
+    if (datatype.code == kDLFloat){
       double val;
-      for (i=0; i<len; i++) {
+      for (i = 0; i < len; i++){
         int ac_ret = AC_GetDouble(&ac, &val, 0);
-        if (ac_ret != AC_OK) {
+        if (ac_ret != AC_OK){
           RAI_TensorFree(t);
           return RedisModule_ReplyWithError(ctx, "ERR invalid value");
         }
         int ret = RAI_TensorSetValueFromDouble(t, i, val);
-        if (ret == -1) {
+        if (ret == -1){
           RAI_TensorFree(t);
           return RedisModule_ReplyWithError(ctx, "ERR cannot specify values for this datatype");
         }
       }
     }
-    else {
+    else{
       long long val;
-      for (i=0; i<len; i++) {
+      for (i = 0; i < len; i++){
         int ac_ret = AC_GetLongLong(&ac, &val, 0);
-        if (ac_ret != AC_OK) {
+        if (ac_ret != AC_OK){
           RAI_TensorFree(t);
           return RedisModule_ReplyWithError(ctx, "ERR invalid value");
         }
         int ret = RAI_TensorSetValueFromLongLong(t, i, val);
-        if (ret == -1) {
+        if (ret == -1){
           RAI_TensorFree(t);
           return RedisModule_ReplyWithError(ctx, "ERR cannot specify values for this datatype");
         }
       }
     }
+    break;
+  default:
+    // default does not require tensor data setting since calloc setted it to 0
+    break;
   }
 
   RedisModuleKey *key = RedisModule_OpenKey(ctx, keystr,

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -9,7 +9,7 @@
 extern RedisModuleType *RedisAI_TensorType;
 
 int RAI_TensorInit(RedisModuleCtx* ctx);
-RAI_Tensor* RAI_TensorCreate(const char* dataTypeStr, long long* dims, int ndims);
+RAI_Tensor* RAI_TensorCreate(const char* dataTypeStr, long long* dims, int ndims, int hasdata);
 RAI_Tensor* RAI_TensorCreateFromDLTensor(DLManagedTensor* dl_tensor);
 size_t RAI_TensorLength(RAI_Tensor* t);
 size_t RAI_TensorGetDataSize(const char* dataTypeStr);


### PR DESCRIPTION
Fixes #214 

Overall changes in this PR:

- [add] added hasdata parameter to RAI_TensorCreate, which calls either RedisModule_Alloc or RedisModule_Calloc. 
- Small prune on RedisAI_TensorSet_RedisCommand conditions ( changed to switch )

## benchmarking (RedisModule_CAlloc + RAI_TensorSetData) vs (RedisModule_Alloc + RAI_TensorSetData) on a 1 x 256 Floats tensor

Using aibench to issue 10M AI.TENSORSET commands like the following example:
```
"AI.TENSORSET" "referenceTensor:1" "FLOAT" "1" "256" "BLOB" "( binary data representation of [256]float32 )"
```

we can see that for:
### Current in Master ) RedisModule_CAlloc + RAI_TensorSetData

aibench_load_data output for 10M tensors
```
time (ns),total commands,instantaneous commands/s,overall commands/s
1568119033403987000,175318,174434.42,174434.42
1568119034404022000,320847,145527.64,160017.47
1568119035403993000,482038,161199.73,160410.88
1568119036403980000,629474,147441.69,157172.74
1568119037404169000,799055,169553.43,159646.74
1568119038400363000,956012,157560.60,159300.45
1568119039404302000,1093568,137019.87,156107.44
(...)
1568119103405177000,9370924,93079.05,131976.57
1568119104404260000,9467500,96667.10,131486.64
1568119105405590000,9559149,91529.60,130938.61
1568119106404443000,9677311,118300.73,130768.04
1568119107405533000,9802397,124953.11,130690.43
1568119108405442000,9924870,122487.28,130582.51
1568119109406080000,9999999,75082.98,129861.34
Took:   77.593 sec
```

Commandstats
```
# Commandstats
cmdstat_config:calls=1,usec=13,usec_per_call=13.00
cmdstat_ai.tensorset:calls=10000000,usec=45263711,usec_per_call=4.53
```

### This PR ) RedisModule_Alloc + RAI_TensorSetData

aibench_load_data output for 10M tensors
```
time (ns),total commands,instantaneous commands/s,overall commands/s
1568118745894076000,176459,175566.24,175566.24
1568118746894075000,336463,160008.29,167807.10
1568118747894093000,500446,163984.24,166534.96
1568118748894080000,631145,130704.07,157588.80
1568118749894072000,800586,169446.77,159957.95
1568118750894107000,965674,165086.48,160812.00
1568118751894082000,1112458,146791.41,158810.57
1568118752894082000,1281296,168842.29,160063.74
1568118753894071000,1462213,180923.76,162380.18
1568118754894104000,1639471,177256.67,163867.11
(...)
1568118808891134000,9287789,129437.65,145120.52
1568118809893500000,9415348,127261.18,144845.13
1568118810894229000,9530633,115204.09,144395.73
1568118811894062000,9597554,66933.90,143239.87
1568118812895609000,9693171,95471.71,142536.38
1568118813896036000,9838865,145635.55,142581.31
1568118814895216000,9962091,123330.30,142306.54
1568118815894565000,9999998,37932.68,140837.56
1568118816895714000,10000000,2.00,138879.45
Took:   72.484 sec
```

Commandstats
```
# Commandstats
cmdstat_ai.tensorset:calls=10000000,usec=39309735,usec_per_call=3.93
cmdstat_config:calls=1,usec=10,usec_per_call=10.00
```

# Conclusions/Further comments
- We can expect at maximum ((4.53/3.93)-1)*100=15.26% performance improvement on AI.TENSORSET. 
- The used tensor had 1024 Bytes and for it we measured 15% improvement. Using a smaller tensor of 120 Bytes we've measured 11% improvement. 
- We've passed from 129861.34 AI.TENSORSET's per second to 138879.45 AI.TENSORSET's on a single ( OSS redis-server + OSS redis-ai ), meaning 7% improvement on the overall throughput seen from the client. 