### PR TITLE
Add NoGradGuard to libtorch execution

### DIFF
--- a/src/libtorch_c/torch_c.cpp
+++ b/src/libtorch_c/torch_c.cpp
@@ -218,10 +218,12 @@ void torchRunModule(ModuleContext* ctx, const char* fnName,
   }
 
   if (ctx->module) {
+    torch::NoGradGuard guard;
     torch::jit::script::Method method = ctx->module->get_method(fnName);
     method.run(stack);
   }
   else {
+    torch::NoGradGuard guard;
     torch::jit::Function& fn = ctx->cu->get_function(fnName);
     fn.run(stack);
   }


### PR DESCRIPTION
Since we cannot be sure that users set `requires_grad` to `False` in all their model parameters, we instantiate a `torch::NoGradGuard` to ensure no gradients are tracked, for efficiency.