### PR TITLE
Jobs on GPU

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,14 +68,12 @@ jobs:
     steps:
       - ci_steps:
           platform: debian
-
   # build-macos:
   #   macos:
   #     xcode: 10.2.1
   #   steps:
   #     - ci_steps:
   #         platform: macosx
-
   build-multiarch-docker:
     machine:
       enabled: true
@@ -100,6 +98,22 @@ jobs:
             sudo docker login -u redisfab -p $DOCKER_REDISFAB_PWD
             make -C opt/build/docker build
             sudo make -C opt/build/docker publish
+  build-gpu:
+    machine:
+      docker_layer_caching: true
+      resource_class: gpu.nvidia.medium
+      image: ubuntu-1604-cuda-10.1:201909-23
+    steps:
+      - checkout
+      - run:
+          name: Bulding Docker
+          command: |
+            docker build -f Dockerfile.gpu-test -t redisai-gpu-test .
+      - run:
+          name: Test
+          command: |
+            mkdir -p ~/workspace/tests
+            docker run --gpus all -v $HOME/workspace/tests:/data/tests/logs -it --rm redisai-gpu-test
 
   deploy_package:
     parameters:
@@ -146,6 +160,16 @@ workflows:
       #        only: /.*/
       #      branches:
       #        only: master
+      - build-gpu:
+          filters:
+            tags:
+              only: /.*/
+      - build-multiarch-docker:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master
       - deploy_package:
           name: deploy_branch
           package: branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,20 +100,28 @@ jobs:
             sudo make -C opt/build/docker publish
   build-gpu:
     machine:
+      enabled: true
       docker_layer_caching: true
       resource_class: gpu.nvidia.small
       image: ubuntu-1604-cuda-10.1:201909-23
     steps:
       - checkout
+#      - run:
+#          name: Checkout LFS
+#          command: |
+#            curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+#            sudo apt-get install -y git-lfs
+#            git lfs install
+#            git lfs pull
       - run:
-          name: Building Docker
+          name: Build
           command: |
-            docker build -f Dockerfile.gpu-test -t redisai-gpu-test .
+            docker build -f Dockerfile.gpu-test -t redisai-gpu:latest-x64-bionic-test .
       - run:
           name: Test
           command: |
             mkdir -p ~/workspace/tests
-            docker run --gpus all -v $HOME/workspace/tests:/redisai/test/logs -it --rm redisai-gpu-test
+            docker run --gpus all -v $HOME/workspace/tests:/build/test/logs -it --rm redisai-gpu:latest-x64-bionic-test
       - store_test_results:
           path: ~/workspace/tests
   deploy_package:
@@ -158,19 +166,13 @@ workflows:
       #- build-multiarch-docker:
       #    filters:
       #      tags:
-      #        only: /.*/
+      #        only: /^v[0-9].*/ 
       #      branches:
-      #        only: master
+      #        ignore: /.*/
       - build-gpu:
           filters:
             tags:
               only: /.*/
-      - build-multiarch-docker:
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: master
       - deploy_package:
           name: deploy_branch
           package: branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,14 +106,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Bulding Docker
+          name: Building Docker
           command: |
             docker build -f Dockerfile.gpu-test -t redisai-gpu-test .
       - run:
           name: Test
           command: |
             mkdir -p ~/workspace/tests
-            docker run --gpus all -v $HOME/workspace/tests:/data/tests/logs -it --rm redisai-gpu-test
+            docker run --gpus all -v $HOME/workspace/tests:/redisai/test/logs -it --rm redisai-gpu-test
       - store_test_results:
           path: ~/workspace/tests
   deploy_package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
   build-gpu:
     machine:
       docker_layer_caching: true
-      resource_class: gpu.nvidia.medium
+      resource_class: gpu.nvidia.small
       image: ubuntu-1604-cuda-10.1:201909-23
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,8 @@ jobs:
           command: |
             mkdir -p ~/workspace/tests
             docker run --gpus all -v $HOME/workspace/tests:/data/tests/logs -it --rm redisai-gpu-test
-
+      - store_test_results:
+          path: ~/workspace/tests
   deploy_package:
     parameters:
       package:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ ADD_DEFINITIONS(-DREDISMODULE_EXPERIMENTAL_API)
 IF(BUILD_TF)
     FIND_LIBRARY(TF_LIBRARIES NAMES tensorflow
         PATHS ${depsAbs}/libtensorflow/lib)
-	MESSAGE(STATUS "Found TensorFlow Libraries: \"${TF_LIBRARIES}\")")
+    MESSAGE(STATUS "Found TensorFlow Libraries: \"${TF_LIBRARIES}\")")
     IF (NOT TF_LIBRARIES)
         MESSAGE(WARNING "Could not find TensorFlow in ${depsAbs}/libtensorflow/lib. Trying find_package method")
         FIND_PACKAGE(TensorFlow REQUIRED)
@@ -113,11 +113,11 @@ ENDIF()
 #----------------------------------------------------------------------------------------------
 
 IF(BUILD_TFLITE)
-	FIND_LIBRARY(TFLITE_LIBRARIES_1 NAMES tensorflow-lite
-		PATHS ${depsAbs}/libtensorflow-lite/lib)
-	FIND_LIBRARY(TFLITE_LIBRARIES_2 NAMES benchmark-lib.a
-		PATHS ${depsAbs}/libtensorflow-lite/lib)
-	SET(TFLITE_LIBRARIES ${TFLITE_LIBRARIES_1} ${TFLITE_LIBRARIES_2})
+    FIND_LIBRARY(TFLITE_LIBRARIES_1 NAMES tensorflow-lite
+            PATHS ${depsAbs}/libtensorflow-lite/lib)
+    FIND_LIBRARY(TFLITE_LIBRARIES_2 NAMES benchmark-lib.a
+            PATHS ${depsAbs}/libtensorflow-lite/lib)
+    SET(TFLITE_LIBRARIES ${TFLITE_LIBRARIES_1} ${TFLITE_LIBRARIES_2})
     MESSAGE(STATUS "Found TensorFlow Lite Libraries: \"${TFLITE_LIBRARIES}\")")
     IF (NOT TFLITE_LIBRARIES)
         MESSAGE(FATAL_ERROR "Could not find TensorFlow Lite")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,8 @@ ADD_DEFINITIONS(-DREDISMODULE_EXPERIMENTAL_API)
 
 IF(BUILD_TF)
     FIND_LIBRARY(TF_LIBRARIES NAMES tensorflow
-            PATHS ${depsAbs}/libtensorflow/lib)
+        PATHS ${depsAbs}/libtensorflow/lib)
+	MESSAGE(STATUS "Found TensorFlow Libraries: \"${TF_LIBRARIES}\")")
     IF (NOT TF_LIBRARIES)
         MESSAGE(WARNING "Could not find TensorFlow in ${depsAbs}/libtensorflow/lib. Trying find_package method")
         FIND_PACKAGE(TensorFlow REQUIRED)
@@ -112,8 +113,11 @@ ENDIF()
 #----------------------------------------------------------------------------------------------
 
 IF(BUILD_TFLITE)
