### PR TITLE
AI.INFO raises keyerror if MODELSET on existing key

### DIFF
--- a/src/redisai.c
+++ b/src/redisai.c
@@ -805,9 +805,10 @@ int RedisAI_ModelSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
   }
 
+  RedisModule_ModuleTypeSetValue(key, RedisAI_ModelType, model);
+
   model->infokey = RAI_AddStatsEntry(ctx, keystr, RAI_MODEL, backend, devicestr, tag);
 
-  RedisModule_ModuleTypeSetValue(key, RedisAI_ModelType, model);
   RedisModule_CloseKey(key);
 
   RedisModule_ReplyWithSimpleString(ctx, "OK");
@@ -1746,9 +1747,10 @@ int RedisAI_ScriptSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
     return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
   }
 
+  RedisModule_ModuleTypeSetValue(key, RedisAI_ScriptType, script);
+
   script->infokey = RAI_AddStatsEntry(ctx, keystr, RAI_SCRIPT, RAI_BACKEND_TORCH, devicestr, tag);
 
-  RedisModule_ModuleTypeSetValue(key, RedisAI_ScriptType, script);
   RedisModule_CloseKey(key);
 
   RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/test/tests_tensorflow.py
+++ b/test/tests_tensorflow.py
@@ -444,7 +444,6 @@ def test_run_tf_model_autobatch(env):
 @skip_if_no_TF
 def test_tensorflow_modelinfo(env):
     con = env.getConnection()
-
     test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
     model_filename = os.path.join(test_data_path, 'graph.pb')
 
@@ -454,6 +453,19 @@ def test_tensorflow_modelinfo(env):
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
                               'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
     env.assertEqual(ret, b'OK')
+    info = con.execute_command('AI.INFO', 'm')  # Getting initial info before modelrun
+    info_dict0 = info_to_dict(info)
+    expected = {'KEY': 'm', 'TYPE': 'MODEL', 'BACKEND': 'TF', 'DEVICE': 'CPU',
+                'TAG': '', 'DURATION': 0, 'SAMPLES': 0, 'CALLS': 0, 'ERRORS': 0}
+    env.assertEqual(info_dict0, expected)
+
+    # second modelset; a corner case
+    ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+    env.assertEqual(ret, b'OK')
+    info = con.execute_command('AI.INFO', 'm')  # this will fail
+    info_dict1 = info_to_dict(info)
+    env.assertEqual(info_dict1, info_dict0)
 
     ret = con.execute_command(
         'AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)

--- a/test/tests_tensorflow.py
+++ b/test/tests_tensorflow.py
@@ -455,7 +455,7 @@ def test_tensorflow_modelinfo(env):
     env.assertEqual(ret, b'OK')
     info = con.execute_command('AI.INFO', 'm')  # Getting initial info before modelrun
     info_dict0 = info_to_dict(info)
-    expected = {'KEY': 'm', 'TYPE': 'MODEL', 'BACKEND': 'TF', 'DEVICE': 'CPU',
+    expected = {'KEY': 'm', 'TYPE': 'MODEL', 'BACKEND': 'TF', 'DEVICE': DEVICE,
                 'TAG': '', 'DURATION': 0, 'SAMPLES': 0, 'CALLS': 0, 'ERRORS': 0}
     env.assertEqual(info_dict0, expected)
 


### PR DESCRIPTION
AI.INFO originally fetches initial dictionary if MODELRUN not executed on a MODELKEY
```python
{..., 'DURATION': 0, 'SAMPLES': 0, 'CALLS': 0, ...}
```
But if MODELSET is on the same key again, INFO raises a key error
```bash
redis.exceptions.ResponseError: cannot find run info for key
```

This PR contains the modified test case for finding this