### PR TITLE
Add TAG to models and revamp MODELGET

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -165,23 +165,23 @@ AI.MODELRUN resnet18 INPUTS image12 OUTPUTS label12
     The execution of models will generate intermediate tensors that are not allocated by the Redis allocator, but by whatever allocator is used in the backends (which may act on main memory or GPU memory, depending on the device), thus not being limited by maxmemory settings on Redis.
 ---
 
-## AI.MODELLIST
+## AI._MODELLIST
 
-NOTE: `MODELLIST` is EXPERIMENTAL and might be removed in future versions.
+NOTE: `_MODELLIST` is EXPERIMENTAL and might be removed in future versions.
 
 List all models. Returns a list of (key, tag) pairs.
 
 ```sql
-AI.MODELLIST
+AI._MODELLIST
 ```
 
-### MODELLIST Example
+### _MODELLIST Example
 
 ```sql
 AI.MODELSET model1 TORCH GPU TAG resnet18:v1 < foo.pt
 AI.MODELSET model2 TORCH GPU TAG resnet18:v2 < bar.pt
 
-AI.MODELLIST
+AI._MODELLIST
 
 >  1) 1) "model1"
 >  1) 2) "resnet18:v1"
@@ -279,23 +279,23 @@ AI.SCRIPTRUN addscript addtwo INPUTS a b OUTPUTS c
     The execution of models will generate intermediate tensors that are not allocated by the Redis allocator, but by whatever allocator is used in the backends (which may act on main memory or GPU memory, depending on the device), thus not being limited by maxmemory settings on Redis.
 ---
 
-## AI.SCRIPTLIST
+## AI._SCRIPTLIST
 
-NOTE: `SCRIPTLIST` is EXPERIMENTAL and might be removed in future versions.
+NOTE: `_SCRIPTLIST` is EXPERIMENTAL and might be removed in future versions.
 
 List all scripts. Returns a list of (key, tag) pairs.
 
 ```sql
-AI.SCRIPTLIST
+AI._SCRIPTLIST
 ```
 
-### SCRIPTLIST Example
+### _SCRIPTLIST Example
 
 ```sql
 AI.SCRIPTSET script1 GPU TAG addtwo:v0.1 < addtwo.txt
 AI.SCRIPTSET script2 GPU TAG addtwo:v0.2 < addtwo.txt
 
-AI.SCRIPTLIST
+AI._SCRIPTLIST
 
 >  1) 1) "script1"
 >  1) 2) "addtwo:v0.1"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -67,12 +67,13 @@ AI.TENSORGET foo BLOB
 Set a model.
 
 ```sql
-AI.MODELSET model_key backend device [BATCHSIZE n [MINBATCHSIZE m]] [INPUTS name1 name2 ... OUTPUTS name1 name2 ...] model_blob
+AI.MODELSET model_key backend device [TAG tag] [BATCHSIZE n [MINBATCHSIZE m]] [INPUTS name1 name2 ... OUTPUTS name1 name2 ...] model_blob
 ```
 
 * model_key - Key for storing the model
 * backend - The backend corresponding to the model being set. Allowed values: `TF`, `TORCH`, `ONNX`.
 * device - Device where the model is loaded and where the computation will run. Allowed values: `CPU`, `GPU`.
+* TAG tag - Optional string tagging the model, such as a version number or other identifier
 * BATCHSIZE n - Batch incoming requests from multiple clients if they hit the same model and if input tensors have the same
                 shape. Upon MODELRUN, the request queue is visited, input tensors from compatible requests are concatenated
                 along the 0-th (batch) dimension, up until BATCHSIZE is exceeded. The model is then run for the entire batch,
@@ -98,7 +99,7 @@ AI.MODELSET resnet18 TF CPU INPUTS in1 OUTPUTS linear4 < foo.pb
 ```
 
 ```sql