-    FIND_LIBRARY(TFLITE_LIBRARIES NAMES tensorflow-lite
-            PATHS ${depsAbs}/libtensorflow-lite/lib)
+	FIND_LIBRARY(TFLITE_LIBRARIES_1 NAMES tensorflow-lite
+		PATHS ${depsAbs}/libtensorflow-lite/lib)
+	FIND_LIBRARY(TFLITE_LIBRARIES_2 NAMES benchmark-lib.a
+		PATHS ${depsAbs}/libtensorflow-lite/lib)
+	SET(TFLITE_LIBRARIES ${TFLITE_LIBRARIES_1} ${TFLITE_LIBRARIES_2})
     MESSAGE(STATUS "Found TensorFlow Lite Libraries: \"${TFLITE_LIBRARIES}\")")
     IF (NOT TFLITE_LIBRARIES)
         MESSAGE(FATAL_ERROR "Could not find TensorFlow Lite")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# BUILD redisfab/redisai-cpu-${OSNICK}:M.m.b-${ARCH}
+# BUILD redisfab/redisai-cpu-${OSNICK}:${VERSION}-${ARCH}
 
 ARG REDIS_VER=5.0.7
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,40 +1,37 @@
-FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04 AS builder
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS builder
 
-ENV DEPS "build-essential git ca-certificates curl unzip wget libgomp1 patchelf"
+ENV DEPS "git ca-certificates curl unzip wget libgomp1 patchelf coreutils tcl libjemalloc-dev"
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
-RUN apt update && apt -y upgrade
-RUN apt-get install -y libgomp1
-RUN apt-get install -y wget
-
-RUN apt install -y build-essential tcl libjemalloc-dev
-RUN wget http://download.redis.io/redis-stable.tar.gz
-RUN tar xzvf redis-stable.tar.gz && cd redis-stable && make && make install && cd .. && rm redis-stable.tar.gz
-
-# install latest cmake
-ADD https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh /cmake-3.12.4-Linux-x86_64.sh
-RUN mkdir /opt/cmake
-RUN sh /cmake-3.12.4-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
-RUN ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
-RUN cmake --version
-
 # Set up a build environment
+ADD https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh /cmake-3.12.4-Linux-x86_64.sh
 RUN set -ex;\
     deps="$DEPS";\
     apt-get update;\
-    apt-get install -y --no-install-recommends $deps
+    apt -y upgrade;\
+    apt install -y $deps;\
+    mkdir /opt/cmake;\
+    sh /cmake-3.12.4-Linux-x86_64.sh --prefix=/opt/cmake --skip-license;\
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+
+WORKDIR /redis
+RUN wget http://download.redis.io/redis-stable.tar.gz;\
+    tar xzvf redis-stable.tar.gz && cd redis-stable && make && cd .. && rm redis-stable.tar.gz
+
+# Configurations
+ADD http://download.redis.io/redis-stable/redis.conf /usr/local/etc/redis/redis.conf
+RUN sed -i 's/bind 127.0.0.1/bind 0.0.0.0/g' /usr/local/etc/redis/redis.conf
+
 
 # Get the dependencies
 WORKDIR /redisai
 ADD ./ /redisai
 RUN set -ex;\
+    apt install -y python3-dev;\
     mkdir -p deps;\
     DEPS_DIRECTORY=deps bash ./get_deps.sh gpu
 
-# Configurations
-ADD http://download.redis.io/redis-stable/redis.conf /usr/local/etc/redis/redis.conf
-RUN sed -i 's/bind 127.0.0.1/bind 0.0.0.0/g' /usr/local/etc/redis/redis.conf
 
 # Build the source
 RUN set -ex;\
@@ -46,12 +43,13 @@ RUN set -ex;\
     cd ..
 
 # Package the runner
-FROM builder
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 
 RUN mkdir -p /usr/lib/redis/modules/
 
 COPY --from=builder /redisai/install-gpu/ /usr/lib/redis/modules/
+COPY --from=builder /redis/redis-stable/src/redis-server /usr/local/bin/
+COPY --from=builder /usr/local/etc/redis/redis.conf /usr/local/etc/redis/
 
-WORKDIR /data
 EXPOSE 6379
