### PR TITLE
Add Keras model test with TF2 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ RedisAI currently supports PyTorch (libtorch), Tensorflow (libtensorflow), Tenso
 | 0.9.0   | 1.3.1   | 1.14.0     | 2.0.0  | 1.0.0         |
 | master  | 1.4.0   | 1.15.0     | 2.0.0  | 1.0.0         |
 
+Note: Keras and TensorFlow 2.x are supported through graph freezing. See [this script](https://github.com/RedisAI/RedisAI/blob/master/test/test_data/tf2-minimal.py) to see how to export a frozen graph from Keras and TensorFlow 2.x.
+
 ## Documentation
 
 Read the docs at [redisai.io](http://redisai.io). Checkout our [showcase repo](https://github.com/RedisAI/redisai-examples) for a lot of examples written using different client libraries.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ RedisAI currently supports PyTorch (libtorch), Tensorflow (libtensorflow), Tenso
 | 0.9.0   | 1.3.1   | 1.14.0     | 2.0.0  | 1.0.0         |
 | master  | 1.4.0   | 1.15.0     | 2.0.0  | 1.0.0         |
 
-Note: Keras and TensorFlow 2.x are supported through graph freezing. See [this script](https://github.com/RedisAI/RedisAI/blob/master/test/test_data/tf2-minimal.py) to see how to export a frozen graph from Keras and TensorFlow 2.x.
+Note: Keras and TensorFlow 2.x are supported through graph freezing. See [this script](https://github.com/RedisAI/RedisAI/blob/master/test/test_data/tf2-minimal.py) to see how to export a frozen graph from Keras and TensorFlow 2.x. Note that a frozen graph will be executed using the TensorFlow 1.15 backend. Should any 2.0 ops be not supported on the 1.15 after freezing, please open an Issue.
 
 ## Documentation
 

--- a/test/test_data/graph_v2.pb
+++ b/test/test_data/graph_v2.pb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9970a47f2818a1137c1e39e96a8c43938abced0eb44f78f5beabe0add9449539
+size 408865

--- a/test/test_data/tf2-minimal.py
+++ b/test/test_data/tf2-minimal.py
@@ -3,6 +3,8 @@ from tensorflow import keras
 from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
 import numpy as np
 
+# From https://github.com/leimao/Frozen_Graph_TensorFlow
+
 tf.random.set_seed(seed=0)
 
 model = keras.Sequential(layers=[
@@ -11,15 +13,6 @@ model = keras.Sequential(layers=[
                              keras.layers.Dense(128, activation="relu", name="dense"),
                              keras.layers.Dense(10, activation="softmax", name="output")
                          ], name="FCN")
-
-# model = keras.Sequential(layers=[
-#                          keras.layers.InputLayer(input_shape=(28, 28), name="input"),
-#                          keras.layers.Flatten(input_shape=(28, 28), name="flatten"),
-#                          keras.layers.Dense(128, activation="relu", name="dense",
-#                              kernel_initializer='random_uniform', bias_initializer='zeros'),
-#                          keras.layers.Dense(10, activation="softmax", name="output",
-#                              kernel_initializer='random_uniform', bias_initializer='zeros'),
-#                          )], name="FCN")
 
 model.compile(optimizer="adam",
               loss="sparse_categorical_crossentropy",

--- a/test/test_data/tf2-minimal.py
+++ b/test/test_data/tf2-minimal.py
@@ -1,0 +1,39 @@
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
+import numpy as np
+
+tf.random.set_seed(seed=0)
+
+model = keras.Sequential(layers=[
+                             keras.layers.InputLayer(input_shape=(28, 28), name="input"),
+                             keras.layers.Flatten(input_shape=(28, 28), name="flatten"),
+                             keras.layers.Dense(128, activation="relu", name="dense"),
+                             keras.layers.Dense(10, activation="softmax", name="output")
+                         ], name="FCN")
+
+# model = keras.Sequential(layers=[
+#                          keras.layers.InputLayer(input_shape=(28, 28), name="input"),
+#                          keras.layers.Flatten(input_shape=(28, 28), name="flatten"),
+#                          keras.layers.Dense(128, activation="relu", name="dense",
+#                              kernel_initializer='random_uniform', bias_initializer='zeros'),
+#                          keras.layers.Dense(10, activation="softmax", name="output",
+#                              kernel_initializer='random_uniform', bias_initializer='zeros'),
+#                          )], name="FCN")
+
+model.compile(optimizer="adam",
+              loss="sparse_categorical_crossentropy",
+              metrics=["accuracy"])
+
+full_model = tf.function(lambda x: model(x))
+full_model = full_model.get_concrete_function(
+                 tf.TensorSpec(model.inputs[0].shape, model.inputs[0].dtype))
+
+frozen_func = convert_variables_to_constants_v2(full_model)
+frozen_func.graph.as_graph_def()
+
+tf.io.write_graph(graph_or_graph_def=frozen_func.graph,
+                  logdir=".",
+                  name="graph_v2.pb",
+                  as_text=False)
+


### PR DESCRIPTION
TF2 supports freezing models, which can ben ran on TF1.15.

This PR adds a test on a MNIST-like model generated with Keras, exported through TF2 and that is ran on RedisAI.