-AI.MODELSET mnist_net ONNX CPU < mnist.onnx
+AI.MODELSET mnist_net ONNX CPU TAG mnist:lenet:v0.1 < mnist.onnx
 ```
 
 ```sql
@@ -111,15 +112,17 @@ AI.MODELSET resnet18 TF CPU BATCHSIZE 10 MINBATCHSIZE 6 INPUTS in1 OUTPUTS linea
 
 ## AI.MODELGET
 
-Get a model.
+Get model metadata and optionally its binary blob.
 
 ```sql
-AI.MODELGET model_key
+AI.MODELGET model_key [META | BLOB]
 ```
 
 * model_key - Key for the model
+* META - Only return information on backend, device and tag
+* BLOB - Return information on backend, device and tag, as well as a binary blob containing the serialized model
 
-The command returns the model as serialized by the backend, that is a string containing a protobuf.
+The command returns a list of key-value strings, namely `BACKEND backend DEVICE device TAG tag [BLOB blob]`.
 
 
 ## AI.MODELDEL
@@ -162,6 +165,31 @@ AI.MODELRUN resnet18 INPUTS image12 OUTPUTS label12
     The execution of models will generate intermediate tensors that are not allocated by the Redis allocator, but by whatever allocator is used in the backends (which may act on main memory or GPU memory, depending on the device), thus not being limited by maxmemory settings on Redis.
 ---
 
+## AI.MODELLIST
+
+NOTE: `MODELLIST` is EXPERIMENTAL and might be removed in future versions.
+
+List all models. Returns a list of (key, tag) pairs.
+
+```sql
+AI.MODELLIST
+```
+
+### MODELLIST Example
+
+```sql
+AI.MODELSET model1 TORCH GPU TAG resnet18:v1 < foo.pt
+AI.MODELSET model2 TORCH GPU TAG resnet18:v2 < bar.pt
+
+AI.MODELLIST
+
+>  1) 1) "model1"
+>  1) 2) "resnet18:v1"
+>  2) 1) "model2"
+>  2) 2) "resnet18:v2"
+```
+---
+
 
 
 ## AI.SCRIPTSET
@@ -169,11 +197,12 @@ AI.MODELRUN resnet18 INPUTS image12 OUTPUTS label12
 Set a script.
 
 ```sql
-AI.SCRIPTSET script_key device script_source
+AI.SCRIPTSET script_key device [TAG tag] script_source
 ```
 
 * script_key - Key for storing the script
 * device - The device where the script will execute
