### PR TITLE
added noAVX cpu support for TF.1.14.0 x64 linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Alternatively, run the following to only fetch the CPU-only backends even on GPU
 bash get_deps.sh cpu
 ```
 
+In case you are deploying on a CPU without AVX support (Tensorflow official binaries comes with AVX build), using TF-1.14.0-x64.
+```sh
+bash get_deps.sh cpu NOAVX=yes
+```
+
 Once the dependencies are downloaded, build the module itself. Note that
 CMake 3.0 or higher is required.
 

--- a/get_deps.sh
+++ b/get_deps.sh
@@ -19,6 +19,7 @@ if [[ $1 == --help || $1 == help ]]; then
 		WITH_TF=0   Skip Tensorflow
 		WITH_PT=0   Skip PyTorch
 		WITH_ORT=0  Skip OnnxRuntime
+		NOAVX=yes   Build from NoAVX TF only x64 linux cpu
 
 	END
 	exit 0
@@ -94,6 +95,9 @@ if [[ $WITH_TF != 0 ]]; then
 				TF_VERSION=1.14.0
 				TF_ARCH=x86_64
 				LIBTF_URL_BASE=https://storage.googleapis.com/tensorflow/libtensorflow
+				if [[ $NOAVX == yes ]]; then
+				LIBTF_URL_BASE=https://github.com/june9666/RedisAI-noAVX/raw/master
+				fi
 			elif [[ $ARCH == arm64v8 ]]; then
 				TF_VERSION=1.14.0
 				TF_ARCH=arm64


### PR DESCRIPTION
Running on a noAVX x64 cpu will crash TF.1.14.0 during load. I built and uploaded to my repo(link should be changed) libtensorflow.