### PR TITLE
Use redislabsmodules/rmbuilder to build docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
 
   deploy_docs:
     docker:
-      - image: redisfab/rmbuilder:x64-buster
+      - image: redislabsmodules/rmbuilder:latest
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Instead of redisfab/rmbuilder:x64-buster, trying to diagnose the following:
Docs has the old only Google analytics instead of Google tag manager line.