-CMD ["redis-server", "/usr/local/etc/redis/redis.conf", "--loadmodule", "/usr/lib/redis/modules/redisai.so"]
+CMD ["/usr/local/bin/redis-server", "/usr/local/etc/redis/redis.conf", "--loadmodule", "/usr/lib/redis/modules/redisai.so"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,58 +1,57 @@
+# BUILD redisfab/redisai-gpu:${VERSION}-${ARCH}-${OSNICK}
+
+ARG REDIS_VER=5.0.7
+
+# OSNICK=bionic|centos7|centos6
+ARG OSNICK=bionic
+
+# ARCH=x64|arm64v8|arm32v7
+ARG ARCH=x64
+
+#----------------------------------------------------------------------------------------------
+FROM redisfab/redis:${REDIS_VER}-${ARCH}-${OSNICK} AS redis
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS builder
 
-ENV DEPS "git ca-certificates wget unzip cmake libgomp1 patchelf coreutils tcl libjemalloc-dev"
+# ENV DEPS "git ca-certificates wget unzip cmake libgomp1 patchelf coreutils tcl libjemalloc-dev"
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
-# Installing Redis
-WORKDIR /redis
-ADD https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh /cmake-3.12.4-Linux-x86_64.sh
-RUN set -ex;\
-    deps="$DEPS";\
-    apt-get update;\
-    DEBIAN_FRONTEND=noninteractive apt install -y $deps;\
-    wget http://download.redis.io/redis-stable.tar.gz;\
-    tar xzvf redis-stable.tar.gz && cd redis-stable && make && cd .. && rm redis-stable.tar.gz
+WORKDIR /build
+COPY --from=redis /usr/local/ /usr/local/
 
+COPY ./opt/ opt/
+COPY ./test/test_requirements.txt test/
 
-# Setup Redis configurations
-ADD http://download.redis.io/redis-stable/redis.conf /usr/local/etc/redis/redis.conf
-RUN sed -i 's/bind 127.0.0.1/bind 0.0.0.0/g' /usr/local/etc/redis/redis.conf
+RUN ./opt/readies/bin/getpy
+RUN ./opt/system-setup.py
 
+ARG DEPS_ARGS=""
+COPY ./get_deps.sh .
+RUN if [ "$DEPS_ARGS" = "" ]; then ./get_deps.sh gpu; else env $DEPS_ARGS ./get_deps.sh gpu; fi
 
-WORKDIR /redisai
+ARG BUILD_ARGS=""
+ADD ./ /build
+RUN make -C opt build GPU=1 $BUILD_ARGS SHOW=1
 
-# Get the dependencies
-ADD ./opt /redisai/opt
-RUN set -ex;\
-    ./opt/readies/bin/getpy
+ARG PACK=0
+ARG TEST=0
 
+RUN if [ "$PACK" = "1" ]; then make -C opt pack GPU=1; fi
+RUN if [ "$TEST" = "1" ]; then TEST="" make -C opt test GPU=1 $BUILD_ARGS NO_LFS=1; fi
 
+#----------------------------------------------------------------------------------------------
+FROM nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04
 
-ADD ./get_deps.sh /redisai/get_deps.sh
-RUN set -ex;\
-    mkdir -p deps;\
-    DEPS_DIRECTORY=deps bash ./get_deps.sh gpu
+RUN set -e; apt-get -qq update; apt-get -q install -y libgomp1
 
+ENV REDIS_MODULES /usr/lib/redis/modules
+RUN mkdir -p $REDIS_MODULES/
 
-# Build the source
-ADD ./ /redisai
-RUN set -ex;\
-    rm -rf build;\
-    mkdir -p build;\
-    cd build;\
-    cmake -DDEVICE=gpu ..;\
-    make && make install;\
-    cd ..
+COPY --from=redis /usr/local/ /usr/local/
+COPY --from=builder /build/install-gpu/ $REDIS_MODULES/
+# COPY --from=builder /usr/local/etc/redis/redis.conf /usr/local/etc/redis/
 
-# Package the runner
-FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
-
-RUN mkdir -p /usr/lib/redis/modules/
-
-COPY --from=builder /redisai/install-gpu/ /usr/lib/redis/modules/
-COPY --from=builder /redis/redis-stable/src/redis-server /usr/local/bin/
-COPY --from=builder /usr/local/etc/redis/redis.conf /usr/local/etc/redis/
-
+WORKDIR /data
 EXPOSE 6379
-CMD ["/usr/local/bin/redis-server", "/usr/local/etc/redis/redis.conf", "--loadmodule", "/usr/lib/redis/modules/redisai.so"]
+# CMD ["/usr/local/bin/redis-server", "/usr/local/etc/redis/redis.conf", "--loadmodule", "/usr/lib/redis/modules/redisai.so"]
+CMD ["/usr/local/bin/redis-server", "--loadmodule", "/usr/lib/redis/modules/redisai.so"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,39 +1,42 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS builder
 
-ENV DEPS "git ca-certificates curl unzip wget libgomp1 patchelf coreutils tcl libjemalloc-dev"
+ENV DEPS "git ca-certificates wget unzip cmake libgomp1 patchelf coreutils tcl libjemalloc-dev"
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
-# Set up a build environment
+# Installing Redis
+WORKDIR /redis
 ADD https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh /cmake-3.12.4-Linux-x86_64.sh
 RUN set -ex;\
     deps="$DEPS";\
     apt-get update;\
-    apt -y upgrade;\
     DEBIAN_FRONTEND=noninteractive apt install -y $deps;\
-    mkdir /opt/cmake;\
-    sh /cmake-3.12.4-Linux-x86_64.sh --prefix=/opt/cmake --skip-license;\
-    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
-
-WORKDIR /redis
-RUN wget http://download.redis.io/redis-stable.tar.gz;\
+    wget http://download.redis.io/redis-stable.tar.gz;\
     tar xzvf redis-stable.tar.gz && cd redis-stable && make && cd .. && rm redis-stable.tar.gz
 
-# Configurations
+
+# Setup Redis configurations
 ADD http://download.redis.io/redis-stable/redis.conf /usr/local/etc/redis/redis.conf
 RUN sed -i 's/bind 127.0.0.1/bind 0.0.0.0/g' /usr/local/etc/redis/redis.conf
 
 
-# Get the dependencies
 WORKDIR /redisai
-ADD ./ /redisai
+
+# Get the dependencies
+ADD ./opt /redisai/opt
 RUN set -ex;\
-    apt install -y python3-dev;\
+    ./opt/readies/bin/getpy
+
+
+
+ADD ./get_deps.sh /redisai/get_deps.sh
+RUN set -ex;\
     mkdir -p deps;\
     DEPS_DIRECTORY=deps bash ./get_deps.sh gpu
 
 
 # Build the source
+ADD ./ /redisai
 RUN set -ex;\
     rm -rf build;\
     mkdir -p build;\
@@ -43,7 +46,7 @@ RUN set -ex;\
     cd ..
 
 # Package the runner
-FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
 
 RUN mkdir -p /usr/lib/redis/modules/
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -10,7 +10,7 @@ RUN set -ex;\
     deps="$DEPS";\
     apt-get update;\
     apt -y upgrade;\
-    apt install -y $deps;\
+    DEBIAN_FRONTEND=noninteractive apt install -y $deps;\
     mkdir /opt/cmake;\
     sh /cmake-3.12.4-Linux-x86_64.sh --prefix=/opt/cmake --skip-license;\
     ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake

--- a/Dockerfile.gpu-test
+++ b/Dockerfile.gpu-test
@@ -1,0 +1,65 @@
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS builder
+
+ENV DEPS "build-essential git ca-certificates curl unzip wget libgomp1 patchelf coreutils tcl libjemalloc-dev"
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Set up a build environment
+#   Installing DEPS, python3.6, git-lfs, cmake
+ADD https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh /cmake-3.12.4-Linux-x86_64.sh
+RUN set -ex;\
+    deps="$DEPS";\
+    apt-get update;\
+    apt -y upgrade;\
+    DEBIAN_FRONTEND=noninteractive apt install -y $deps;\
+    apt install -y python3-dev python3-pip;\
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash;\
+    apt install -y git-lfs;\
+    mkdir /opt/cmake;\
+    sh /cmake-3.12.4-Linux-x86_64.sh --prefix=/opt/cmake --skip-license;\
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+
+
+# Installing Redis
+WORKDIR /redis
+RUN wget http://download.redis.io/redis-stable.tar.gz;\
+    tar xzvf redis-stable.tar.gz && cd redis-stable && make && cd .. && rm redis-stable.tar.gz;\
+    mv /redis/redis-stable/src/redis-server /usr/local/bin/
+
+# Setup Redis configurations
+ADD http://download.redis.io/redis-stable/redis.conf /usr/local/etc/redis/redis.conf
+RUN sed -i 's/bind 127.0.0.1/bind 0.0.0.0/g' /usr/local/etc/redis/redis.conf
+
+# Python dependencies
+RUN set -ex;\
+    python3 -m pip install git+https://github.com/RedisLabsModules/RLTest.git@master;\
+    python3 -m pip install git+https://github.com/RedisLabs/RAMP@master;\
+    python3 -m pip install numpy scipy scikit-image redis-py-cluster
+
+WORKDIR /redisai
+ADD ./ /redisai
+
+# Clean up for git lfs to work
+RUN git remote set-url origin https://github.com/RedisAI/RedisAI
+
+# Installing GPU dependencies
+RUN set -ex;\
+    python3 -m pip install -r /redisai/test/test_requirements.txt;\
+    mkdir -p deps;\
+    DEPS_DIRECTORY=deps bash ./get_deps.sh gpu
+
+# Build the source
+RUN set -ex;\
+    rm -rf build;\
+    mkdir -p build;\
+    cd build;\
+    cmake -DDEVICE=gpu ..;\
+    make && make install;\
+    cd ..;\
+    mkdir -p /redisai/bin/linux-x64-gpu/install;\
+    mv /redisai/install-gpu/* /redisai/bin/linux-x64-gpu/install
+
+
+
+EXPOSE 6379
+CMD ["sh", "-c", "export DEVICE=GPU && make -C opt test SHOW=1 GPU=1"]

--- a/Dockerfile.gpu-test
+++ b/Dockerfile.gpu-test
@@ -30,7 +30,6 @@ RUN set -ex;\
     ./opt/system-setup.py
 
 
-
 # Few more dependencies
 ADD ./get_deps.sh /redisai/get_deps.sh
 RUN set -ex;\

--- a/Dockerfile.gpu-test
+++ b/Dockerfile.gpu-test
@@ -1,56 +1,41 @@
+# BUILD redisfab/redisai-gpu:${VERSION}-${ARCH}-${OSNICK}-test
+
+ARG REDIS_VER=5.0.7
+
+# OSNICK=bionic|centos7|centos6
+ARG OSNICK=bionic
+
+# ARCH=x64|arm64v8|arm32v7
+ARG ARCH=x64
+
+#----------------------------------------------------------------------------------------------
+FROM redisfab/redis:${REDIS_VER}-${ARCH}-${OSNICK} AS redis
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS builder
 
-ENV DEPS "git ca-certificates wget libgomp1 unzip patchelf coreutils tcl libjemalloc-dev"
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
+WORKDIR /build
+COPY --from=redis /usr/local/ /usr/local/
 
-# Installing Redis
-WORKDIR /redis
-RUN set -ex;\
-    apt-get update;\
-    deps="$DEPS";\
-    DEBIAN_FRONTEND=noninteractive apt install -y $deps;\
-    wget http://download.redis.io/redis-stable.tar.gz;\
-    tar xzvf redis-stable.tar.gz && cd redis-stable && make && cd .. && rm redis-stable.tar.gz;\
-    mv /redis/redis-stable/src/redis-server /usr/local/bin/
+COPY ./opt/ opt/
+COPY ./test/test_requirements.txt test/
 
-# Setup Redis configurations
-ADD http://download.redis.io/redis-stable/redis.conf /usr/local/etc/redis/redis.conf
-RUN sed -i 's/bind 127.0.0.1/bind 0.0.0.0/g' /usr/local/etc/redis/redis.conf
+RUN ./opt/readies/bin/getpy
+RUN ./opt/system-setup.py
 
+ARG DEPS_ARGS=""
+COPY ./get_deps.sh .
+RUN if [ "$DEPS_ARGS" = "" ]; then ./get_deps.sh gpu; else env $DEPS_ARGS ./get_deps.sh gpu; fi
 
-WORKDIR /redisai
+ARG BUILD_ARGS=""
+ADD ./ /build
+RUN make -C opt build GPU=1 $BUILD_ARGS SHOW=1
 
-# System and test dependencies
-ADD ./opt /redisai/opt
-ADD ./test/test_requirements.txt /redisai/test/test_requirements.txt
-RUN set -ex;\
-    ./opt/readies/bin/getpy;\
-    ./opt/system-setup.py
+ARG PACK=1
 
+RUN if [ "$PACK" = "1" ]; then make -C opt pack GPU=1; fi
 
-# Few more dependencies
-ADD ./get_deps.sh /redisai/get_deps.sh
-RUN set -ex;\
-    mkdir -p deps;\
-    DEPS_DIRECTORY=deps bash ./get_deps.sh gpu
-
-# Build the source
-ADD ./ /redisai
-RUN set -ex;\
-    rm -rf build;\
-    mkdir -p build;\
-    cd build;\
-    cmake -DDEVICE=gpu ..;\
-    make && make install;\
-    cd ..;\
-    mkdir -p /redisai/bin/linux-x64-gpu/install;\
-    mv /redisai/install-gpu/* /redisai/bin/linux-x64-gpu/install
-
-# Clean up for git lfs to work
 RUN git remote set-url origin https://github.com/RedisAI/RedisAI
 
-
-EXPOSE 6379
-CMD ["sh", "-c", "export DEVICE=GPU && make -C opt test SHOW=1 GPU=1"]
+CMD ["bash", "-c", "make -C opt test GPU=1 SHOW=1"]

--- a/Dockerfile.gpu-test
+++ b/Dockerfile.gpu-test
@@ -1,28 +1,17 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS builder
 
-ENV DEPS "build-essential git ca-certificates curl unzip wget libgomp1 patchelf coreutils tcl libjemalloc-dev"
+ENV DEPS "git ca-certificates wget libgomp1 unzip patchelf coreutils tcl libjemalloc-dev"
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
-
-# Set up a build environment
-#   Installing DEPS, python3.6, git-lfs, cmake
-ADD https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh /cmake-3.12.4-Linux-x86_64.sh
-RUN set -ex;\
-    deps="$DEPS";\
-    apt-get update;\
-    apt -y upgrade;\
-    DEBIAN_FRONTEND=noninteractive apt install -y $deps;\
-    apt install -y python3-dev python3-pip;\
-    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash;\
-    apt install -y git-lfs;\
-    mkdir /opt/cmake;\
-    sh /cmake-3.12.4-Linux-x86_64.sh --prefix=/opt/cmake --skip-license;\
-    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 
 
 # Installing Redis
 WORKDIR /redis
-RUN wget http://download.redis.io/redis-stable.tar.gz;\
+RUN set -ex;\
+    apt-get update;\
+    deps="$DEPS";\
+    DEBIAN_FRONTEND=noninteractive apt install -y $deps;\
+    wget http://download.redis.io/redis-stable.tar.gz;\
     tar xzvf redis-stable.tar.gz && cd redis-stable && make && cd .. && rm redis-stable.tar.gz;\
     mv /redis/redis-stable/src/redis-server /usr/local/bin/
 
@@ -30,25 +19,26 @@ RUN wget http://download.redis.io/redis-stable.tar.gz;\
 ADD http://download.redis.io/redis-stable/redis.conf /usr/local/etc/redis/redis.conf
 RUN sed -i 's/bind 127.0.0.1/bind 0.0.0.0/g' /usr/local/etc/redis/redis.conf
 
-# Python dependencies
-RUN set -ex;\
-    python3 -m pip install git+https://github.com/RedisLabsModules/RLTest.git@master;\
-    python3 -m pip install git+https://github.com/RedisLabs/RAMP@master;\
-    python3 -m pip install numpy scipy scikit-image redis-py-cluster
 
 WORKDIR /redisai
-ADD ./ /redisai
 
-# Clean up for git lfs to work
-RUN git remote set-url origin https://github.com/RedisAI/RedisAI
-
-# Installing GPU dependencies
+# System and test dependencies
+ADD ./opt /redisai/opt
+ADD ./test/test_requirements.txt /redisai/test/test_requirements.txt
 RUN set -ex;\
-    python3 -m pip install -r /redisai/test/test_requirements.txt;\
+    ./opt/readies/bin/getpy;\
+    ./opt/system-setup.py
+
+
+
+# Few more dependencies
+ADD ./get_deps.sh /redisai/get_deps.sh
+RUN set -ex;\
     mkdir -p deps;\
     DEPS_DIRECTORY=deps bash ./get_deps.sh gpu
 
 # Build the source
+ADD ./ /redisai
 RUN set -ex;\
     rm -rf build;\
     mkdir -p build;\
@@ -59,6 +49,8 @@ RUN set -ex;\
     mkdir -p /redisai/bin/linux-x64-gpu/install;\
     mv /redisai/install-gpu/* /redisai/bin/linux-x64-gpu/install
 
+# Clean up for git lfs to work
+RUN git remote set-url origin https://github.com/RedisAI/RedisAI
 
 
 EXPOSE 6379

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -223,7 +223,7 @@ if [[ $WITH_PT != 0 ]]; then
 		LIBTORCH_ARCHIVE=libtorch-${PT_BUILD}-${PT_OS}-${PT_ARCH}-${PT_VERSION}.tar.gz
 
 		if [[ $PT_REPACK == 1 ]]; then
-			PT_VERSION=$PT_VERSION $HERE/opt/build/libtorch/repack.sh
+		  PT_VERSION=$PT_VERSION $HERE/opt/build/libtorch/repack.sh "$1"
 		else
 			LIBTORCH_URL=https://s3.amazonaws.com/redismodules/pytorch/$LIBTORCH_ARCHIVE
 

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -169,7 +169,8 @@ if [[ $WITH_TFLITE != 0 ]]; then
 
 		LIBTFLITE_ARCHIVE=libtensorflowlite-${TFLITE_OS}-${TFLITE_ARCH}-${TFLITE_VERSION}.tar.gz
 
-		[[ ! -f $LIBTFLITE_ARCHIVE || $FORCE == 1 ]] && wget --quiet $LIBTF_URL_BASE/$LIBTFLITE_ARCHIVE
+		[[ ! -f $LIBTFLITE_ARCHIVE || $FORCE == 1 ]] && wget $LIBTF_URL_BASE/$LIBTFLITE_ARCHIVE
+		echo $LIBTF_URL_BASE/$LIBTFLITE_ARCHIVE
 
 		rm -rf $LIBTFLITE.x
 		mkdir $LIBTFLITE.x
@@ -195,13 +196,13 @@ if [[ $WITH_PT != 0 ]]; then
 		echo "Installing libtorch ..."
 
 		PT_REPACK=0
-		
+
 		if [[ $OS == linux ]]; then
 			PT_OS=linux
 			if [[ $GPU == no ]]; then
 				PT_BUILD=cpu
 			else
-				PT_BUILD=cu100
+				PT_BUILD=cu101
 			fi
 			if [[ $ARCH == x64 ]]; then
 				PT_ARCH=x86_64

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -30,13 +30,13 @@ set -e
 [[ $VERBOSE == 1 ]] && set -x
 
 if [[ "$1" == "cpu" ]]; then
-	GPU=no
+	GPU=0
 	DEVICE=cpu
 elif [[ "$1" == "gpu" ]]; then
-	GPU=yes
+	GPU=1
 	DEVICE=gpu
 else
-	GPU=${GPU:-no}
+	GPU=${GPU:-0}
 	if [[ $GPU == 1 ]]; then
 		DEVICE=gpu
 	else
@@ -92,7 +92,7 @@ if [[ $WITH_TF != 0 ]]; then
 		
 		if [[ $OS == linux ]]; then
 			TF_OS="linux"
-			if [[ $GPU == no ]]; then
+			if [[ $GPU != 1 ]]; then
 				TF_BUILD="cpu"
 			else
 				TF_BUILD="gpu"
@@ -148,7 +148,7 @@ if [[ $WITH_TFLITE != 0 ]]; then
 		LIBTF_URL_BASE=https://s3.amazonaws.com/redismodules/tensorflow
 		if [[ $OS == linux ]]; then
 			TFLITE_OS="linux"
-			# if [[ $GPU == no ]]; then
+			# if [[ $GPU != 1 ]]; then
 			# 	TFLITE_BUILD="cpu"
 			# else
 			# 	TFLITE_BUILD="gpu"
@@ -199,7 +199,7 @@ if [[ $WITH_PT != 0 ]]; then
 
 		if [[ $OS == linux ]]; then
 			PT_OS=linux
-			if [[ $GPU == no ]]; then
+			if [[ $GPU != 1 ]]; then
 				PT_BUILD=cpu
 			else
 				PT_BUILD=cu101
@@ -224,7 +224,7 @@ if [[ $WITH_PT != 0 ]]; then
 		LIBTORCH_ARCHIVE=libtorch-${PT_BUILD}-${PT_OS}-${PT_ARCH}-${PT_VERSION}.tar.gz
 
 		if [[ $PT_REPACK == 1 ]]; then
-		  PT_VERSION=$PT_VERSION $HERE/opt/build/libtorch/repack.sh "$1"
+			PT_VERSION=$PT_VERSION GPU=$GPU $HERE/opt/build/libtorch/repack.sh
 		else
 			LIBTORCH_URL=https://s3.amazonaws.com/redismodules/pytorch/$LIBTORCH_ARCHIVE
 
@@ -281,7 +281,7 @@ if [[ $WITH_ORT != 0 ]]; then
 
 		if [[ $OS == linux ]]; then
 			ORT_OS=linux
-			if [[ $GPU == no ]]; then
+			if [[ $GPU != 1 ]]; then
 				ORT_BUILD=""
 			else
 				ORT_BUILD="-gpu"

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -170,7 +170,6 @@ if [[ $WITH_TFLITE != 0 ]]; then
 		LIBTFLITE_ARCHIVE=libtensorflowlite-${TFLITE_OS}-${TFLITE_ARCH}-${TFLITE_VERSION}.tar.gz
 
 		[[ ! -f $LIBTFLITE_ARCHIVE || $FORCE == 1 ]] && wget $LIBTF_URL_BASE/$LIBTFLITE_ARCHIVE
-		echo $LIBTF_URL_BASE/$LIBTFLITE_ARCHIVE
 
 		rm -rf $LIBTFLITE.x
 		mkdir $LIBTFLITE.x

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -1,5 +1,5 @@
 
-ROOT:=$(abspath ..)
+ROOT:=..
 include readies/mk/main
 
 MK_CMAKE:=1

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -22,6 +22,11 @@ fetch and build options:
   WITH_TFLITE=0 # SKip TensofFlowLite
   WITH_PT=0     # Skip PyTorch
   WITH_ORT=0    # SKip ONNXRuntime
+
+device selection options (fetch, build, and test):
+  CPU=1         # build for CPU
+  GPU=1         # build for GPU
+  CUDA=1        # build for GPU
 endef
 
 #---------------------------------------------------------------------------------------------- 
@@ -127,6 +132,10 @@ endif
 
 TEST_REPORT_DIR ?= $(PWD)
 
+ifeq ($(TEST),)
+TEST=basic_tests.py
+endif
+
 test:
 ifneq ($(NO_LFS),1)
 	$(SHOW)if [ "$(git lfs env > /dev/null 2>&1 ; echo $?)" != "0" ]; then cd $(ROOT); git lfs install; fi
@@ -134,10 +143,11 @@ ifneq ($(NO_LFS),1)
 endif
 	$(SHOW)set -e ;\
 	cd $(ROOT)/test ;\
-	python3 -m RLTest $(TEST_ARGS) --test basic_tests.py --module $(INSTALL_DIR)/redisai.so ;\
-	python3 -m RLTest $(TEST_ARGS) --test basic_tests.py --module $(INSTALL_DIR)/redisai.so --use-slaves ;\
-	python3 -m RLTest $(TEST_ARGS) --test basic_tests.py --module $(INSTALL_DIR)/redisai.so --use-aof 
-        # Commented until the MacOS CI is available
+	export DEVICE=$(DEVICE) ;\
+	python3 -m RLTest $(TEST_ARGS) --test $(TEST) --module $(INSTALL_DIR)/redisai.so ;\
+	python3 -m RLTest $(TEST_ARGS) --test $(TEST) --module $(INSTALL_DIR)/redisai.so --use-slaves ;\
+	python3 -m RLTest $(TEST_ARGS) --test $(TEST) --module $(INSTALL_DIR)/redisai.so --use-aof 
+	# Commented until the MacOS CI is available
 	# python3 -m RLTest $(TEST_ARGS) --test double-panda.py --module $(INSTALL_DIR)/redisai.so
 
 #----------------------------------------------------------------------------------------------

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -1,5 +1,5 @@
 
-ROOT:=..
+ROOT:=$(abspath ..)
 include readies/mk/main
 
 MK_CMAKE:=1

--- a/opt/build/libtorch/Makefile
+++ b/opt/build/libtorch/Makefile
@@ -1,7 +1,7 @@
 
 ROOT=../../..
 
-VERSION ?= 1.2.0
+VERSION ?= 1.3.1
 OSNICK ?= buster
 
 #----------------------------------------------------------------------------------------------
@@ -100,7 +100,7 @@ $(eval $(call publish_arm,arm64v8,arm64))
 $(eval $(call publish_arm,arm32v7,arm))
 
 repack:
-	@PT_VERSION=$(VERSION) ./repack.sh
+	@PT_VERSION=$(VERSION) GPU=$(GPU) ./repack.sh
 
 help:
 	@echo "make [build|repack|publish] [X64=1|ARM7=1|ARM8=1]"

--- a/opt/build/libtorch/repack.sh
+++ b/opt/build/libtorch/repack.sh
@@ -10,11 +10,11 @@ ROOT=$HERE/../../..
 ROOT=$(realpath $ROOT)
 
 if [[ "$1" == "cpu" ]]; then
-	GPU=no
+	GPU=0
 elif [[ "$1" == "gpu" ]]; then
-	GPU=yes
+	GPU=1
 else
-	GPU=${GPU:-no}
+	GPU=${GPU:-0}
 fi
 OS=$(python3 $ROOT/opt/readies/bin/platform --os)
 ARCH=$(python3 $ROOT/opt/readies/bin/platform --arch)
@@ -28,7 +28,7 @@ fi
 
 if [[ $OS == linux ]]; then
 	PT_OS=shared-with-deps
-	if [[ $GPU == no ]]; then
+	if [[ $GPU != 1 ]]; then
 		PT_BUILD=cpu
 	else
 		PT_BUILD=cu101
@@ -50,11 +50,11 @@ if [[ $OS == linux ]]; then
 	elif [[ $PT_VERSION == latest ]]; then
 		LIBTORCH_ARCHIVE=libtorch-shared-with-deps-latest.zip
 	else
-	  if [[ $GPU == no ]]; then
-		  LIBTORCH_ARCHIVE=libtorch-cxx11-abi-shared-with-deps-${PT_VERSION}%2Bcpu.zip
-	  else
-		  LIBTORCH_ARCHIVE=libtorch-cxx11-abi-shared-with-deps-${PT_VERSION}.zip
-	  fi
+		if [[ $GPU != 1 ]]; then
+			LIBTORCH_ARCHIVE=libtorch-cxx11-abi-shared-with-deps-${PT_VERSION}%2Bcpu.zip
+		else
+			LIBTORCH_ARCHIVE=libtorch-cxx11-abi-shared-with-deps-${PT_VERSION}.zip
+		fi
 	fi
 elif [[ $OS == macosx ]]; then
 	LIBTORCH_ARCHIVE=libtorch-${PT_OS}-${PT_VERSION}.zip

--- a/opt/build/libtorch/repack.sh
+++ b/opt/build/libtorch/repack.sh
@@ -32,7 +32,7 @@ if [[ $OS == linux ]]; then
 	if [[ $GPU == no ]]; then
 		PT_BUILD=cpu
 	else
-		PT_BUILD=cu90
+		PT_BUILD=cu100
 	fi
 	if [[ $ARCH == x64 ]]; then
 		PT_ARCH=x86_64

--- a/opt/build/libtorch/repack.sh
+++ b/opt/build/libtorch/repack.sh
@@ -16,7 +16,6 @@ elif [[ "$1" == "gpu" ]]; then
 else
 	GPU=${GPU:-no}
 fi
-
 OS=$(python3 $ROOT/opt/readies/bin/platform --os)
 ARCH=$(python3 $ROOT/opt/readies/bin/platform --arch)
 
@@ -32,7 +31,7 @@ if [[ $OS == linux ]]; then
 	if [[ $GPU == no ]]; then
 		PT_BUILD=cpu
 	else
-		PT_BUILD=cu100
+		PT_BUILD=cu101
 	fi
 	if [[ $ARCH == x64 ]]; then
 		PT_ARCH=x86_64
@@ -51,7 +50,11 @@ if [[ $OS == linux ]]; then
 	elif [[ $PT_VERSION == latest ]]; then
 		LIBTORCH_ARCHIVE=libtorch-shared-with-deps-latest.zip
 	else
-		LIBTORCH_ARCHIVE=libtorch-shared-with-deps-${PT_VERSION}%2Bcpu.zip
+	  if [[ $GPU == no ]]; then
+		  LIBTORCH_ARCHIVE=libtorch-cxx11-abi-shared-with-deps-${PT_VERSION}%2Bcpu.zip
+	  else
+		  LIBTORCH_ARCHIVE=libtorch-cxx11-abi-shared-with-deps-${PT_VERSION}.zip
+	  fi
 	fi
 elif [[ $OS == macosx ]]; then
 	LIBTORCH_ARCHIVE=libtorch-${PT_OS}-${PT_VERSION}.zip
@@ -62,6 +65,7 @@ fi
 LIBTORCH_ZIP=libtorch-${PT_BUILD}-${PT_OS}-${PT_ARCH}-${PT_VERSION}.zip
 if [ ! -f $LIBTORCH_ARCHIVE ]; then
 	echo "Downloading libtorch ${PT_VERSION} ${PT_BUILD}"
+  echo $LIBTORCH_URL
 	wget -q -O $LIBTORCH_ZIP $LIBTORCH_URL
 fi
 

--- a/opt/build/libtorch/repack.sh
+++ b/opt/build/libtorch/repack.sh
@@ -16,6 +16,7 @@ elif [[ "$1" == "gpu" ]]; then
 else
 	GPU=${GPU:-0}
 fi
+
 OS=$(python3 $ROOT/opt/readies/bin/platform --os)
 ARCH=$(python3 $ROOT/opt/readies/bin/platform --arch)
 
@@ -65,7 +66,6 @@ fi
 LIBTORCH_ZIP=libtorch-${PT_BUILD}-${PT_OS}-${PT_ARCH}-${PT_VERSION}.zip
 if [ ! -f $LIBTORCH_ARCHIVE ]; then
 	echo "Downloading libtorch ${PT_VERSION} ${PT_BUILD}"
-  echo $LIBTORCH_URL
 	wget -q -O $LIBTORCH_ZIP $LIBTORCH_URL
 fi
 

--- a/opt/system-setup.py
+++ b/opt/system-setup.py
@@ -19,7 +19,7 @@ class RedisAISetup(paella.Setup):
         self.setup_pip()
         self.pip3_install("wheel")
         self.pip3_install("setuptools --upgrade")
-        
+
         if self.os == 'linux':
             self.install("ca-certificates")
         self.install("git cmake unzip wget patchelf awscli")
@@ -27,7 +27,7 @@ class RedisAISetup(paella.Setup):
 
     def debian_compat(self):
         self.install("build-essential")
-        self.install("python3-venv python3-psutil python3-networkx")
+        self.install("python3-venv python3-psutil python3-networkx python3-numpy") # python3-skimage
         self.install_git_lfs_on_linux()
 
     def redhat_compat(self):
@@ -39,7 +39,7 @@ class RedisAISetup(paella.Setup):
         self.install("python36-psutil")
 
         self.install_git_lfs_on_linux()
-        
+
     def fedora(self):
         self.group_install("'Development Tools'")
         self.install("python3-venv python3-psutil python3-networkx")
@@ -56,7 +56,7 @@ class RedisAISetup(paella.Setup):
     def install_git_lfs_on_linux(self):
         self.run("curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash")
         self.install("git-lfs")
-    
+
     def common_last(self):
         if not self.has_command("RLTest"):
             self.pip3_install("git+https://github.com/RedisLabsModules/RLTest.git@master")

--- a/opt/system-setup.py
+++ b/opt/system-setup.py
@@ -27,7 +27,7 @@ class RedisAISetup(paella.Setup):
 
     def debian_compat(self):
         self.install("build-essential")
-        self.install("python3-venv python3-psutil python3-networkx python3-numpy python3-skimage")
+        self.install("python3-venv python3-psutil python3-networkx")
         self.install_git_lfs_on_linux()
 
     def redhat_compat(self):
@@ -42,7 +42,7 @@ class RedisAISetup(paella.Setup):
         
     def fedora(self):
         self.group_install("'Development Tools'")
-        self.install("python3-venv python3-psutil python3-networkx python3-numpy")
+        self.install("python3-venv python3-psutil python3-networkx")
         self.install_git_lfs_on_linux()
 
     def macosx(self):
@@ -64,7 +64,6 @@ class RedisAISetup(paella.Setup):
             self.pip3_install("git+https://github.com/RedisLabs/RAMP@master")
         root = os.path.join(os.path.dirname(__file__), "..")
         self.pip3_install("-r {}/test/test_requirements.txt".format(root))
-        # self.pip3_install("redis-py-cluster")
 
 #----------------------------------------------------------------------------------------------
 
@@ -72,4 +71,4 @@ parser = argparse.ArgumentParser(description='Set up system for build.')
 parser.add_argument('-n', '--nop', action="store_true", help='no operation')
 args = parser.parse_args()
 
-RedisAISetup(nop = args.nop).setup()
+RedisAISetup(nop=args.nop).setup()

--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -1,3 +1,4 @@
+#include <cuda_provider_factory.h>
 #include "backends/onnxruntime.h"
 #include "backends/util.h"
 #include "tensor.h"
@@ -281,12 +282,11 @@ RAI_Model *RAI_ModelCreateORT(RAI_Backend backend, const char* devicestr,
     ort->ReleaseSessionOptions(session_options);
     goto error;
   }
-
   // TODO: we will need to propose a more dynamic way to request a specific provider,
   // e.g. given the name, in ONNXRuntime
 #if RAI_ONNXRUNTIME_USE_CUDA
   if (device == RAI_DEVICE_GPU) {
-    ort->SessionOptionsAppendExecutionProvider_CUDA(session_options, deviceid);
+    OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, deviceid);
   }
 #else
   // TODO: Do dynamic device/provider check with GetExecutionProviderType or something else

--- a/test/basic_tests.py
+++ b/test/basic_tests.py
@@ -11,11 +11,13 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../opt/readies"))
+import paella
 
 TEST_TF = os.environ.get("TEST_TF") != "0" and os.environ.get("WITH_TF") != "0"
 TEST_TFLITE = os.environ.get("TEST_TFLITE") != "0" and os.environ.get("WITH_TFLITE") != "0"
 TEST_PT = os.environ.get("TEST_PT") != "0" and os.environ.get("WITH_PT") != "0"
 TEST_ONNX = os.environ.get("TEST_ONNX") != "0" and os.environ.get("WITH_ORT") != "0"
+
 
 '''
 python -m RLTest --test basic_tests.py --module path/to/redisai.so

--- a/test/basic_tests.py
+++ b/test/basic_tests.py
@@ -11,7 +11,6 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../opt/readies"))
-import paella
 
 TEST_TF = os.environ.get("TEST_TF") != "0" and os.environ.get("WITH_TF") != "0"
 TEST_TFLITE = os.environ.get("TEST_TFLITE") != "0" and os.environ.get("WITH_TFLITE") != "0"
@@ -19,8 +18,11 @@ TEST_PT = os.environ.get("TEST_PT") != "0" and os.environ.get("WITH_PT") != "0"
 TEST_ONNX = os.environ.get("TEST_ONNX") != "0" and os.environ.get("WITH_ORT") != "0"
 
 '''
-python -m RLTest --test basic_tests.py --module install/redisai.so
+python -m RLTest --test basic_tests.py --module path/to/redisai.so
 '''
+
+DEVICE = os.environ.get('DEVICE', 'CPU').upper()
+print(f"Running tests on {DEVICE}\n")
 
 
 def check_cuda():
@@ -118,7 +120,7 @@ def test_del_tf_model(env):
     with open(model_filename, 'rb') as f:
         model_pb = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TF', 'CPU',
+    ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
                               'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
     env.assertEqual(ret, b'OK')
 
@@ -141,13 +143,12 @@ def test_run_tf_model(env):
 
     with open(wrong_model_filename, 'rb') as f:
         wrong_model_pb = f.read()
-
-    ret = con.execute_command('AI.MODELSET', 'm', 'TF', 'CPU',
+    ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
                               'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
     env.assertEqual(ret, b'OK')
 
     try:
-        ret = con.execute_command('AI.MODELSET', 'm', 'TF', 'CPU',
+        ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
                                   'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', wrong_model_pb)
     except Exception as e:
         exception = e
@@ -161,14 +162,14 @@ def test_run_tf_model(env):
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_2', 'PORCH', 'CPU',
+        con.execute_command('AI.MODELSET', 'm_2', 'PORCH', DEVICE,
                             'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_3', 'TORCH', 'CPU',
+        con.execute_command('AI.MODELSET', 'm_3', 'TORCH', DEVICE,
                             'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
     except Exception as e:
         exception = e
@@ -182,41 +183,41 @@ def test_run_tf_model(env):
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_5', 'TF', 'CPU',
+        con.execute_command('AI.MODELSET', 'm_5', 'TF', DEVICE,
                             'INPUTS', 'a', 'b', 'c', 'OUTPUTS', 'mul', model_pb)
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_6', 'TF', 'CPU',
+        con.execute_command('AI.MODELSET', 'm_6', 'TF', DEVICE,
                             'INPUTS', 'a', 'b', 'OUTPUTS', 'mult', model_pb)
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_7', 'TF', 'CPU', model_pb)
+        con.execute_command('AI.MODELSET', 'm_7', 'TF', DEVICE, model_pb)
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_8', 'TF', 'CPU',
+        con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
                             'INPUTS', 'a', 'b', 'OUTPUTS', 'mul')
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_8', 'TF', 'CPU',
+        con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
                             'INPUTS', 'a_', 'b', 'OUTPUTS', 'mul')
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_8', 'TF', 'CPU',
+        con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
                             'INPUTS', 'a', 'b', 'OUTPUTS', 'mul_')
     except Exception as e:
         exception = e
@@ -272,11 +273,11 @@ def test_run_torch_model(env):
     with open(wrong_model_filename, 'rb') as f:
         wrong_model_pb = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', 'CPU', model_pb)
-    env.assertEqual(ret, b'OK')
+    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, model_pb)
+    con.assertEqual(ret, b'OK')
 
     try:
-        con.execute_command('AI.MODELSET', 'm', 'TORCH', 'CPU', wrong_model_pb)
+        con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, wrong_model_pb)
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -383,11 +384,11 @@ def test_run_onnx_model(env):
     with open(sample_filename, 'rb') as f:
         sample_raw = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'ONNX', 'CPU', model_pb)
-    env.assertEqual(ret, b'OK')
+    ret = con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, model_pb)
+    con.assertEqual(ret, b'OK')
 
     try:
-        con.execute_command('AI.MODELSET', 'm', 'ONNX', 'CPU', wrong_model_pb)
+        con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, wrong_model_pb)
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -490,11 +491,11 @@ def test_run_onnxml_model(env):
     with open(logreg_model_filename, 'rb') as f:
         logreg_model = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', 'CPU', linear_model)
-    env.assertEqual(ret, b'OK')
+    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, linear_model)
+    con.assertEqual(ret, b'OK')
 
-    ret = con.execute_command('AI.MODELSET', 'logreg', 'ONNX', 'CPU', logreg_model)
-    env.assertEqual(ret, b'OK')
+    ret = con.execute_command('AI.MODELSET', 'logreg', 'ONNX', DEVICE, logreg_model)
+    con.assertEqual(ret, b'OK')
 
     con.execute_command('AI.TENSORSET', 'features', 'FLOAT', 1, 4, 'VALUES', 5.1, 3.5, 1.4, 0.2)
 
@@ -650,7 +651,7 @@ def load_mobilenet_test_data():
     with open(model_filename, 'rb') as f:
         model_pb = f.read()
 
-    with open(labels_filename, 'rb') as f:
+    with open(labels_filename, 'r') as f:
         labels = json.load(f)
 
     img_height, img_width = 224, 224
@@ -673,7 +674,7 @@ def test_run_mobilenet(env):
 
     model_pb, labels, img = load_mobilenet_test_data()
 
-    con.execute_command('AI.MODELSET', 'mobilenet', 'TF', 'CPU',
+    con.execute_command('AI.MODELSET', 'mobilenet', 'TF', DEVICE,
                         'INPUTS', input_var, 'OUTPUTS', output_var, model_pb)
 
     con.execute_command('AI.TENSORSET', 'input',
@@ -716,7 +717,7 @@ def test_run_mobilenet_multiproc(env):
     output_var = 'MobilenetV2/Predictions/Reshape_1'
 
     model_pb, labels, img = load_mobilenet_test_data()
-    con.execute_command('AI.MODELSET', 'mobilenet', 'TF', 'CPU',
+    con.execute_command('AI.MODELSET', 'mobilenet', 'TF', DEVICE,
                         'INPUTS', input_var, 'OUTPUTS', output_var, model_pb)
 
     run_test_multiproc(env, 30, run_mobilenet, (img, input_var, output_var))
@@ -744,7 +745,7 @@ def test_set_incorrect_script(env):
     con = env.getConnection()
 
     try:
-        con.execute_command('AI.SCRIPTSET', 'ket', 'CPU', 'return 1')
+        con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, 'return 1')
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -756,7 +757,7 @@ def test_set_incorrect_script(env):
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.SCRIPTSET', 'more', 'CPU')
+        con.execute_command('AI.SCRIPTSET', 'more', DEVICE)
     except Exception as e:
         exception = e
     env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -774,9 +775,7 @@ def test_set_correct_script(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    con.execute_command('AI.SCRIPTSET', 'ket', 'CPU', script)
-
-    time.sleep(0.1)
+    con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, script)
 
     for _ in env.reloadingIterator():
         env.assertExists('ket')
@@ -794,11 +793,11 @@ def test_del_script(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    ret = con.execute_command('AI.SCRIPTSET', 'ket', 'CPU', script)
+    ret = con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, script)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.SCRIPTDEL', 'ket')
-    env.assertFalse(env.execute_command('EXISTS', 'ket'))
+    env.assertFalse(con.execute_command('EXISTS', 'ket'))
 
 
 def test_run_script(env):
@@ -813,7 +812,7 @@ def test_run_script(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    con.execute_command('AI.SCRIPTSET', 'ket', 'CPU', script)
+    con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, script)
 
     con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
     con.execute_command('AI.TENSORSET', 'b', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)

--- a/test/basic_tests.py
+++ b/test/basic_tests.py
@@ -276,7 +276,7 @@ def test_run_torch_model(env):
         wrong_model_pb = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, model_pb)
-    con.assertEqual(ret, b'OK')
+    env.assertEqual(ret, b'OK')
 
     try:
         con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, wrong_model_pb)
@@ -387,7 +387,7 @@ def test_run_onnx_model(env):
         sample_raw = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, model_pb)
-    con.assertEqual(ret, b'OK')
+    env.assertEqual(ret, b'OK')
 
     try:
         con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, wrong_model_pb)
@@ -494,10 +494,10 @@ def test_run_onnxml_model(env):
         logreg_model = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, linear_model)
-    con.assertEqual(ret, b'OK')
+    env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.MODELSET', 'logreg', 'ONNX', DEVICE, logreg_model)
-    con.assertEqual(ret, b'OK')
+    env.assertEqual(ret, b'OK')
 
     con.execute_command('AI.TENSORSET', 'features', 'FLOAT', 1, 4, 'VALUES', 5.1, 3.5, 1.4, 0.2)
 

--- a/test/double-panda.py
+++ b/test/double-panda.py
@@ -38,7 +38,7 @@ def load_mobilenet_test_data():
     with open(model_filename, 'rb') as f:
         model_pb = f.read()
 
-    with open(labels_filename, 'rb') as f:
+    with open(labels_filename, 'r') as f:
         labels = json.load(f)
 
     img_height, img_width = 224, 224

--- a/test/test_requirements.txt
+++ b/test/test_requirements.txt
@@ -1,3 +1,4 @@
 numpy
+scipy
 scikit-image
 redis-py-cluster

--- a/test/test_requirements.txt
+++ b/test/test_requirements.txt
@@ -1,4 +1,3 @@
 numpy
-scipy
 scikit-image
 redis-py-cluster


### PR DESCRIPTION
- CircleCI config for running GPU jobs
- Test cases running on GPU Device

I am not using any of the existing build utilities such as system-setup.py since relying on a file inside the repo trigger rebuilding of that layer on each push which is time-consuming. We need to iterate over this and other build processes to unify the build processes and to do the packaging and release of GPU docker image etc

Also, because of the `allow growth` feature in TF, the test cases on GPU takes a lot of time now