### PR TITLE
enable configuring the main thread to create a fixed number of worker threads up front per device.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,12 +67,12 @@ jobs:
     steps:
       - ci_steps:
           platform: debian 
-  build-macos:
-    macos:
-      xcode: 10.2.1
-    steps:
-      - ci_steps:
-          platform: macosx
+  # build-macos:
+  #   macos:
+  #     xcode: 10.2.1
+  #   steps:
+  #     - ci_steps:
+  #         platform: macosx
   build-multiarch-docker:
     machine:
       enabled: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,10 +126,10 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build-macos:
-          filters:
-            tags:
-              only: /.*/
+      # - build-macos:
+      #     filters:
+      #       tags:
+      #         only: /.*/
       - build-multiarch-docker:
           filters:
             tags:

--- a/src/redisai.h
+++ b/src/redisai.h
@@ -24,6 +24,11 @@ typedef struct RAI_Error RAI_Error;
 
 #define REDISAI_DEVICE_CPU 0
 #define REDISAI_DEVICE_GPU 1
+#define REDISAI_DEFAULT_THREADS_PER_QUEUE 1
+
+#define REDISAI_ERRORMSG_PROCESSING_ARG "ERR: error processing argument"
+#define REDISAI_ERRORMSG_THREADS_PER_QUEUE "ERR: error setting THREADS_PER_QUEUE to"
+#define REDISAI_INFOMSG_THREADS_PER_QUEUE "Setting THREADS_PER_QUEUE parameter to"
 
 RAI_Tensor* MODULE_API_FUNC(RedisAI_TensorCreate)(const char* dataTypeStr, long long* dims, int ndims);
 size_t MODULE_API_FUNC(RedisAI_TensorLength)(RAI_Tensor* t);


### PR DESCRIPTION
## summary report 
The presented values were obtained with OSS Redis 5.0.5 version and RedisAI OSS ( current master )
For the used fraud detection model:
- we passed from overall 13.7K inferences per second to 18.8K
- we've reduced the overall q50 total inference time from 0.56ms to 0.41ms 

## Results for 1 fixed thread ( current master ) 
```
aibench_run_inference_redisai -workers 8 -burn-in 10 -max-queries 0 -print-interval 0 -reporting-period 1000ms -model financialNet -host redis://127.0.0.1:6379
time (ns),total inferences,instantaneous inferences/s,overall inferences/s
burn-in complete after 10 queries with 8 workers
1570011177482832000,12577,12567.20,12567.20
1570011178483315000,26216,13631.35,13099.21
1570011179483239000,40062,13846.05,13348.05
1570011180482957000,54350,14291.07,13583.69
1570011181483121000,68422,14068.83,13680.71
1570011182483955000,82848,14413.18,13802.85
1570011183483322000,96637,13797.03,13802.02
1570011184483380000,111089,14450.49,13883.07
1570011185484550000,125457,14350.60,13935.06
1570011186485725000,139499,14024.99,13944.06
1570011187486906000,153873,14356.55,13981.59
1570011188482577000,167478,13663.73,13955.22
1570011189483245000,180416,12929.01,13876.23
1570011190482210000,193807,13404.55,13842.58
1570011191483147000,207550,13729.83,13835.06
1570011192482660000,220817,13273.22,13799.96
1570011193482141000,234439,13628.85,13789.90
1570011194482178000,247889,13449.31,13770.98
1570011195482110000,261206,13317.74,13747.13
1570011196482912000,274426,13209.28,13720.21
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Run complete after 284797 queries with 8 workers:
All queries                                                 :
+ Inference execution latency (statistical histogram):
        min:     0.15 ms,  mean:     0.58 ms, q25:     0.53 ms, med(q50):     0.56 ms, q75:     0.59 ms, q99:     0.93 ms, max:    13.93 ms, stddev:     0.13ms, sum: 164.492 sec, count: 284797, timedOut count: 0

RedisAI Query - with AI.TENSORSET transacation datatype BLOB:
+ Inference execution latency (statistical histogram):
        min:     0.15 ms,  mean:     0.58 ms, q25:     0.53 ms, med(q50):     0.56 ms, q75:     0.59 ms, q99:     0.93 ms, max:    13.93 ms, stddev:     0.13ms, sum: 164.492 sec, count: 284797, timedOut count: 0

Took:   20.781 sec
+ redis-cli info commandstats
# Commandstats
cmdstat_ai.tensorget:calls=284807,usec=579932,usec_per_call=2.04
cmdstat_config:calls=1,usec=11,usec_per_call=11.00
cmdstat_ai.tensorset:calls=284807,usec=1385755,usec_per_call=4.87
cmdstat_ai.modelrun:calls=284807,usec=1352374,usec_per_call=4.75
```

## Results for a thread pool of 2 threads for CPU device ( using changes in-placed in this PR ) 
```
aibench_run_inference_redisai -workers 8 -burn-in 10 -max-queries 0 -print-interval 0 -reporting-period 1000ms -model financialNet -host redis://127.0.0.1:6379
time (ns),total inferences,instantaneous inferences/s,overall inferences/s
burn-in complete after 10 queries with 8 workers
1570011221960013000,18551,18520.65,18520.65
1570011222959032000,38862,20331.27,19424.77
1570011223959054000,60769,21906.87,20251.96
1570011224961283000,81602,20787.03,20385.93
1570011225959108000,101755,20197.27,20348.29
1570011226959394000,120998,19237.82,20163.19
1570011227959120000,139635,18642.44,19946.02
1570011228962918000,157239,17537.71,19644.01
1570011229959150000,174923,17751.22,19434.51
1570011230959189000,193746,18822.61,19373.32
1570011231959224000,212800,19053.69,19344.27
1570011232959996000,228932,16119.86,19075.40
1570011233959244000,246133,17214.27,18932.35
1570011234959297000,264970,18836.36,18925.49
1570011235959275000,281741,16771.70,18781.92
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Run complete after 284797 queries with 8 workers:
All queries                                                 :
+ Inference execution latency (statistical histogram):
        min:     0.16 ms,  mean:     0.42 ms, q25:     0.36 ms, med(q50):     0.41 ms, q75:     0.46 ms, q99:     0.76 ms, max:     3.24 ms, stddev:     0.11ms, sum: 119.405 sec, count: 284797, timedOut count: 0

RedisAI Query - with AI.TENSORSET transacation datatype BLOB:
+ Inference execution latency (statistical histogram):
        min:     0.16 ms,  mean:     0.42 ms, q25:     0.36 ms, med(q50):     0.41 ms, q75:     0.46 ms, q99:     0.76 ms, max:     3.24 ms, stddev:     0.11ms, sum: 119.405 sec, count: 284797, timedOut count: 0

Took:   15.163 sec
+ redis-cli info commandstats
# Commandstats
cmdstat_ai.tensorget:calls=284807,usec=518151,usec_per_call=1.82
cmdstat_ai.tensorset:calls=284807,usec=1687792,usec_per_call=5.93
cmdstat_config:calls=1,usec=9,usec_per_call=9.00
cmdstat_ai.modelrun:calls=284807,usec=1913307,usec_per_call=6.72

```