+* TAG tag - Optional string tagging the script, such as a version number or other identifier
 * script_source - A string containing [TorchScript](https://pytorch.org/docs/stable/jit.html) source code
 
 ### SCRIPTSET Example
@@ -189,9 +218,13 @@ def addtwo(a, b):
 AI.SCRIPTSET addscript GPU < addtwo.txt
 ```
 
+```sql
+AI.SCRIPTSET addscript GPU TAG myscript:v0.1 < addtwo.txt
+```
+
 ## AI.SCRIPTGET
 
-Get a script.
+Get script metadata and source.
 
 ```sql
 AI.SCRIPTGET script_key
@@ -199,6 +232,7 @@ AI.SCRIPTGET script_key
 
 * script_key - key for the script
 
+The command returns a list of key-value strings, namely `DEVICE device TAG tag [SOURCE source]`.
 
 ## AI.SCRIPTDEL
 
@@ -243,6 +277,31 @@ AI.SCRIPTRUN addscript addtwo INPUTS a b OUTPUTS c
 !!! warning "Intermediate tensors memory overhead when issuing `AI.MODELRUN` and `AI.SCRIPTRUN`"
         
     The execution of models will generate intermediate tensors that are not allocated by the Redis allocator, but by whatever allocator is used in the backends (which may act on main memory or GPU memory, depending on the device), thus not being limited by maxmemory settings on Redis.
+---
+
+## AI.SCRIPTLIST
+
+NOTE: `SCRIPTLIST` is EXPERIMENTAL and might be removed in future versions.
+
+List all scripts. Returns a list of (key, tag) pairs.
+
+```sql
+AI.SCRIPTLIST
+```
+
+### SCRIPTLIST Example
+
+```sql
+AI.SCRIPTSET script1 GPU TAG addtwo:v0.1 < addtwo.txt
+AI.SCRIPTSET script2 GPU TAG addtwo:v0.2 < addtwo.txt
+
+AI.SCRIPTLIST
+
+>  1) 1) "script1"
+>  1) 2) "addtwo:v0.1"
+>  2) 1) "script2"
+>  2) 2) "addtwo:v0.2"
+```
 ---
 
 ## AI.INFO

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ ADD_LIBRARY(redisai_obj OBJECT
         model.c
         err.c
         script.c
+        stats.c
         tensor.c
         rmutil/alloc.c
         rmutil/sds.c

--- a/src/config.h
+++ b/src/config.h
@@ -2,6 +2,11 @@
 #define SRC_CONFIG_H_
 
 typedef enum {
+  RAI_MODEL,
+  RAI_SCRIPT
+} RAI_RunType;
+
+typedef enum {
   RAI_BACKEND_TENSORFLOW = 0,
   RAI_BACKEND_TFLITE,
   RAI_BACKEND_TORCH,

--- a/src/model.h
+++ b/src/model.h
@@ -10,7 +10,7 @@
 extern RedisModuleType *RedisAI_ModelType;
 
 int RAI_ModelInit(RedisModuleCtx* ctx);
-RAI_Model *RAI_ModelCreate(RAI_Backend backend, const char* devicestr, RAI_ModelOpts opts,
+RAI_Model *RAI_ModelCreate(RAI_Backend backend, const char* devicestr, const char* tag, RAI_ModelOpts opts,
                            size_t ninputs, const char **inputs,
                            size_t noutputs, const char **outputs,
                            const char *modeldef, size_t modellen, RAI_Error* err);

--- a/src/model_struct.h
+++ b/src/model_struct.h
@@ -17,6 +17,7 @@ typedef struct RAI_Model {
   void *session;
   RAI_Backend backend;
   char* devicestr;
+  char* tag;
   RAI_ModelOpts opts;
   char **inputs;
   size_t ninputs;
@@ -24,6 +25,7 @@ typedef struct RAI_Model {
   size_t noutputs;
   long long refCount;
   void* data;
+  void* infokey;
 } RAI_Model;
 
 typedef struct RAI_ModelCtxParam {

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -556,6 +556,7 @@ void RedisAI_FreeRunStats(RedisModuleCtx *ctx, struct RedisAI_RunStats *rstats) 
 void *RedisAI_RunSession(struct RedisAI_RunInfo **batch_rinfo) {
   if (array_len(batch_rinfo) == 0) {
     return NULL;
+  }
 
   RAI_Error* err = RedisModule_Calloc(1, sizeof(RAI_Error));
   long long rtime;
@@ -688,6 +689,7 @@ int RedisAI_ModelSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     if (AC_GetUnsignedLongLong(&ac, &minbatchsize, 0) != AC_OK) {
       return RedisModule_ReplyWithError(ctx, "Invalid argument for MINBATCHSIZE");
     }
+  }
 
 
   if (AC_IsAtEnd(&ac)) {
@@ -2045,7 +2047,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
       == REDISMODULE_ERR)
     return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.modellist", RedisAI_ModelList_RedisCommand, "readonly", 1, 1, 1)
+  if (RedisModule_CreateCommand(ctx, "ai._modellist", RedisAI_ModelList_RedisCommand, "readonly", 1, 1, 1)
       == REDISMODULE_ERR)
     return REDISMODULE_ERR;
 
@@ -2065,7 +2067,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
       == REDISMODULE_ERR)
     return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.scriptlist", RedisAI_ScriptList_RedisCommand, "readonly", 1, 1, 1)
+  if (RedisModule_CreateCommand(ctx, "ai._scriptlist", RedisAI_ScriptList_RedisCommand, "readonly", 1, 1, 1)
       == REDISMODULE_ERR)
     return REDISMODULE_ERR;
 

--- a/src/redisai.h
+++ b/src/redisai.h
@@ -49,7 +49,7 @@ long long MODULE_API_FUNC(RedisAI_TensorDim)(RAI_Tensor* t, int dim);
 size_t MODULE_API_FUNC(RedisAI_TensorByteSize)(RAI_Tensor* t);
 char* MODULE_API_FUNC(RedisAI_TensorData)(RAI_Tensor* t);
 
-RAI_Model* MODULE_API_FUNC(RedisAI_ModelCreate)(int backend, char* devicestr, RAI_ModelOpts opts,
+RAI_Model* MODULE_API_FUNC(RedisAI_ModelCreate)(int backend, char* devicestr, char* tag, RAI_ModelOpts opts,
                                                 size_t ninputs, const char **inputs,
                                                 size_t noutputs, const char **outputs,
                                                 const char *modeldef, size_t modellen, RAI_Error* err);
@@ -64,7 +64,7 @@ int MODULE_API_FUNC(RedisAI_ModelRun)(RAI_ModelRunCtx* mctx, RAI_Error* err);
 RAI_Model* MODULE_API_FUNC(RedisAI_ModelGetShallowCopy)(RAI_Model* model);
 int MODULE_API_FUNC(RedisAI_ModelSerialize)(RAI_Model *model, char **buffer, size_t *len, RAI_Error *err);
 
-RAI_Script* MODULE_API_FUNC(RedisAI_ScriptCreate)(char* devicestr, const char* scriptdef, RAI_Error* err);
+RAI_Script* MODULE_API_FUNC(RedisAI_ScriptCreate)(char* devicestr, char* tag, const char* scriptdef, RAI_Error* err);
 void MODULE_API_FUNC(RedisAI_ScriptFree)(RAI_Script* script, RAI_Error* err);
 RAI_ScriptRunCtx* MODULE_API_FUNC(RedisAI_ScriptRunCtxCreate)(RAI_Script* script, const char *fnname);
 int MODULE_API_FUNC(RedisAI_ScriptRunCtxAddInput)(RAI_ScriptRunCtx* sctx, RAI_Tensor* inputTensor);

--- a/src/script.h
+++ b/src/script.h
@@ -10,7 +10,7 @@
 extern RedisModuleType *RedisAI_ScriptType;
 
 int RAI_ScriptInit(RedisModuleCtx* ctx);
-RAI_Script* RAI_ScriptCreate( const char* devicestr, const char* scriptdef, RAI_Error* err);
+RAI_Script* RAI_ScriptCreate( const char* devicestr, const char* tag, const char* scriptdef, RAI_Error* err);
 void RAI_ScriptFree(RAI_Script* script, RAI_Error* err);
 
 RAI_ScriptRunCtx* RAI_ScriptRunCtxCreate(RAI_Script* script, const char *fnname);

--- a/src/script_struct.h
+++ b/src/script_struct.h
@@ -12,7 +12,9 @@ typedef struct RAI_Script {
   // We keep it here at the moment, until we have a
   // CUDA allocator for dlpack
   char* devicestr;
+  char* tag;
   long long refCount;
+  void* infokey;
 } RAI_Script;
 
 typedef struct RAI_ScriptCtxParam {

--- a/src/stats.c
+++ b/src/stats.c
@@ -1,0 +1,65 @@
+#include "stats.h"
+
+void* RAI_AddStatsEntry(RedisModuleCtx* ctx, RedisModuleString* key, RAI_RunType runtype,
+                        RAI_Backend backend, const char* devicestr, const char* tag) {
+  const char* infokey = RedisModule_StringPtrLen(key, NULL);
+
+  struct RedisAI_RunStats *rstats = NULL;
+  rstats = RedisModule_Calloc(1, sizeof(struct RedisAI_RunStats));
+  RedisModule_RetainString(ctx, key);
+  rstats->key = key;
+  rstats->type = runtype;
+  rstats->backend = backend;
+  rstats->devicestr = RedisModule_Strdup(devicestr);
+  rstats->tag = RedisModule_Strdup(tag);
+
+  AI_dictAdd(run_stats, (void*)infokey, (void*)rstats);
+
+  return (void*)infokey;
+}
+
+void RAI_ListStatsEntries(RAI_RunType type, long long* nkeys, RedisModuleString*** keys,
+                          const char*** tags) {
+  AI_dictIterator *stats_iter = AI_dictGetSafeIterator(run_stats);
+
+  long long stats_size = AI_dictSize(run_stats);
+
+  *keys = RedisModule_Calloc(stats_size, sizeof(RedisModuleString*));
+  *tags = RedisModule_Calloc(stats_size, sizeof(const char*));
+
+  *nkeys = 0;
+
+  AI_dictEntry *stats_entry = AI_dictNext(stats_iter);
+  struct RedisAI_RunStats *rstats = NULL;
+
+  while (stats_entry) {
+    rstats = AI_dictGetVal(stats_entry);
+
+    if (rstats->type == type) {
+      (*keys)[*nkeys] = rstats->key;
+      (*tags)[*nkeys] = rstats->tag;
+      *nkeys += 1;
+    }
+
+    stats_entry = AI_dictNext(stats_iter);
+  }
+
+  AI_dictReleaseIterator(stats_iter);
+}
+
+void RAI_RemoveStatsEntry(void* infokey) {
+  AI_dictEntry *stats_entry = AI_dictFind(run_stats, infokey);
+
+  if (stats_entry) {
+    struct RedisAI_RunStats *rstats = AI_dictGetVal(stats_entry);
+    AI_dictDelete(run_stats, infokey);
+    RAI_FreeRunStats(rstats);
+    RedisModule_Free(rstats);
+  }
+}
+
+void RAI_FreeRunStats(struct RedisAI_RunStats *rstats) {
+  RedisModule_Free(rstats->devicestr);
+  RedisModule_Free(rstats->tag);
+}
+

--- a/src/stats.h
+++ b/src/stats.h
@@ -1,0 +1,32 @@
+#ifndef SRC_STATS_H_
+#define SRC_STATS_H_
+
+#include "redismodule.h"
+#include "config.h"
+#include "util/dict.h"
+
+struct RedisAI_RunStats {
+  RedisModuleString *key;
+  RAI_RunType type;
+  RAI_Backend backend;
+  char* devicestr;
+  char* tag;
+  long long duration_us;
+  long long samples;
+  long long calls;
+  long long nerrors;
+};
+
+void* RAI_AddStatsEntry(RedisModuleCtx* ctx, RedisModuleString* key, RAI_RunType type,
+                        RAI_Backend backend, const char* devicestr, const char* tag);
+
+void RAI_RemoveStatsEntry(void* infokey);
+
+void RAI_ListStatsEntries(RAI_RunType type, long long* nkeys, RedisModuleString*** keys,
+                          const char*** tags);
+
+void RAI_FreeRunStats(struct RedisAI_RunStats *rstats);
+
+AI_dict *run_stats;
+
+#endif /* SRC_SATTS_H_ */

--- a/test/tests_onnx.py
+++ b/test/tests_onnx.py
@@ -35,7 +35,18 @@ def test_onnx_modelrun_mnist(env):
     ensureSlaveSynced(con, env)
 
     ret = con.execute_command('AI.MODELGET', 'm')
-    env.assertEqual(len(ret), 3)
+    env.assertEqual(len(ret), 6)
+    env.assertEqual(ret[-1], b'')
+
+    ret = con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, 'TAG', 'asdf', model_pb)
+    env.assertEqual(ret, b'OK')
+
+    ensureSlaveSynced(con, env)
+
+    ret = con.execute_command('AI.MODELGET', 'm')
+    env.assertEqual(len(ret), 6)
+    env.assertEqual(ret[-1], b'asdf')
+ 
     # TODO: enable me
     # env.assertEqual(ret[0], b'ONNX')
     # env.assertEqual(ret[1], b'CPU')

--- a/test/tests_pytorch.py
+++ b/test/tests_pytorch.py
@@ -619,12 +619,12 @@ def test_pytorch_modellist_scriptlist(env):
 
     ensureSlaveSynced(con, env)
 
-    ret = con.execute_command('AI.MODELLIST')
+    ret = con.execute_command('AI._MODELLIST')
 
     env.assertEqual(ret[0], [b'm1', b'm:v1'])
     env.assertEqual(ret[1], [b'm2', b'm:v1'])
 
-    ret = con.execute_command('AI.SCRIPTLIST')
+    ret = con.execute_command('AI._SCRIPTLIST')
 
     env.assertEqual(ret[0], [b's1', b's:v1'])
     env.assertEqual(ret[1], [b's2', b's:v1'])

--- a/test/tests_tensorflow.py
+++ b/test/tests_tensorflow.py
@@ -187,7 +187,20 @@ def test_run_tf_model(env):
     ensureSlaveSynced(con, env)
 
     ret = con.execute_command('AI.MODELGET', 'm')
-    env.assertEqual(len(ret), 3)
+    env.assertEqual(len(ret), 6)
+    env.assertEqual(ret[-1], b'')
+
+    ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE, 'TAG', 'asdf',
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+    env.assertEqual(ret, b'OK')
+
+    ensureSlaveSynced(con, env)
+
+    ret = con.execute_command('AI.MODELGET', 'm')
+    env.assertEqual(len(ret), 6)
+    env.assertEqual(ret[-1], b'asdf')
+
+
     # TODO: enable me
     # env.assertEqual(ret[0], b'TF')
     # env.assertEqual(ret[1], b'CPU')

--- a/test/tests_tflite.py
+++ b/test/tests_tflite.py
@@ -34,13 +34,24 @@ def test_run_tflite_model(env):
     ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', model_pb)
     env.assertEqual(ret, b'OK')
 
+    ret = con.execute_command('AI.MODELGET', 'm')
+    env.assertEqual(len(ret), 6)
+    env.assertEqual(ret[-1], b'')
+
+    ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', 'TAG', 'asdf', model_pb)
+    env.assertEqual(ret, b'OK')
+
+    ret = con.execute_command('AI.MODELGET', 'm')
+    env.assertEqual(len(ret), 6)
+    env.assertEqual(ret[-1], b'asdf')
+
     ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 1, 1, 28, 28, 'BLOB', sample_raw)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
 
     ret = con.execute_command('AI.MODELGET', 'm')
-    env.assertEqual(len(ret), 3)
+    env.assertEqual(len(ret), 6)
     # TODO: enable me
     # env.assertEqual(ret[0], b'TFLITE')
     # env.assertEqual(ret[1], b'CPU')


### PR DESCRIPTION
Addresses:
* #306 by adding an optional `TAG <tag>` argument to `AI.MODELSET` and `AI.SCRIPTSET`; tags are returned by `AI.MODELGET` and `AI.SCRIPTGET` and they are reported as part of `AI.INFO`
* #304 by adding a `META` or `BLOB` argument to `AI.MODELGET` and `META` or `SOURCE` argument to `AI.SCRIPTGET` to get information like backend, device, tag, with or without the actual model blob or script source
* #303 by adding two new commands `AI.MODELLIST` and `AI.SCRIPTLIST`, that return key and tag for each model or script respectively