### PR TITLE
Code refactoring, consistent error messages, and RedisAI_ModelRun_RedisCommand optimizations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 ADD_LIBRARY(redisai_obj OBJECT
         util/dict.c
+        util/queue.c
         redisai.c
         backends.c
         model.c

--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -347,7 +347,7 @@ RAI_Model *RAI_ModelCreateORT(RAI_Backend backend, const char* devicestr, RAI_Mo
 #else
   // TODO: Do dynamic device/provider check with GetExecutionProviderType or something on these lines
   if (device == RAI_DEVICE_GPU) {
-    RAI_SetError(error, RAI_EMODELCREATE, "GPU requested but ONNX couldn't find CUDA");
+    RAI_SetError(error, RAI_EMODELCREATE, "ERR GPU requested but ONNX couldn't find CUDA");
     return NULL;
   }
 #endif
@@ -408,13 +408,13 @@ int RAI_ModelRunORT(RAI_ModelRunCtx *mctx, RAI_Error *error)
   OrtSession *session = mctx->model->session;
 
   if (session == NULL) {
-    RAI_SetError(error, RAI_EMODELRUN, "ONNXRuntime session was not allocated\n");
+    RAI_SetError(error, RAI_EMODELRUN, "ERR ONNXRuntime session was not allocated");
     return 1;
   }
 
   const size_t nbatches = array_len(mctx->batches);
   if (nbatches == 0) {
-    RAI_SetError(error, RAI_EMODELRUN, "No batches to run\n");
+    RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
     return 1;
   }
  
@@ -462,14 +462,14 @@ int RAI_ModelRunORT(RAI_ModelRunCtx *mctx, RAI_Error *error)
 
     if (ninputs != n_input_nodes) {
       char msg[70];
-      sprintf(msg, "Expected %li inputs but got %li", n_input_nodes, ninputs);
+      sprintf(msg, "ERR Expected %li inputs but got %li", n_input_nodes, ninputs);
       RAI_SetError(error, RAI_EMODELRUN, msg);
       return 1;
     }
 
     if (noutputs != n_output_nodes) {
       char msg[70];
-      sprintf(msg, "Expected %li outputs but got %li", n_output_nodes, noutputs);
+      sprintf(msg, "ERR Expected %li outputs but got %li", n_output_nodes, noutputs);
       RAI_SetError(error, RAI_EMODELRUN, msg);
       return 1;
     }
@@ -500,14 +500,14 @@ int RAI_ModelRunORT(RAI_ModelRunCtx *mctx, RAI_Error *error)
     status = OrtSessionGetInputTypeInfo(session, i, &typeinfo);
     const OrtTensorTypeAndShapeInfo* tensor_info = OrtCastTypeInfoToTensorInfo(typeinfo);
     ONNXTensorElementDataType type = OrtGetTensorElementType(tensor_info);
-    // printf("Input %zu : type=%d\n", i, type);
+    // printf("Input %zu : type=%d", i, type);
 
     size_t num_dims = OrtGetDimensionsCount(tensor_info);
-    // printf("Input %zu : num_dims=%zu\n", i, num_dims);
+    // printf("Input %zu : num_dims=%zu", i, num_dims);
     input_node_dims.resize(num_dims);
     OrtGetDimensions(tensor_info, (int64_t*)input_node_dims.data(), num_dims);
     for (size_t j = 0; j < num_dims; j++) {
-      // printf("Input %zu : dim %zu=%jd\n", i, j, input_node_dims[j]);
+      // printf("Input %zu : dim %zu=%jd", i, j, input_node_dims[j]);
     }
 
     OrtReleaseTypeInfo(typeinfo);
@@ -549,7 +549,7 @@ int RAI_ModelRunORT(RAI_ModelRunCtx *mctx, RAI_Error *error)
           RAI_TensorFree(output_tensor);
         }
         else {
-          printf("ERR: non-tensor output from ONNX models, ignoring (currently unsupported).\n");
+          printf("ERR: non-tensor output from ONNX models, ignoring (currently unsupported)");
         }
       }
 

--- a/src/backends/tensorflow.c
+++ b/src/backends/tensorflow.c
@@ -256,8 +256,8 @@ RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char* devicestr, RAI_Mod
     TF_Operation* oper = TF_GraphOperationByName(model, inputs[i]);
     if (oper == NULL) {
       size_t len = strlen(inputs[i]);
-      char* msg = RedisModule_Calloc(40 + len, sizeof(*msg));
-      sprintf(msg, "Input node named \"%s\" not found in TF graph.", inputs[i]);
+      char* msg = RedisModule_Calloc(60 + len, sizeof(*msg));
+      sprintf(msg, "ERR Input node named \"%s\" not found in TF graph.", inputs[i]);
       RAI_SetError(error, RAI_EMODELIMPORT, msg);
       return NULL;
     }
@@ -267,8 +267,8 @@ RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char* devicestr, RAI_Mod
     TF_Operation* oper = TF_GraphOperationByName(model, outputs[i]);
     if (oper == NULL) {
       size_t len = strlen(outputs[i]);
-      char* msg = RedisModule_Calloc(40 + len, sizeof(*msg));
-      sprintf(msg, "Output node named \"%s\" not found in TF graph", outputs[i]);
+      char* msg = RedisModule_Calloc(60 + len, sizeof(*msg));
+      sprintf(msg, "ERR Output node named \"%s\" not found in TF graph", outputs[i]);
       RAI_SetError(error, RAI_EMODELIMPORT, msg);
       return NULL;
     }

--- a/src/backends/tensorflow.c
+++ b/src/backends/tensorflow.c
@@ -268,7 +268,7 @@ RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char* devicestr, RAI_Mod
     if (oper == NULL) {
       size_t len = strlen(outputs[i]);
       char* msg = RedisModule_Calloc(40 + len, sizeof(*msg));
-      sprintf(msg, "Output node named \"%s\" not found in TF graph.", outputs[i]);
+      sprintf(msg, "Output node named \"%s\" not found in TF graph", outputs[i]);
       RAI_SetError(error, RAI_EMODELIMPORT, msg);
       return NULL;
     }
@@ -336,7 +336,7 @@ RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char* devicestr, RAI_Mod
     }
   }
   if (foundNoGPU == 1 && device == RAI_DEVICE_GPU) {
-    RAI_SetError(error, RAI_EMODELCREATE, "GPU requested but TF couldn't find CUDA");
+    RAI_SetError(error, RAI_EMODELCREATE, "ERR GPU requested but TF couldn't find CUDA");
     TF_DeleteDeviceList(deviceList);
     TF_DeleteStatus(deviceListStatus);
     // TODO: free other memory allocations
@@ -424,7 +424,7 @@ int RAI_ModelRunTF(RAI_ModelRunCtx* mctx, RAI_Error *error) {
 
   const size_t nbatches = array_len(mctx->batches);
   if (nbatches == 0) {
-    RAI_SetError(error, RAI_EMODELRUN, "No batches to run\n");
+    RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
     return 1;
   }
   
@@ -522,7 +522,7 @@ int RAI_ModelSerializeTF(RAI_Model *model, char **buffer, size_t *len, RAI_Error
   TF_GraphToGraphDef(model->model, tf_buffer, status);
 
   if (TF_GetCode(status) != TF_OK) {
-    RAI_SetError(error, RAI_EMODELSERIALIZE, "Error serializing TF model");
+    RAI_SetError(error, RAI_EMODELSERIALIZE, "ERR Error serializing TF model");
     TF_DeleteBuffer(tf_buffer);
     TF_DeleteStatus(status);
     return 1;

--- a/src/backends/tflite.c
+++ b/src/backends/tflite.c
@@ -27,7 +27,7 @@ RAI_Model *RAI_ModelCreateTFLite(RAI_Backend backend, const char* devicestr, RAI
   RAI_Device device;
   int64_t deviceid;
   if (!parseDeviceStr(devicestr, &device, &deviceid)) {
-    RAI_SetError(error, RAI_EMODELCONFIGURE, "Unsupported device");
+    RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR Unsupported device");
     return NULL;
   }
 
@@ -39,7 +39,7 @@ RAI_Model *RAI_ModelCreateTFLite(RAI_Backend backend, const char* devicestr, RAI
       dl_device = kDLGPU;
       break;
     default:
-      RAI_SetError(error, RAI_EMODELCONFIGURE, "Error configuring model: unsupported device\n");
+      RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR Error configuring model: unsupported device");
       return NULL;
   }
 
@@ -86,7 +86,7 @@ int RAI_ModelRunTFLite(RAI_ModelRunCtx* mctx, RAI_Error *error) {
 
   const size_t nbatches = array_len(mctx->batches);
   if (nbatches == 0) {
-    RAI_SetError(error, RAI_EMODELRUN, "No batches to run\n");
+    RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
     return 1;
   }
 
@@ -149,13 +149,13 @@ int RAI_ModelRunTFLite(RAI_ModelRunCtx* mctx, RAI_Error *error) {
 
   for(size_t i=0 ; i<noutputs; ++i) {
     if (outputs_dl[i] == NULL) {
-      RAI_SetError(error, RAI_EMODELRUN, "Model did not generate the expected number of outputs.");
+      RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected number of outputs");
       return 1;
     }
     RAI_Tensor* output_tensor = RAI_TensorCreateFromDLTensor(outputs_dl[i]);
     if (nbatches > 1 && RAI_TensorDim(output_tensor, 0) != total_batch_size) {
       RAI_TensorFree(output_tensor);
-      RAI_SetError(error, RAI_EMODELRUN, "Model did not generate the expected batch size.");
+      RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");
       return 1;
     }
     if (nbatches > 1) {

--- a/src/backends/torch.c
+++ b/src/backends/torch.c
@@ -35,7 +35,7 @@ RAI_Model *RAI_ModelCreateTorch(RAI_Backend backend, const char* devicestr, RAI_
       dl_device = kDLGPU;
       break;
     default:
-      RAI_SetError(error, RAI_EMODELCONFIGURE, "Error configuring model: unsupported device\n");
+      RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR Error configuring model: unsupported device");
       return NULL;
   }
 
@@ -71,7 +71,7 @@ void RAI_ModelFreeTorch(RAI_Model* model, RAI_Error *error) {
 int RAI_ModelRunTorch(RAI_ModelRunCtx* mctx, RAI_Error *error) {
   const size_t nbatches = array_len(mctx->batches);
   if (nbatches == 0) {
-    RAI_SetError(error, RAI_EMODELRUN, "No batches to run\n");
+    RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
     return 1;
   }
 
@@ -134,7 +134,7 @@ int RAI_ModelRunTorch(RAI_ModelRunCtx* mctx, RAI_Error *error) {
 
   for(size_t i=0 ; i<noutputs; ++i) {
     if (outputs_dl[i] == NULL) {
-      RAI_SetError(error, RAI_EMODELRUN, "Model did not generate the expected number of outputs.");
+      RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected number of outputs");
       return 1;
     }
     RAI_Tensor* output_tensor = RAI_TensorCreateFromDLTensor(outputs_dl[i]);
@@ -188,7 +188,7 @@ RAI_Script *RAI_ScriptCreateTorch(const char* devicestr, const char *scriptdef, 
       dl_device = kDLGPU;
       break;
     default:
-      RAI_SetError(error, RAI_ESCRIPTCONFIGURE, "Error configuring script: unsupported device\n");
+      RAI_SetError(error, RAI_ESCRIPTCONFIGURE, "ERR Error configuring script: unsupported device");
       break;
   }
 

--- a/src/err.c
+++ b/src/err.c
@@ -26,7 +26,7 @@ void RAI_SetError(RAI_Error *err, RAI_ErrorCode code, const char *detail) {
   if (detail) {
     err->detail = RedisModule_Strdup(detail);
   } else {
-    err->detail = RedisModule_Strdup("Generic error");
+    err->detail = RedisModule_Strdup("ERR Generic error");
   }
 
   err->detail_oneline = RAI_Chomp(err->detail);

--- a/src/model.c
+++ b/src/model.c
@@ -220,34 +220,34 @@ RAI_Model *RAI_ModelCreate(RAI_Backend backend, const char* devicestr, const cha
   RAI_Model *model;
   if (backend == RAI_BACKEND_TENSORFLOW) {
     if (!RAI_backends.tf.model_create_with_nodes) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TF.\n");
+      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
       return NULL;
     }
     model = RAI_backends.tf.model_create_with_nodes(backend, devicestr, opts, ninputs, inputs, noutputs, outputs, modeldef, modellen, err);
   }
   else if (backend == RAI_BACKEND_TFLITE) {
     if (!RAI_backends.tflite.model_create) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TFLITE.\n");
+      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
       return NULL;
     }
     model = RAI_backends.tflite.model_create(backend, devicestr, opts, modeldef, modellen, err);
   }
   else if (backend == RAI_BACKEND_TORCH) {
     if (!RAI_backends.torch.model_create) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TORCH.\n");
+      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
       return NULL;
     }
     model = RAI_backends.torch.model_create(backend, devicestr, opts, modeldef, modellen, err);
   }
   else if (backend == RAI_BACKEND_ONNXRUNTIME) {
     if (!RAI_backends.onnx.model_create) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: ONNX.\n");
+      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
       return NULL;
     }
     model = RAI_backends.onnx.model_create(backend, devicestr, opts, modeldef, modellen, err);
   }
   else {
-    RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "Unsupported backend.\n");
+    RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "ERR Unsupported backend\n");
     return NULL;
   }
 
@@ -265,28 +265,28 @@ void RAI_ModelFree(RAI_Model* model, RAI_Error* err) {
 
   if (model->backend == RAI_BACKEND_TENSORFLOW) {
     if (!RAI_backends.tf.model_free) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TF.\n");
+      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF\n");
       return;
     }
     RAI_backends.tf.model_free(model, err);
   }
   else if (model->backend == RAI_BACKEND_TFLITE) {
     if (!RAI_backends.tflite.model_free) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TFLITE.\n");
+      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
       return;
     }
     RAI_backends.tflite.model_free(model, err);
   }
   else if (model->backend == RAI_BACKEND_TORCH) {
     if (!RAI_backends.torch.model_free) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TORCH.\n");
+      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
       return;
     }
     RAI_backends.torch.model_free(model, err);
   }
   else if (model->backend == RAI_BACKEND_ONNXRUNTIME) {
     if (!RAI_backends.onnx.model_free) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: ONNX.\n");
+      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
       return;
     }
     RAI_backends.onnx.model_free(model, err);
@@ -428,34 +428,34 @@ int RAI_ModelRun(RAI_ModelRunCtx* mctx, RAI_Error* err) {
   switch (mctx->model->backend) {
     case RAI_BACKEND_TENSORFLOW:
       if (!RAI_backends.tf.model_run) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TF.\n");
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
         return REDISMODULE_ERR;
       }
       ret = RAI_backends.tf.model_run(mctx, err);
       break;
     case RAI_BACKEND_TFLITE:
       if (!RAI_backends.tflite.model_run) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TFLITE.\n");
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
         return REDISMODULE_ERR;
       }
       ret = RAI_backends.tflite.model_run(mctx, err);
       break;
     case RAI_BACKEND_TORCH:
       if (!RAI_backends.torch.model_run) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TORCH.\n");
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
         return REDISMODULE_ERR;
       }
       ret = RAI_backends.torch.model_run(mctx, err);
       break;
     case RAI_BACKEND_ONNXRUNTIME:
       if (!RAI_backends.onnx.model_run) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: ONNX.\n");
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
         return REDISMODULE_ERR;
       }
       ret = RAI_backends.onnx.model_run(mctx, err);
       break;
     default:
-      RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "Unsupported backend.\n");
+      RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "ERR Unsupported backend");
       return REDISMODULE_ERR;
   }
 
@@ -473,34 +473,34 @@ int RAI_ModelSerialize(RAI_Model *model, char **buffer, size_t *len, RAI_Error *
   switch (model->backend) {
     case RAI_BACKEND_TENSORFLOW:
       if (!RAI_backends.tf.model_serialize) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TF.\n");
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
         return REDISMODULE_ERR;
       }
       ret = RAI_backends.tf.model_serialize(model, buffer, len, err);
       break;
     case RAI_BACKEND_TFLITE:
       if (!RAI_backends.tflite.model_serialize) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TFLITE.\n");
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
         return REDISMODULE_ERR;
       }
       ret = RAI_backends.tflite.model_serialize(model, buffer, len, err);
       break;
     case RAI_BACKEND_TORCH:
       if (!RAI_backends.torch.model_serialize) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TORCH.\n");
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
         return REDISMODULE_ERR;
       }
       ret = RAI_backends.torch.model_serialize(model, buffer, len, err);
       break;
     case RAI_BACKEND_ONNXRUNTIME:
       if (!RAI_backends.onnx.model_serialize) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: ONNX.\n");
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
         return REDISMODULE_ERR;
       }
       ret = RAI_backends.onnx.model_serialize(model, buffer, len, err);
       break;
     default:
-      RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "Unsupported backend.\n");
+      RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "ERR Unsupported backend");
       return REDISMODULE_ERR;
   }
 

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -98,7 +98,7 @@ mstime_t mstime(void) {
 /* Return REDISMODULE_ERR if there was an error getting the Model.
  * Return REDISMODULE_OK if the model value stored at key was correctly
  * returned and available at *model variable. */
-int RAI_getModelFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
+int RAI_GetModelFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
                               RedisModuleKey **key, RAI_Model **model,
                               int mode) {
   *key = RedisModule_OpenKey(ctx, keyName, mode);
@@ -119,7 +119,7 @@ int RAI_getModelFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
 /* Return REDISMODULE_ERR if there was an error getting the Script.
  * Return REDISMODULE_OK if the model value stored at key was correctly
  * returned and available at *model variable. */
-int RAI_getScriptFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
+int RAI_GetScriptFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
                               RedisModuleKey **key, RAI_Script **script,
                               int mode) {
   *key = RedisModule_OpenKey(ctx, keyName, mode);
@@ -139,7 +139,7 @@ int RAI_getScriptFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
 
 /* Return REDISMODULE_ERR if is the key not associated with a tensor type.
  * Return REDISMODULE_OK otherwise. */
-int RAI_openKey_Tensor(RedisModuleCtx *ctx, RedisModuleString *keyName,
+int RAI_OpenKey_Tensor(RedisModuleCtx *ctx, RedisModuleString *keyName,
                               RedisModuleKey **key,
                               int mode) {
   *key = RedisModule_OpenKey(ctx, keyName, mode);
@@ -157,7 +157,7 @@ int RAI_openKey_Tensor(RedisModuleCtx *ctx, RedisModuleString *keyName,
 /* Return REDISMODULE_ERR if there was an error getting the Tensor.
  * Return REDISMODULE_OK if the tensor value stored at key was correctly
  * returned and available at *tensor variable. */
-int RAI_getTensorFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
+int RAI_GetTensorFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
                                RedisModuleKey **key, RAI_Tensor **tensor,
                                int mode) {
   *key = RedisModule_OpenKey(ctx, keyName, mode);
@@ -349,7 +349,7 @@ int RedisAI_Run_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   for (size_t i=0; i<num_outputs; ++i) {
     RedisModuleKey *outkey;
-    const int status = RAI_openKey_Tensor(ctx, rinfo->outkeys[i], &outkey, REDISMODULE_READ|REDISMODULE_WRITE);
+    const int status = RAI_OpenKey_Tensor(ctx, rinfo->outkeys[i], &outkey, REDISMODULE_READ|REDISMODULE_WRITE);
     if(status==REDISMODULE_ERR){
         RedisAI_FreeRunInfo(ctx, rinfo);
         if (rstats) {
@@ -583,7 +583,7 @@ int RedisAI_TensorSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   if (argc < 4) return RedisModule_WrongArity(ctx);
 
   RedisModuleKey *key;
-  const int status = RAI_openKey_Tensor(ctx, argv[1], &key, REDISMODULE_READ|REDISMODULE_WRITE);
+  const int status = RAI_OpenKey_Tensor(ctx, argv[1], &key, REDISMODULE_READ|REDISMODULE_WRITE);
   if(status==REDISMODULE_ERR){
       return REDISMODULE_ERR;
   }
@@ -729,7 +729,7 @@ int RedisAI_TensorGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
 
   RAI_Tensor *t;
   RedisModuleKey *key;
-  const int status = RAI_getTensorFromKeyspace(ctx, argv[1], &key, &t, REDISMODULE_READ);
+  const int status = RAI_GetTensorFromKeyspace(ctx, argv[1], &key, &t, REDISMODULE_READ);
   if(status==REDISMODULE_ERR){
       return REDISMODULE_ERR;
   }
@@ -1019,7 +1019,7 @@ int RedisAI_ModelGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   RAI_Model *mto;
   RedisModuleKey *key;
-  const int status = RAI_getModelFromKeyspace( ctx, argv[1], &key, &mto, REDISMODULE_READ | REDISMODULE_WRITE);
+  const int status = RAI_GetModelFromKeyspace( ctx, argv[1], &key, &mto, REDISMODULE_READ | REDISMODULE_WRITE);
   if (status == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
@@ -1086,7 +1086,7 @@ int RedisAI_ModelDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   RAI_Model *mto;
   RedisModuleKey *key;
-  const int status = RAI_getModelFromKeyspace(ctx, argv[1], &key, &mto, REDISMODULE_READ|REDISMODULE_WRITE);
+  const int status = RAI_GetModelFromKeyspace(ctx, argv[1], &key, &mto, REDISMODULE_READ|REDISMODULE_WRITE);
   if(status==REDISMODULE_ERR){
       return REDISMODULE_ERR;
   }
@@ -1149,7 +1149,7 @@ int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   RAI_Model *mto;
   RedisModuleKey *modelKey;
-  const int status = RAI_getModelFromKeyspace(ctx, argv[1], &modelKey, &mto, REDISMODULE_READ);
+  const int status = RAI_GetModelFromKeyspace(ctx, argv[1], &modelKey, &mto, REDISMODULE_READ);
   if(status==REDISMODULE_ERR){
       return REDISMODULE_ERR;
   }
@@ -1191,7 +1191,7 @@ int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
       if (is_input == 0) {
         RAI_Tensor *inputTensor;
         RedisModuleKey *tensorKey;
-        const int status = RAI_getTensorFromKeyspace(
+        const int status = RAI_GetTensorFromKeyspace(
             ctx, argv[argpos], &tensorKey, &inputTensor, REDISMODULE_READ);
         if (status == REDISMODULE_ERR) {
           // TODO: free rinfo
@@ -1289,7 +1289,7 @@ int RedisAI_ScriptRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
 
   RAI_Script *sto;
   RedisModuleKey *key;
-  const int status = RAI_getScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_READ);
+  const int status = RAI_GetScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_READ);
   if(status==REDISMODULE_ERR){
       return REDISMODULE_ERR;
   }
@@ -1332,7 +1332,7 @@ int RedisAI_ScriptRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   for (size_t i=0; i<ninputs; i++) {
     RAI_Tensor *t;
     RedisModuleKey *argkey;
-    const int status = RAI_getTensorFromKeyspace(ctx, inputs[i], &argkey, &t, REDISMODULE_READ);
+    const int status = RAI_GetTensorFromKeyspace(ctx, inputs[i], &argkey, &t, REDISMODULE_READ);
     if(status==REDISMODULE_ERR){
          RedisModule_CloseKey(key);
         return REDISMODULE_ERR;
@@ -1395,7 +1395,7 @@ int RedisAI_ScriptGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
 
   RAI_Script *sto;
   RedisModuleKey *key;
-  const int status = RAI_getScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_READ);
+  const int status = RAI_GetScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_READ);
   if(status==REDISMODULE_ERR){
       return REDISMODULE_ERR;
   }
@@ -1419,7 +1419,7 @@ int RedisAI_ScriptDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
 
   RAI_Script *sto;
   RedisModuleKey *key;
-  const int status = RAI_getScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_WRITE);
+  const int status = RAI_GetScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_WRITE);
   if(status==REDISMODULE_ERR){
       return REDISMODULE_ERR;
   }

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -1098,28 +1098,8 @@ int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   // The key is having a single thread looping for execution
   if (argc < 3) return RedisModule_WrongArity(ctx);
 
-  if (RedisModule_IsKeysPositionRequest(ctx)) {
-    RedisModule_KeyAtPos(ctx, 1);
-    for (int i=2; i<argc; i++) {
-      const char* arg = RedisModule_StringPtrLen(argv[i], NULL);
-      if (strcasecmp(arg, "INPUTS") == 0 || strcasecmp(arg, "OUTPUTS") == 0) {
-        continue;
-      }
-      RedisModule_KeyAtPos(ctx, i);
-    }
-    return REDISMODULE_OK;
-  }
-
-  RedisModule_AutoMemory(ctx);
-
-  ArgsCursor ac;
-  ArgsCursor_InitRString(&ac, argv+1, argc-1);
-
-  RedisModuleString* keystr;
-  AC_GetRString(&ac, &keystr, 0);
-
-  RedisModuleKey *key = RedisModule_OpenKey(ctx, keystr, REDISMODULE_READ);
-  int type = RedisModule_KeyType(key);
+  RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+  const int type = RedisModule_KeyType(key);
   if (type == REDISMODULE_KEYTYPE_EMPTY) {
     RedisModule_CloseKey(key);
     return RedisModule_ReplyWithError(ctx, "ERR model key is empty");
@@ -1131,46 +1111,15 @@ int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   }
 
   RAI_Model *mto = RedisModule_ModuleTypeGetValue(key);
-
-  ArgsCursor inac = {0};
-  ArgsCursor outac = {0};
-
-  if (!AC_AdvanceIfMatch(&ac, "INPUTS")) {
-    return RedisModule_ReplyWithError(ctx, "INPUTS not specified.");
-  }
-
-  const char* matches[] = {"OUTPUTS"};
-  AC_GetSliceUntilMatches(&ac, &inac, 1, matches);
-
-  if (!AC_AdvanceIfMatch(&ac, "OUTPUTS")) {
-    return RedisModule_ReplyWithError(ctx, "OUTPUTS not specified.");
-  }
-
-  AC_GetSliceToEnd(&ac, &outac);
-
-  size_t ninputs = inac.argc;
-  RedisModuleString *inputs[ninputs];
-  for (size_t i=0; i<ninputs; i++) {
-    AC_GetRString(&inac, inputs+i, 0); 
-  }
-
-  size_t noutputs = outac.argc;
-  RedisModuleString *outputs[noutputs];
-  for (size_t i=0; i<noutputs; i++) {
-    AC_GetRString(&outac, outputs+i, 0); 
-  }
-
-  if (mto->inputs && array_len(mto->inputs) != ninputs) {
-    return RedisModule_ReplyWithError(ctx, "Number of names given as INPUTS during MODELSET and keys given as INPUTS here do not match.");
-  }
-
-  if (mto->outputs && array_len(mto->outputs) != noutputs) {
-    return RedisModule_ReplyWithError(ctx, "Number of names given as OUTPUTS during MODELSET and keys given as OUTPUTS here do not match.");
+  const char *inputstr = RedisModule_StringPtrLen(argv[2], NULL);
+  if (strcasecmp(inputstr, "INPUTS")) {
+    RedisModule_CloseKey(key);
+    return RedisModule_ReplyWithError(ctx, "ERR INPUTS not specified.");
   }
 
   struct RedisAI_RunInfo *rinfo = RedisModule_Calloc(1, sizeof(struct RedisAI_RunInfo));
-  RedisModule_RetainString(ctx, keystr);
-  rinfo->runkey = keystr;
+  RedisModule_RetainString(NULL, argv[1]);
+  rinfo->runkey = argv[1];
   rinfo->mctx = RAI_ModelRunCtxCreate(mto);
   rinfo->sctx = NULL;
   rinfo->outkeys = NULL;
@@ -1178,62 +1127,79 @@ int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   RAI_ModelRunCtxAddBatch(rinfo->mctx);
 
-  for (size_t i=0; i<ninputs; i++) {
-    RedisModuleKey *argkey = RedisModule_OpenKey(ctx, inputs[i], REDISMODULE_READ);
-    int type = RedisModule_KeyType(argkey);
-    if (type == REDISMODULE_KEYTYPE_EMPTY) {
-      // todo free rinfo, close key
-      RedisModule_CloseKey(argkey);
-      return RedisModule_ReplyWithError(ctx, "Input key is empty");
-    }
-    if (!(RedisModule_KeyType(argkey) == REDISMODULE_KEYTYPE_MODULE &&
-          RedisModule_ModuleTypeGetType(argkey) == RedisAI_TensorType)) {
-      // todo free rinfo, close key
-      RedisModule_CloseKey(argkey);
-      return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-    }
-    RAI_Tensor *t = RedisModule_ModuleTypeGetValue(argkey);
-    RedisModule_CloseKey(argkey);
-    // Opname here is passed without copying
-    const char* opname = NULL;
-    if (mto->inputs) {
-      opname = mto->inputs[i];
-    }
-    if (!RAI_ModelRunCtxAddInput(rinfo->mctx, 0, opname, t)) {
-      // todo free rinfo
-      return RedisModule_ReplyWithError(ctx, "Input key not found.");
+  // parsing aux vars
+  int is_input = 0;
+  size_t ninputs = 0;
+  size_t noutputs = 0;
+  size_t expected_noutputs = 0;
+  if (mto->outputs) {
+    expected_noutputs = array_len(mto->outputs);
+    rinfo->outkeys =
+        RedisModule_Calloc(expected_noutputs, sizeof(RedisModuleString *));
+  }
+  int outputs_flag_count = 0;
+
+  for (size_t argpos = 3; argpos <= argc - 1; argpos++) {
+    const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
+    if (!strcasecmp(arg_string, "OUTPUTS") && outputs_flag_count == 0) {
+      is_input = 1;
+      outputs_flag_count = 1;
+    } else {
+      RedisModule_RetainString(NULL, argv[argpos]);
+      if (is_input == 0) {
+        RedisModuleKey *argkey =
+            RedisModule_OpenKey(ctx, argv[argpos], REDISMODULE_READ);
+        const int type = RedisModule_KeyType(argkey);
+        if (type == REDISMODULE_KEYTYPE_EMPTY) {
+          // todo free rinfo, close key
+          RedisModule_CloseKey(argkey);
+          return RedisModule_ReplyWithError(ctx, "ERR Input key is empty");
+        }
+        if (!(RedisModule_KeyType(argkey) == REDISMODULE_KEYTYPE_MODULE &&
+              RedisModule_ModuleTypeGetType(argkey) == RedisAI_TensorType)) {
+          // todo free rinfo, close key
+          RedisModule_CloseKey(argkey);
+          return RedisModule_ReplyWithError(ctx,
+                                            REDISMODULE_ERRORMSG_WRONGTYPE);
+        }
+        RAI_Tensor *t = RedisModule_ModuleTypeGetValue(argkey);
+        RedisModule_CloseKey(argkey);
+        // Opname here is passed without copying
+        const char *opname = NULL;
+        if (mto->inputs) {
+          opname = mto->inputs[ninputs];
+        }
+        if (!RAI_ModelRunCtxAddInput(rinfo->mctx, 0, opname, t)) {
+          // todo free rinfo
+          return RedisModule_ReplyWithError(ctx, "ERR Input key not found.");
+        }
+        ninputs++;
+      } else {
+        // Opname here is passed without copying
+        const char *opname = NULL;
+        if (mto->outputs) {
+          opname = mto->outputs[noutputs];
+        }
+        if (!RAI_ModelRunCtxAddOutput(rinfo->mctx, 0, opname)) {
+          // todo free rinfo
+          return RedisModule_ReplyWithError(ctx, "ERR Output key not found.");
+        }
+        rinfo->outkeys[noutputs] = argv[argpos];
+        noutputs++;
+      }
     }
   }
-
-  rinfo->outkeys = RedisModule_Calloc(noutputs, sizeof(RedisModuleString*));
-  for (size_t i=0; i<noutputs; i++) {
-    // Opname here is passed without copying
-    const char* opname = NULL;
-    if (mto->outputs) {
-      opname = mto->outputs[i];
-    }
-    if (!RAI_ModelRunCtxAddOutput(rinfo->mctx, 0, opname)) {
-      // todo free rinfo
-      return RedisModule_ReplyWithError(ctx, "Output key not found.");
-    }
-    RedisModule_RetainString(ctx, outputs[i]);
-    rinfo->outkeys[i] = outputs[i];
-  }
-
-  //  RedisModule_AbortBlock(bc);
-  //  return RedisModule_ReplyWithError(ctx, "-ERR Can't start thread");
 
   AI_dictEntry *entry = AI_dictFind(run_queues, mto->devicestr);
   RunQueueInfo *run_queue_info = NULL;
-  if (!entry){
-      // If the queue does not exist, initialize it
-      if(ensureRunQueue(mto->devicestr)==REDISMODULE_ERR) {
-        return RedisModule_ReplyWithError(ctx, "Queue not initialized for device.");
-      }
-      entry = AI_dictFind(run_queues, mto->devicestr);
-      run_queue_info = AI_dictGetVal(entry);
-  }
-  else{
+  if (!entry) {
+    // If the queue does not exist, initialize it
+    if (ensureRunQueue(mto->devicestr) == REDISMODULE_ERR) {
+      return RedisModule_ReplyWithError(ctx, "ERR Queue not initialized for device.");
+    }
+    entry = AI_dictFind(run_queues, mto->devicestr);
+    run_queue_info = AI_dictGetVal(entry);
+  } else {
     run_queue_info = AI_dictGetVal(entry);
   }
 
@@ -1244,12 +1210,6 @@ int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   queuePush(run_queue_info->run_queue, rinfo);
   pthread_cond_signal(&run_queue_info->queue_condition_var);
   pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
-
-  // RedisAI_RunSession(rinfo);
-  // RedisAI_FreeRunInfo(ctx, rinfo);
-  // return RedisModule_ReplyWithSimpleString(ctx, "foo");
-
-  // RedisModule_ReplicateVerbatim(ctx);
 
   return REDISMODULE_OK;
 }

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -20,6 +20,13 @@
 #include "redisai.h"
 #undef REDISAI_H_INCLUDE
 
+typedef struct RunQueueInfo {
+  pthread_mutex_t run_queue_mutex;
+  pthread_cond_t queue_condition_var;
+  queue *run_queue;
+  pthread_t *threads;
+} RunQueueInfo;
+
 static AI_dict *run_queues = NULL;
 static long long perqueueThreadPoolSize = REDISAI_DEFAULT_THREADS_PER_QUEUE;
 
@@ -87,12 +94,6 @@ long long ustime(void) {
 mstime_t mstime(void) {
   return ustime()/1000;
 }
-
-enum RedisAI_DataFmt {
-  REDISAI_DATA_BLOB = 0,
-  REDISAI_DATA_VALUES,
-  REDISAI_DATA_NONE
-};
 
 /* Return REDISMODULE_ERR if there was an error getting the Model.
  * Return REDISMODULE_OK if the model value stored at key was correctly
@@ -174,7 +175,408 @@ int RAI_getTensor_fromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
   return REDISMODULE_OK;
 }
 
-/*
+void RedisAI_FreeRunInfo(RedisModuleCtx *ctx, struct RedisAI_RunInfo *rinfo) {
+  if (rinfo->mctx) {
+    for(int i = 0 ; i < RAI_ModelRunCtxNumOutputs(rinfo->mctx) ; ++i){
+      RedisModule_FreeString(ctx, rinfo->outkeys[i]);
+    }
+    RedisModule_Free(rinfo->outkeys);
+    RAI_ModelRunCtxFree(rinfo->mctx);
+  }
+  else if (rinfo->sctx) {
+    for(int i = 0 ; i < RAI_ScriptRunCtxNumOutputs(rinfo->sctx) ; ++i){
+      RedisModule_FreeString(ctx, rinfo->outkeys[i]);
+    }
+    RedisModule_Free(rinfo->outkeys);
+    RAI_ScriptRunCtxFree(rinfo->sctx);
+  }
+
+  if (rinfo->err) {
+    RAI_ClearError(rinfo->err);
+    RedisModule_Free(rinfo->err);
+  }
+
+  RedisModule_Free(rinfo);
+}
+
+void RedisAI_FreeRunStats(RedisModuleCtx *ctx, struct RedisAI_RunStats *rstats) {
+  RedisModule_FreeString(ctx, rstats->key);
+  RedisModule_Free(rstats->devicestr);
+}
+
+void *RedisAI_RunSession(struct RedisAI_RunInfo **batch_rinfo) {
+  if (array_len(batch_rinfo) == 0) {
+    return NULL;
+  }
+
+  RAI_Error* err = RedisModule_Calloc(1, sizeof(RAI_Error));
+  long long rtime;
+  int status;
+  RAI_ModelRunCtx* mctx = NULL;
+  RAI_ScriptRunCtx* sctx = NULL;
+  if (batch_rinfo[0]->mctx) {
+    mctx = RAI_ModelRunCtxCreate(batch_rinfo[0]->mctx->model);
+    for (long long i=0; i<array_len(batch_rinfo); i++) {
+      int id = RAI_ModelRunCtxAddBatch(mctx);
+      RAI_ModelRunCtxCopyBatch(mctx, id, batch_rinfo[i]->mctx, 0);
+    }
+  }
+  else if (batch_rinfo[0]->sctx) {
+    // No batching for scripts for now
+    sctx = batch_rinfo[0]->sctx;
+  }
+
+  const long long start = ustime();
+  if (mctx) {
+    status = RAI_ModelRun(mctx, err);
+  }
+  else if (sctx) {
+    status = RAI_ScriptRun(sctx, err);
+  }
+  rtime = ustime() - start;
+
+  for (long long i=0; i<array_len(batch_rinfo); i++) {
+    struct RedisAI_RunInfo *rinfo = batch_rinfo[i];
+    if (mctx) {
+      size_t noutputs = RAI_ModelRunCtxNumOutputs(mctx);
+      for (long long o=0; o<noutputs; o++) {
+        RAI_Tensor* tensor = mctx->batches[i].outputs[o].tensor;
+        if (tensor) {
+          rinfo->mctx->batches[0].outputs[o].tensor = RAI_TensorGetShallowCopy(tensor);
+        }
+        else {
+          rinfo->mctx->batches[0].outputs[o].tensor = NULL;
+        }
+      }
+    }
+    else if (sctx) {
+      // No batching for scripts for now
+    }
+
+    rinfo->status = status;
+    rinfo->err = RedisModule_Calloc(1, sizeof(RAI_Error));
+    // TODO: add information on whether the call was batched
+    // and how large the batch was
+    rinfo->duration_us = rtime;
+
+    rinfo->err->code = err->code;
+    if (err->code != RAI_OK) {
+      rinfo->err->detail = RedisModule_Strdup(err->detail);
+      rinfo->err->detail_oneline = RedisModule_Strdup(err->detail_oneline);
+    }
+    if (rinfo->client != NULL) {
+      RedisModule_UnblockClient(rinfo->client, rinfo);
+    }
+  }
+
+  if (mctx) {
+    RAI_ModelRunCtxFree(mctx);
+  }
+  else if (sctx) {
+    // No batching for scripts for now
+  }
+
+  return NULL;
+}
+
+void RedisAI_FreeData(RedisModuleCtx *ctx, void *rinfo) {
+}
+
+void RedisAI_Disconnected(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc) {
+  RedisModule_Log(ctx, "warning", "Blocked client %p disconnected!", (void*)bc);
+}
+
+void RedisAI_ReplicateTensorSet(RedisModuleCtx *ctx, RedisModuleString *key, RAI_Tensor *t) {
+  long long ndims = RAI_TensorNumDims(t);
+
+  char *dtypestr = NULL;
+  Tensor_DataTypeStr(RAI_TensorDataType(t), &dtypestr);
+
+  assert(dtypestr);
+
+  char *data = RAI_TensorData(t);
+  long long size = RAI_TensorByteSize(t);
+
+  RedisModuleString* dims[ndims];
+
+  for (long long i=0; i<ndims; i++) {
+    dims[i] = RedisModule_CreateStringFromLongLong(ctx, RAI_TensorDim(t, i));
+  }
+
+  RedisModule_Replicate(ctx, "AI.TENSORSET", "scvcb", key, dtypestr,
+                        dims, ndims, "BLOB", data, size);
+
+  for (long long i=0; i<ndims; i++) {
+    RedisModule_FreeString(ctx,dims[i]);
+  }
+
+  RedisModule_Free(dtypestr);
+}
+
+int RedisAI_Run_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  REDISMODULE_NOT_USED(argv);
+  REDISMODULE_NOT_USED(argc);
+  struct RedisAI_RunInfo *rinfo = RedisModule_GetBlockedClientPrivateData(ctx);
+  
+  const char* runkey = RedisModule_StringPtrLen(rinfo->runkey, NULL);
+  AI_dictEntry *stats_entry = AI_dictFind(run_stats, runkey);
+
+  struct RedisAI_RunStats *rstats = NULL;
+  if (stats_entry) {
+    rstats = AI_dictGetVal(stats_entry);
+  }
+
+  if (rinfo->status) {
+    RedisModule_Log(ctx, "warning", "ERR %s", rinfo->err->detail);
+    if (rstats) {
+      rstats->calls += 1;
+      rstats->nerrors += 1;
+    }
+    int ret = RedisModule_ReplyWithError(ctx, rinfo->err->detail_oneline);
+    RedisAI_FreeRunInfo(ctx, rinfo);
+    return ret;
+  }
+
+  size_t num_outputs = 0;
+  if (rinfo->mctx) {
+    num_outputs = RAI_ModelRunCtxNumOutputs(rinfo->mctx);
+  }
+  else if (rinfo->sctx) {
+    num_outputs = RAI_ScriptRunCtxNumOutputs(rinfo->sctx);
+  }
+
+  int64_t batch_size = 0;
+
+  for (size_t i=0; i<num_outputs; ++i) {
+    RedisModuleKey *outkey;
+    const int status = RAI_openKey_Tensor(ctx, rinfo->outkeys[i], &outkey, REDISMODULE_READ|REDISMODULE_WRITE);
+    if(status==REDISMODULE_ERR){
+        RedisAI_FreeRunInfo(ctx, rinfo);
+        if (rstats) {
+          rstats->calls += 1;
+          rstats->nerrors += 1;
+        }
+        return REDISMODULE_ERR;
+    }
+    RAI_Tensor *t = NULL;
+    if (rinfo->mctx) {
+      t = RAI_ModelRunCtxOutputTensor(rinfo->mctx, 0, i);
+      if (t && batch_size == 0) {
+        batch_size = RAI_TensorDim(t, 0);
+      }
+    }
+    else if (rinfo->sctx) {
+      t = RAI_ScriptRunCtxOutputTensor(rinfo->sctx, i);
+    }
+    if (t) {
+      RedisModule_ModuleTypeSetValue(outkey, RedisAI_TensorType, RAI_TensorGetShallowCopy(t));
+    }
+    RedisModule_CloseKey(outkey);
+
+    if (t) {
+      RedisAI_ReplicateTensorSet(ctx, rinfo->outkeys[i], t);
+    }
+  }
+
+  if (rstats) {
+    rstats->duration_us += rinfo->duration_us;
+    rstats->calls += 1;
+
+    if (rinfo->mctx) {
+      rstats->samples += batch_size;
+    }
+  }
+
+  // FIXME This crashes Redis, we need to investigate.
+  //RedisModule_CloseKey(rinfo->modelkey);
+
+  RedisAI_FreeRunInfo(ctx, rinfo);
+
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+size_t RAI_RunInfoBatchSize(struct RedisAI_RunInfo* rinfo) {
+  if (rinfo->mctx == NULL) {
+    return -1;
+  }
+
+  size_t ninputs = RAI_ModelRunCtxNumInputs(rinfo->mctx);
+
+  int batchsize = 0;
+
+  if (ninputs == 0) {
+    return batchsize;
+  }
+
+  for (size_t i=0; i<ninputs; i++) {
+    RAI_Tensor* input = RAI_ModelRunCtxInputTensor(rinfo->mctx, 0, i);
+
+    if (i == 0) {
+      batchsize = RAI_TensorDim(input, 0);
+      continue;
+    }
+
+    if (batchsize != RAI_TensorDim(input, 0)) {
+      batchsize = 0;
+      break;
+    }
+  }
+
+  return batchsize;
+}
+
+int RAI_RunInfoBatchable(struct RedisAI_RunInfo* rinfo1, struct RedisAI_RunInfo* rinfo2) {
+  if (rinfo1->mctx == NULL || rinfo2->mctx == NULL) {
+    return 0;
+  }
+
+  if (rinfo1->mctx->model != rinfo2->mctx->model) {
+    return 0;
+  }
+
+  int ninputs1 = RAI_ModelRunCtxNumInputs(rinfo1->mctx);
+  int ninputs2 = RAI_ModelRunCtxNumInputs(rinfo2->mctx);
+
+  if (ninputs1 != ninputs2) {
+    return 0;
+  }
+
+  for (int i=0; i<ninputs1; i++) {
+    RAI_Tensor* input1 = RAI_ModelRunCtxInputTensor(rinfo1->mctx, 0, i);
+    RAI_Tensor* input2 = RAI_ModelRunCtxInputTensor(rinfo2->mctx, 0, i);
+
+    int ndims1 = RAI_TensorNumDims(input1);
+    int ndims2 = RAI_TensorNumDims(input2);
+
+    if (ndims1 != ndims2) {
+      return 0;
+    }
+
+    if (ndims1 == 0) {
+      continue;
+    }
+
+    for (int j=1; j<ndims1; j++) {
+      int dim1 = RAI_TensorDim(input1, j);
+      int dim2 = RAI_TensorDim(input2, j);
+      if (dim1 != dim2) {
+        return 0;
+      }
+    }
+  }
+
+  return 1;
+}
+
+void *RedisAI_Run_ThreadMain(void *arg) {
+
+  RunQueueInfo* run_queue_info = (RunQueueInfo*)arg;
+
+  pthread_mutex_lock(&run_queue_info->run_queue_mutex);
+  while (true){
+    int rc = pthread_cond_wait(&run_queue_info->queue_condition_var, &run_queue_info->run_queue_mutex);
+
+    long long run_queue_len = queueLength(run_queue_info->run_queue);
+
+    while (run_queue_len > 0) {
+      queueItem **evicted_items = NULL;
+      struct RedisAI_RunInfo **batch_rinfo = NULL;
+
+      queueItem *item = queueFront(run_queue_info->run_queue);
+
+      while (item) {
+        struct RedisAI_RunInfo *rinfo = (struct RedisAI_RunInfo *)item->value;
+
+        if (evicted_items) {
+          array_free(evicted_items);
+          array_free(batch_rinfo);
+        }
+        evicted_items = array_new(queueItem *, run_queue_len);
+        batch_rinfo = array_new(struct RedisAI_RunInfo *, run_queue_len);
+
+        array_append(evicted_items, item);
+        array_append(batch_rinfo, rinfo);
+
+        if (rinfo->sctx) {
+          break;
+        }
+
+        size_t batchsize = rinfo->mctx->model->opts.batchsize;
+
+        if (batchsize == 0) {
+          break;
+        }
+
+        size_t current_batchsize = RAI_RunInfoBatchSize(rinfo);
+
+        if (current_batchsize == 0 ||
+            current_batchsize >= batchsize) {
+          break;
+        }
+
+        queueItem *next_item = item->next;
+
+        while (next_item != NULL) {
+          struct RedisAI_RunInfo *next_rinfo = (struct RedisAI_RunInfo *)next_item->value;
+
+          if (RAI_RunInfoBatchable(rinfo, next_rinfo) == 0) {
+            next_item = queueNext(next_item);
+            continue;
+          }
+
+          int next_batchsize = RAI_RunInfoBatchSize(next_rinfo);
+
+          if (current_batchsize + next_batchsize > batchsize) {
+            break;
+          }
+
+          array_append(evicted_items, next_item);
+          array_append(batch_rinfo, next_rinfo);
+
+          current_batchsize += next_batchsize;
+          next_item = queueNext(next_item);
+        }
+
+        size_t minbatchsize = rinfo->mctx->model->opts.minbatchsize;
+
+        if (minbatchsize == 0 || current_batchsize >= minbatchsize) {
+          break;
+        }
+
+        item = item->next;
+      }
+
+      if (item == NULL) {
+        array_free(evicted_items);
+        array_free(batch_rinfo);
+        pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
+        break;
+      }
+
+      for (long long i=0; i<array_len(evicted_items); i++) {
+        queueEvict(run_queue_info->run_queue, evicted_items[i]);
+      }
+
+      pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
+
+      RedisAI_RunSession(batch_rinfo);
+
+      for (long long i=0; i<array_len(evicted_items); i++) {
+        RedisModule_Free(evicted_items[i]);
+      }
+      array_free(evicted_items);
+      array_free(batch_rinfo);
+
+      pthread_mutex_lock(&run_queue_info->run_queue_mutex);
+
+      run_queue_len = queueLength(run_queue_info->run_queue);
+    }
+  }
+}
+
+/* ----------------------- RedisAI Module Commands ------------------------- */
+
+/**
  * AI.TENSORSET key type dim1..dimN [BLOB data | VALUES val1..valN]
  */
 int RedisAI_TensorSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -319,7 +721,7 @@ int RedisAI_TensorSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   return REDISMODULE_OK;
 }
 
-/*
+/**
 * AI.TENSORGET tensor_key [BLOB | VALUES | META]
 */
 int RedisAI_TensorGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -423,111 +825,7 @@ int RedisAI_TensorGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   return REDISMODULE_OK;
 }
 
-void RedisAI_FreeRunInfo(RedisModuleCtx *ctx, struct RedisAI_RunInfo *rinfo) {
-  if (rinfo->mctx) {
-    for(int i = 0 ; i < RAI_ModelRunCtxNumOutputs(rinfo->mctx) ; ++i){
-      RedisModule_FreeString(ctx, rinfo->outkeys[i]);
-    }
-    RedisModule_Free(rinfo->outkeys);
-    RAI_ModelRunCtxFree(rinfo->mctx);
-  }
-  else if (rinfo->sctx) {
-    for(int i = 0 ; i < RAI_ScriptRunCtxNumOutputs(rinfo->sctx) ; ++i){
-      RedisModule_FreeString(ctx, rinfo->outkeys[i]);
-    }
-    RedisModule_Free(rinfo->outkeys);
-    RAI_ScriptRunCtxFree(rinfo->sctx);
-  }
-
-  if (rinfo->err) {
-    RAI_ClearError(rinfo->err);
-    RedisModule_Free(rinfo->err);
-  }
-
-  RedisModule_Free(rinfo);
-}
-
-void RedisAI_FreeRunStats(RedisModuleCtx *ctx, struct RedisAI_RunStats *rstats) {
-  RedisModule_FreeString(ctx, rstats->key);
-  RedisModule_Free(rstats->devicestr);
-}
-
-void *RedisAI_RunSession(struct RedisAI_RunInfo **batch_rinfo) {
-  if (array_len(batch_rinfo) == 0) {
-    return NULL;
-  }
-
-  RAI_Error* err = RedisModule_Calloc(1, sizeof(RAI_Error));
-  long long rtime;
-  int status;
-  RAI_ModelRunCtx* mctx = NULL;
-  RAI_ScriptRunCtx* sctx = NULL;
-  if (batch_rinfo[0]->mctx) {
-    mctx = RAI_ModelRunCtxCreate(batch_rinfo[0]->mctx->model);
-    for (long long i=0; i<array_len(batch_rinfo); i++) {
-      int id = RAI_ModelRunCtxAddBatch(mctx);
-      RAI_ModelRunCtxCopyBatch(mctx, id, batch_rinfo[i]->mctx, 0);
-    }
-  }
-  else if (batch_rinfo[0]->sctx) {
-    // No batching for scripts for now
-    sctx = batch_rinfo[0]->sctx;
-  }
-
-  const long long start = ustime();
-  if (mctx) {
-    status = RAI_ModelRun(mctx, err);
-  }
-  else if (sctx) {
-    status = RAI_ScriptRun(sctx, err);
-  }
-  rtime = ustime() - start;
-
-  for (long long i=0; i<array_len(batch_rinfo); i++) {
-    struct RedisAI_RunInfo *rinfo = batch_rinfo[i];
-    if (mctx) {
-      size_t noutputs = RAI_ModelRunCtxNumOutputs(mctx);
-      for (long long o=0; o<noutputs; o++) {
-        RAI_Tensor* tensor = mctx->batches[i].outputs[o].tensor;
-        if (tensor) {
-          rinfo->mctx->batches[0].outputs[o].tensor = RAI_TensorGetShallowCopy(tensor);
-        }
-        else {
-          rinfo->mctx->batches[0].outputs[o].tensor = NULL;
-        }
-      }
-    }
-    else if (sctx) {
-      // No batching for scripts for now
-    }
-
-    rinfo->status = status;
-    rinfo->err = RedisModule_Calloc(1, sizeof(RAI_Error));
-    // TODO: add information on whether the call was batched
-    // and how large the batch was
-    rinfo->duration_us = rtime;
-
-    rinfo->err->code = err->code;
-    if (err->code != RAI_OK) {
-      rinfo->err->detail = RedisModule_Strdup(err->detail);
-      rinfo->err->detail_oneline = RedisModule_Strdup(err->detail_oneline);
-    }
-    if (rinfo->client != NULL) {
-      RedisModule_UnblockClient(rinfo->client, rinfo);
-    }
-  }
-
-  if (mctx) {
-    RAI_ModelRunCtxFree(mctx);
-  }
-  else if (sctx) {
-    // No batching for scripts for now
-  }
-
-  return NULL;
-}
-
-/*
+/**
 * AI.MODELSET model_key backend device [TAG tag] [BATCHSIZE n [MINBATCHSIZE m]] [INPUTS name1 name2 ... OUTPUTS name1 name2 ...] model_blob
 */
 int RedisAI_ModelSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -719,7 +1017,7 @@ int RedisAI_ModelSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   return REDISMODULE_OK;
 }
 
-/*
+/**
 * AI.MODELGET model_key [META | BLOB]
 */
 int RedisAI_ModelGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -786,7 +1084,7 @@ int RedisAI_ModelGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   return REDISMODULE_OK;
 }
 
-/*
+/**
 * AI.MODELDEL model_key
 */
 int RedisAI_ModelDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -806,6 +1104,9 @@ int RedisAI_ModelDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 
+/** 
+* AI._MODELLIST
+*/
 int RedisAI_ModelList_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (argc != 1) return RedisModule_WrongArity(ctx);
 
@@ -828,122 +1129,6 @@ int RedisAI_ModelList_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   RedisModule_Free(tags);
 
   return REDISMODULE_OK;
-}
-
-void RedisAI_FreeData(RedisModuleCtx *ctx, void *rinfo) {
-}
-
-void RedisAI_Disconnected(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc) {
-  RedisModule_Log(ctx, "warning", "Blocked client %p disconnected!", (void*)bc);
-}
-
-void RedisAI_ReplicateTensorSet(RedisModuleCtx *ctx, RedisModuleString *key, RAI_Tensor *t) {
-  long long ndims = RAI_TensorNumDims(t);
-
-  char *dtypestr = NULL;
-  Tensor_DataTypeStr(RAI_TensorDataType(t), &dtypestr);
-
-  assert(dtypestr);
-
-  char *data = RAI_TensorData(t);
-  long long size = RAI_TensorByteSize(t);
-
-  RedisModuleString* dims[ndims];
-
-  for (long long i=0; i<ndims; i++) {
-    dims[i] = RedisModule_CreateStringFromLongLong(ctx, RAI_TensorDim(t, i));
-  }
-
-  RedisModule_Replicate(ctx, "AI.TENSORSET", "scvcb", key, dtypestr,
-                        dims, ndims, "BLOB", data, size);
-
-  for (long long i=0; i<ndims; i++) {
-    RedisModule_FreeString(ctx,dims[i]);
-  }
-
-  RedisModule_Free(dtypestr);
-}
-
-int RedisAI_Run_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  REDISMODULE_NOT_USED(argv);
-  REDISMODULE_NOT_USED(argc);
-  struct RedisAI_RunInfo *rinfo = RedisModule_GetBlockedClientPrivateData(ctx);
-  
-  const char* runkey = RedisModule_StringPtrLen(rinfo->runkey, NULL);
-  AI_dictEntry *stats_entry = AI_dictFind(run_stats, runkey);
-
-  struct RedisAI_RunStats *rstats = NULL;
-  if (stats_entry) {
-    rstats = AI_dictGetVal(stats_entry);
-  }
-
-  if (rinfo->status) {
-    RedisModule_Log(ctx, "warning", "ERR %s", rinfo->err->detail);
-    if (rstats) {
-      rstats->calls += 1;
-      rstats->nerrors += 1;
-    }
-    int ret = RedisModule_ReplyWithError(ctx, rinfo->err->detail_oneline);
-    RedisAI_FreeRunInfo(ctx, rinfo);
-    return ret;
-  }
-
-  size_t num_outputs = 0;
-  if (rinfo->mctx) {
-    num_outputs = RAI_ModelRunCtxNumOutputs(rinfo->mctx);
-  }
-  else if (rinfo->sctx) {
-    num_outputs = RAI_ScriptRunCtxNumOutputs(rinfo->sctx);
-  }
-
-  int64_t batch_size = 0;
-
-  for (size_t i=0; i<num_outputs; ++i) {
-    RedisModuleKey *outkey;
-    const int status = RAI_openKey_Tensor(ctx, rinfo->outkeys[i], &outkey, REDISMODULE_READ|REDISMODULE_WRITE);
-    if(status==REDISMODULE_ERR){
-        RedisAI_FreeRunInfo(ctx, rinfo);
-        if (rstats) {
-          rstats->calls += 1;
-          rstats->nerrors += 1;
-        }
-        return REDISMODULE_ERR;
-    }
-    RAI_Tensor *t = NULL;
-    if (rinfo->mctx) {
-      t = RAI_ModelRunCtxOutputTensor(rinfo->mctx, 0, i);
-      if (t && batch_size == 0) {
-        batch_size = RAI_TensorDim(t, 0);
-      }
-    }
-    else if (rinfo->sctx) {
-      t = RAI_ScriptRunCtxOutputTensor(rinfo->sctx, i);
-    }
-    if (t) {
-      RedisModule_ModuleTypeSetValue(outkey, RedisAI_TensorType, RAI_TensorGetShallowCopy(t));
-    }
-    RedisModule_CloseKey(outkey);
-
-    if (t) {
-      RedisAI_ReplicateTensorSet(ctx, rinfo->outkeys[i], t);
-    }
-  }
-
-  if (rstats) {
-    rstats->duration_us += rinfo->duration_us;
-    rstats->calls += 1;
-
-    if (rinfo->mctx) {
-      rstats->samples += batch_size;
-    }
-  }
-
-  // FIXME This crashes Redis, we need to investigate.
-  //RedisModule_CloseKey(rinfo->modelkey);
-
-  RedisAI_FreeRunInfo(ctx, rinfo);
-
-  return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 
 /**
@@ -1082,186 +1267,9 @@ int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   return REDISMODULE_OK;
 }
 
-size_t RAI_RunInfoBatchSize(struct RedisAI_RunInfo* rinfo) {
-  if (rinfo->mctx == NULL) {
-    return -1;
-  }
-
-  size_t ninputs = RAI_ModelRunCtxNumInputs(rinfo->mctx);
-
-  int batchsize = 0;
-
-  if (ninputs == 0) {
-    return batchsize;
-  }
-
-  for (size_t i=0; i<ninputs; i++) {
-    RAI_Tensor* input = RAI_ModelRunCtxInputTensor(rinfo->mctx, 0, i);
-
-    if (i == 0) {
-      batchsize = RAI_TensorDim(input, 0);
-      continue;
-    }
-
-    if (batchsize != RAI_TensorDim(input, 0)) {
-      batchsize = 0;
-      break;
-    }
-  }
-
-  return batchsize;
-}
-
-int RAI_RunInfoBatchable(struct RedisAI_RunInfo* rinfo1, struct RedisAI_RunInfo* rinfo2) {
-  if (rinfo1->mctx == NULL || rinfo2->mctx == NULL) {
-    return 0;
-  }
-
-  if (rinfo1->mctx->model != rinfo2->mctx->model) {
-    return 0;
-  }
-
-  int ninputs1 = RAI_ModelRunCtxNumInputs(rinfo1->mctx);
-  int ninputs2 = RAI_ModelRunCtxNumInputs(rinfo2->mctx);
-
-  if (ninputs1 != ninputs2) {
-    return 0;
-  }
-
-  for (int i=0; i<ninputs1; i++) {
-    RAI_Tensor* input1 = RAI_ModelRunCtxInputTensor(rinfo1->mctx, 0, i);
-    RAI_Tensor* input2 = RAI_ModelRunCtxInputTensor(rinfo2->mctx, 0, i);
-
-    int ndims1 = RAI_TensorNumDims(input1);
-    int ndims2 = RAI_TensorNumDims(input2);
-
-    if (ndims1 != ndims2) {
-      return 0;
-    }
-
-    if (ndims1 == 0) {
-      continue;
-    }
-
-    for (int j=1; j<ndims1; j++) {
-      int dim1 = RAI_TensorDim(input1, j);
-      int dim2 = RAI_TensorDim(input2, j);
-      if (dim1 != dim2) {
-        return 0;
-      }
-    }
-  }
-
-  return 1;
-}
-
-void *RedisAI_Run_ThreadMain(void *arg) {
-
-  RunQueueInfo* run_queue_info = (RunQueueInfo*)arg;
-
-  pthread_mutex_lock(&run_queue_info->run_queue_mutex);
-  while (true){
-    int rc = pthread_cond_wait(&run_queue_info->queue_condition_var, &run_queue_info->run_queue_mutex);
-
-    long long run_queue_len = queueLength(run_queue_info->run_queue);
-
-    while (run_queue_len > 0) {
-      queueItem **evicted_items = NULL;
-      struct RedisAI_RunInfo **batch_rinfo = NULL;
-
-      queueItem *item = queueFront(run_queue_info->run_queue);
-
-      while (item) {
-        struct RedisAI_RunInfo *rinfo = (struct RedisAI_RunInfo *)item->value;
-
-        if (evicted_items) {
-          array_free(evicted_items);
-          array_free(batch_rinfo);
-        }
-        evicted_items = array_new(queueItem *, run_queue_len);
-        batch_rinfo = array_new(struct RedisAI_RunInfo *, run_queue_len);
-
-        array_append(evicted_items, item);
-        array_append(batch_rinfo, rinfo);
-
-        if (rinfo->sctx) {
-          break;
-        }
-
-        size_t batchsize = rinfo->mctx->model->opts.batchsize;
-
-        if (batchsize == 0) {
-          break;
-        }
-
-        size_t current_batchsize = RAI_RunInfoBatchSize(rinfo);
-
-        if (current_batchsize == 0 ||
-            current_batchsize >= batchsize) {
-          break;
-        }
-
-        queueItem *next_item = item->next;
-
-        while (next_item != NULL) {
-          struct RedisAI_RunInfo *next_rinfo = (struct RedisAI_RunInfo *)next_item->value;
-
-          if (RAI_RunInfoBatchable(rinfo, next_rinfo) == 0) {
-            next_item = queueNext(next_item);
-            continue;
-          }
-
-          int next_batchsize = RAI_RunInfoBatchSize(next_rinfo);
-
-          if (current_batchsize + next_batchsize > batchsize) {
-            break;
-          }
-
-          array_append(evicted_items, next_item);
-          array_append(batch_rinfo, next_rinfo);
-
-          current_batchsize += next_batchsize;
-          next_item = queueNext(next_item);
-        }
-
-        size_t minbatchsize = rinfo->mctx->model->opts.minbatchsize;
-
-        if (minbatchsize == 0 || current_batchsize >= minbatchsize) {
-          break;
-        }
-
-        item = item->next;
-      }
-
-      if (item == NULL) {
-        array_free(evicted_items);
-        array_free(batch_rinfo);
-        pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
-        break;
-      }
-
-      for (long long i=0; i<array_len(evicted_items); i++) {
-        queueEvict(run_queue_info->run_queue, evicted_items[i]);
-      }
-
-      pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
-
-      RedisAI_RunSession(batch_rinfo);
-
-      for (long long i=0; i<array_len(evicted_items); i++) {
-        RedisModule_Free(evicted_items[i]);
-      }
-      array_free(evicted_items);
-      array_free(batch_rinfo);
-
-      pthread_mutex_lock(&run_queue_info->run_queue_mutex);
-
-      run_queue_len = queueLength(run_queue_info->run_queue);
-    }
-  }
-}
-
-// script key, fnname, INPUTS, key1, key2 ... OUTPUTS, key1, key2 ...
+/** 
+* AI.SCRIPTRUN script_key fn_name INPUTS input_key1 ... OUTPUTS output_key1 ...
+*/
 int RedisAI_ScriptRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (argc < 4) return RedisModule_WrongArity(ctx);
 
@@ -1385,7 +1393,7 @@ int RedisAI_ScriptRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   return REDISMODULE_OK;
 }
 
-/*
+/**
  * AI.SCRIPTGET script_key
  */
 int RedisAI_ScriptGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -1409,7 +1417,7 @@ int RedisAI_ScriptGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   return REDISMODULE_OK;
 }
 
-/*
+/**
  * AI.SCRIPTDEL script_key
  */
 int RedisAI_ScriptDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -1430,7 +1438,9 @@ int RedisAI_ScriptDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 
-// key device scriptdef
+/** 
+* AI.SCRIPTSET script_key device [TAG tag] script_source
+*/
 int RedisAI_ScriptSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   RedisModule_AutoMemory(ctx);
 
@@ -1521,6 +1531,9 @@ int RedisAI_ScriptSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
   return REDISMODULE_OK;
 }
 
+/** 
+* AI._SCRIPTLIST
+*/
 int RedisAI_ScriptList_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (argc != 1) return RedisModule_WrongArity(ctx);
 
@@ -1545,7 +1558,7 @@ int RedisAI_ScriptList_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **arg
   return REDISMODULE_OK;
 }
 
-/* 
+/** 
 * AI.INFO <model_or_script_key> [RESETSTAT]
 */
 int RedisAI_Info_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -1676,6 +1689,9 @@ int RedisAI_Config_QueueThreads(RedisModuleString *queueThreadsString) {
   return result;
 }
 
+/** 
+* AI.CONFIG [BACKENDSPATH <default_location_of_backend_libraries> | LOADBACKEND <backend_identifier> <location_of_backend_library>]
+*/
 int RedisAI_Config_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   RedisModule_AutoMemory(ctx);
 

--- a/src/redisai.h
+++ b/src/redisai.h
@@ -31,6 +31,12 @@ typedef struct RAI_Error RAI_Error;
 #define REDISAI_ERRORMSG_THREADS_PER_QUEUE "ERR: error setting THREADS_PER_QUEUE to"
 #define REDISAI_INFOMSG_THREADS_PER_QUEUE "Setting THREADS_PER_QUEUE parameter to"
 
+enum RedisAI_DataFmt {
+  REDISAI_DATA_BLOB = 0,
+  REDISAI_DATA_VALUES,
+  REDISAI_DATA_NONE
+};
+
 struct RedisAI_RunInfo {
   RedisModuleBlockedClient *client;
   RedisModuleString *runkey;

--- a/src/redisai.h
+++ b/src/redisai.h
@@ -31,6 +31,17 @@ typedef struct RAI_Error RAI_Error;
 #define REDISAI_ERRORMSG_THREADS_PER_QUEUE "ERR: error setting THREADS_PER_QUEUE to"
 #define REDISAI_INFOMSG_THREADS_PER_QUEUE "Setting THREADS_PER_QUEUE parameter to"
 
+struct RedisAI_RunInfo {
+  RedisModuleBlockedClient *client;
+  RedisModuleString *runkey;
+  RedisModuleString **outkeys;
+  RAI_ModelRunCtx *mctx;
+  RAI_ScriptRunCtx *sctx;
+  int status;
+  long long duration_us;
+  RAI_Error* err;
+};
+
 RAI_Tensor* MODULE_API_FUNC(RedisAI_TensorCreate)(const char* dataTypeStr, long long* dims, int ndims);
 RAI_Tensor* MODULE_API_FUNC(RedisAI_TensorCreateByConcatenatingTensors)(RAI_Tensor** ts, long long n);
 RAI_Tensor* MODULE_API_FUNC(RedisAI_TensorCreateBySlicingTensor)(RAI_Tensor* t, long long offset, long long len);

--- a/src/script.c
+++ b/src/script.c
@@ -99,7 +99,7 @@ int RAI_ScriptInit(RedisModuleCtx* ctx) {
 
 RAI_Script *RAI_ScriptCreate( const char* devicestr, const char* tag, const char *scriptdef, RAI_Error* err) {
   if (!RAI_backends.torch.script_create) {
-    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TORCH.\n");
+    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
     return NULL;
   }
   RAI_Script* script = RAI_backends.torch.script_create(devicestr, scriptdef, err);
@@ -117,7 +117,7 @@ void RAI_ScriptFree(RAI_Script* script, RAI_Error* err) {
   }
 
   if (!RAI_backends.torch.script_free) {
-    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TORCH.\n");
+    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
     return;
   }
 
@@ -196,7 +196,7 @@ void RAI_ScriptRunCtxFree(RAI_ScriptRunCtx* sctx) {
 
 int RAI_ScriptRun(RAI_ScriptRunCtx* sctx, RAI_Error* err) {
   if (!RAI_backends.torch.script_run) {
-    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "Backend not loaded: TORCH.\n");
+    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
     return REDISMODULE_ERR;
   }
  

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -9,10 +9,10 @@
 RedisModuleType *RedisAI_TensorType = NULL;
 
 DLDataType RAI_TensorDataTypeFromString(const char* typestr){
-  if (strcasecmp(typestr, "FLOAT") == 0){
+  if (strcasecmp(typestr, RAI_DATATYPE_STR_FLOAT) == 0){
     return (DLDataType){ .code = kDLFloat, .bits = 32, .lanes = 1};
   }
-  if (strcasecmp(typestr, "DOUBLE") == 0) {
+  if (strcasecmp(typestr, RAI_DATATYPE_STR_DOUBLE) == 0) {
     return (DLDataType){ .code = kDLFloat, .bits = 64, .lanes = 1};
   }
   if (strncasecmp(typestr, "INT", 3) == 0) {
@@ -46,14 +46,17 @@ static size_t Tensor_DataTypeSize(DLDataType dtype) {
   return dtype.bits / 8;
 }
 
-void Tensor_DataTypeStr(DLDataType dtype, char **dtypestr) {
+int Tensor_DataTypeStr(DLDataType dtype, char **dtypestr) {
+  int result = REDISMODULE_ERR;
   *dtypestr = RedisModule_Calloc(8, sizeof(char));
   if (dtype.code == kDLFloat) {
     if (dtype.bits == 32) {
-      strcpy(*dtypestr, "FLOAT");
+      strcpy(*dtypestr, RAI_DATATYPE_STR_FLOAT);
+      result = REDISMODULE_OK;
     }
     else if (dtype.bits == 64) {
-      strcpy(*dtypestr, "DOUBLE");
+      strcpy(*dtypestr, RAI_DATATYPE_STR_DOUBLE);
+      result = REDISMODULE_OK;
     }
     else {
       RedisModule_Free(*dtypestr);
@@ -62,16 +65,20 @@ void Tensor_DataTypeStr(DLDataType dtype, char **dtypestr) {
   }
   else if (dtype.code == kDLInt) {
     if (dtype.bits == 8) {
-      strcpy(*dtypestr, "INT8");
+      strcpy(*dtypestr, RAI_DATATYPE_STR_INT8);
+      result = REDISMODULE_OK;
     }
     else if (dtype.bits == 16) {
-      strcpy(*dtypestr, "INT16");
+      strcpy(*dtypestr, RAI_DATATYPE_STR_INT16);
+      result = REDISMODULE_OK;
     }
     else if (dtype.bits == 32) {
-      strcpy(*dtypestr, "INT32");
+      strcpy(*dtypestr, RAI_DATATYPE_STR_INT32);
+      result = REDISMODULE_OK;
     }
     else if (dtype.bits == 64) {
-      strcpy(*dtypestr, "INT64");
+      strcpy(*dtypestr, RAI_DATATYPE_STR_INT64);
+      result = REDISMODULE_OK;
     }
     else {
       RedisModule_Free(*dtypestr);
@@ -80,16 +87,19 @@ void Tensor_DataTypeStr(DLDataType dtype, char **dtypestr) {
   }
   else if (dtype.code == kDLUInt) {
     if (dtype.bits == 8) {
-      strcpy(*dtypestr, "UINT8");
+      strcpy(*dtypestr, RAI_DATATYPE_STR_UINT8);
+      result = REDISMODULE_OK;
     }
     else if (dtype.bits == 16) {
-      strcpy(*dtypestr, "UINT16");
+      strcpy(*dtypestr, RAI_DATATYPE_STR_UINT16);
+      result = REDISMODULE_OK;
     }
     else {
       RedisModule_Free(*dtypestr);
       *dtypestr = NULL;
     }
   }
+  return result;
 }
 
 static void* RAI_Tensor_RdbLoad(struct RedisModuleIO *io, int encver) {

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -468,7 +468,7 @@ int RAI_TensorSetData(RAI_Tensor* t, const char* data, size_t len){
 
 int RAI_TensorSetDataFromRS(RAI_Tensor* t, RedisModuleString* rs){
   t->tensorRS = rs;
-  t->tensor.dl_tensor.data = RedisModule_StringPtrLen(rs,NULL);
+  t->tensor.dl_tensor.data = (void*)RedisModule_StringPtrLen(rs,NULL);
   return 1;
 }
 

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -10,6 +10,16 @@
 #define TENSORALLOC_ALLOC 1
 #define TENSORALLOC_CALLOC 2
 
+// Numeric data type of tensor elements, one of FLOAT, DOUBLE, INT8, INT16, INT32, INT64, UINT8, UINT16
+static const char* RAI_DATATYPE_STR_FLOAT = "FLOAT";
+static const char* RAI_DATATYPE_STR_DOUBLE = "DOUBLE";
+static const char* RAI_DATATYPE_STR_INT8 = "INT8";
+static const char* RAI_DATATYPE_STR_INT16 = "INT16";
+static const char* RAI_DATATYPE_STR_INT32 = "INT32";
+static const char* RAI_DATATYPE_STR_INT64 = "INT64";
+static const char* RAI_DATATYPE_STR_UINT8 = "UINT8";
+static const char* RAI_DATATYPE_STR_UINT16 = "UINT16";
+
 extern RedisModuleType *RedisAI_TensorType;
 
 int RAI_TensorInit(RedisModuleCtx* ctx);
@@ -24,7 +34,7 @@ size_t RAI_TensorDataSizeFromDLDataType(DLDataType dtype);
 size_t RAI_TensorDataSizeFromString(const char* dataType);
 DLDataType RAI_TensorDataType(RAI_Tensor* t);
 DLDataType RAI_TensorDataTypeFromString(const char* dataType);
-void Tensor_DataTypeStr(DLDataType dtype, char **dtypestr);
+int Tensor_DataTypeStr(DLDataType dtype, char **dtypestr);
 void RAI_TensorFree(RAI_Tensor* t);
 int RAI_TensorSetData(RAI_Tensor* t, const char* data, size_t len);
 int RAI_TensorSetDataFromRS(RAI_Tensor* t, RedisModuleString* rs);

--- a/src/util/queue.c
+++ b/src/util/queue.c
@@ -1,0 +1,91 @@
+#include <pthread.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "queue.h"
+#include "../redisai_memory.h"
+#include "redismodule.h"
+
+queue *queueCreate(void) {
+  struct queue *queue;
+
+  if ((queue = RedisModule_Calloc(1, sizeof(*queue))) == NULL) return NULL;
+
+  queue->front = queue->back = NULL;
+  queue->len = 0;
+  queue->free = NULL;
+  return queue;
+}
+
+void queuePush(queue *queue, void *value) {
+  queueItem *item;
+
+  if ((item = RedisModule_Calloc(1, sizeof(*item))) == NULL) return;
+  item->value = value;
+  item->next = NULL;
+  item->prev = NULL;
+
+  if (queue->len == 0) {
+    queue->front = queue->back = item;
+  } else {
+    queue->back->next = item;
+    item->prev = queue->back;
+    queue->back = item;
+  }
+  queue->len++;
+}
+
+queueItem *queuePop(queue *queue) {
+  queueItem *item = queue->front;
+  if (item == NULL) {
+    return NULL;
+  }
+  queue->front = item->next;
+  if (queue->front != NULL) {
+    queue->front->prev = NULL;
+  }
+  if (item == queue->back) {
+    queue->back = NULL;
+  }
+  item->next = NULL;
+  item->prev = NULL;
+  queue->len--;
+  return item;
+}
+
+queueItem *queueFront(queue *queue) { return queue->front; }
+
+queueItem *queueNext(queueItem *item) { return item->next; }
+
+queueItem *queueEvict(queue *queue, queueItem *item) {
+  if (item == queue->front) {
+    return queuePop(queue);
+  } else if (item == queue->back) {
+    queue->back = item->prev;
+    queue->back->next = NULL;
+  } else {
+    item->prev->next = item->next;
+    item->next->prev = item->prev;
+  }
+
+  item->next = NULL;
+  item->prev = NULL;
+  queue->len--;
+  return item;
+}
+
+long long queueLength(queue *queue) { return queue->len; }
+
+void queueRelease(queue *queue) {
+  unsigned long len;
+  queueItem *current;
+
+  len = queue->len;
+  while (len--) {
+    current = queuePop(queue);
+    if (current && queue->free) queue->free(current->value);
+    RedisModule_Free(current);
+  }
+  queue->front = queue->back = NULL;
+  queue->len = 0;
+}

--- a/src/util/queue.h
+++ b/src/util/queue.h
@@ -1,0 +1,41 @@
+
+#include <pthread.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../redisai_memory.h"
+#include "redismodule.h"
+
+#ifndef __QUEUE_H
+#define __QUEUE_H
+
+typedef struct queueItem {
+  struct queueItem *next;
+  struct queueItem *prev;
+  void *value;
+} queueItem;
+
+typedef struct queue {
+  queueItem *front;
+  queueItem *back;
+  void (*free)(void *ptr);
+  unsigned long len;
+} queue;
+
+queue *queueCreate(void);
+void queuePush(queue *queue, void *value);
+queueItem *queuePop(queue *queue);
+queueItem *queueFront(queue *queue);
+queueItem *queueNext(queueItem *item);
+queueItem *queueEvict(queue *queue, queueItem *item);
+long long queueLength(queue *queue);
+void queueRelease(queue *queue);
+
+typedef struct RunQueueInfo {
+  pthread_mutex_t run_queue_mutex;
+  pthread_cond_t queue_condition_var;
+  queue *run_queue;
+  pthread_t *threads;
+} RunQueueInfo;
+
+#endif /* __QUEUE_H */

--- a/src/util/queue.h
+++ b/src/util/queue.h
@@ -31,11 +31,4 @@ queueItem *queueEvict(queue *queue, queueItem *item);
 long long queueLength(queue *queue);
 void queueRelease(queue *queue);
 
-typedef struct RunQueueInfo {
-  pthread_mutex_t run_queue_mutex;
-  pthread_cond_t queue_condition_var;
-  queue *run_queue;
-  pthread_t *threads;
-} RunQueueInfo;
-
 #endif /* __QUEUE_H */

--- a/test/tests_common.py
+++ b/test/tests_common.py
@@ -180,13 +180,13 @@ def test_common_tensorget(env):
 def test_common_tensorget_error_replies(env):
     con = env.getConnection()
 
-    # ERR cannot get tensor from empty key
+    # ERR tensor key is empty
     try:
         con.execute_command('AI.TENSORGET', 'empty', 'unsupported')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual(exception.__str__(), "cannot get tensor from empty key")
+        env.assertEqual("tensor key is empty",exception.__str__())
 
     # WRONGTYPE Operation against a key holding the wrong kind of value
     try:
@@ -195,7 +195,7 @@ def test_common_tensorget_error_replies(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual(exception.__str__(), "WRONGTYPE Operation against a key holding the wrong kind of value")
+        env.assertEqual("WRONGTYPE Operation against a key holding the wrong kind of value",exception.__str__())
 
     # ERR unsupported data format
     ret = con.execute_command('AI.TENSORSET', "T_FLOAT", "FLOAT", 2, 'VALUES', 1, 1)

--- a/test/tests_onnx.py
+++ b/test/tests_onnx.py
@@ -57,18 +57,21 @@ def test_onnx_modelrun_mnist(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("No graph was found in the protobuf.", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_1', 'ONNX', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Invalid DEVICE.", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_2', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("wrong number of arguments for 'AI.MODELSET' command", exception.__str__())
 
     con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 1, 1, 28, 28, 'BLOB', sample_raw)
 
@@ -77,48 +80,56 @@ def test_onnx_modelrun_mnist(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("model key is empty", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm_2', 'INPUTS', 'a', 'b', 'c')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("model key is empty", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm_3', 'a', 'b', 'c')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("model key is empty", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm_1', 'OUTPUTS', 'c')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("model key is empty", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm', 'OUTPUTS', 'c')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("INPUTS not specified.", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'b')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("tensor key is empty", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm_1', 'INPUTS', 'OUTPUTS')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("model key is empty", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm_1', 'INPUTS', 'a', 'OUTPUTS', 'b')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("model key is empty", exception.__str__())
 
     con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'OUTPUTS', 'b')
 

--- a/test/tests_onnx.py
+++ b/test/tests_onnx.py
@@ -64,7 +64,7 @@ def test_onnx_modelrun_mnist(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Invalid DEVICE.", exception.__str__())
+        env.assertEqual("Invalid DEVICE", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_2', model_pb)
@@ -108,7 +108,7 @@ def test_onnx_modelrun_mnist(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("INPUTS not specified.", exception.__str__())
+        env.assertEqual("INPUTS not specified", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'b')

--- a/test/tests_pytorch.py
+++ b/test/tests_pytorch.py
@@ -465,6 +465,8 @@ def test_pytorch_scriptrun(env):
     values = tensor[-1]
     env.assertEqual(values, [b'4', b'6', b'4', b'6'])
 
+    ensureSlaveSynced(con, env)
+
     if env.useSlaves:
         con2 = env.getSlaveConnection()
         tensor2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')

--- a/test/tests_pytorch.py
+++ b/test/tests_pytorch.py
@@ -323,7 +323,7 @@ def test_pytorch_scriptdel(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("no script at key", exception.__str__())
+        env.assertEqual("script key is empty", exception.__str__())
 
     # ERR wrong type from SCRIPTDEL
     try:
@@ -374,7 +374,7 @@ def test_pytorch_scriptrun(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("cannot get script from empty key", exception.__str__())
+        env.assertEqual("script key is empty", exception.__str__())
 
     # ERR wrong type from SCRIPTGET
     try:
@@ -410,7 +410,7 @@ def test_pytorch_scriptrun(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Input key is empty", exception.__str__())
+        env.assertEqual("tensor key is empty", exception.__str__())
 
     # ERR Input key not tensor
     try:

--- a/test/tests_tensorflow.py
+++ b/test/tests_tensorflow.py
@@ -157,7 +157,7 @@ def test_del_tf_model(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("no model at key", exception.__str__())
+        env.assertEqual("model key is empty", exception.__str__())
 
     # ERR wrong type
     try:
@@ -349,14 +349,14 @@ def test_run_tf_model_errors(env):
     # cleanup
     con.execute_command('DEL', 'NOT_MODEL')
 
-    # ERR cannot get model from empty key
+    # ERR model key is empty
     con.execute_command('DEL', 'DONT_EXIST')
     try:
         con.execute_command('AI.MODELGET', 'DONT_EXIST')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("cannot get model from empty key", exception.__str__())
+        env.assertEqual("model key is empty", exception.__str__())
 
     try:
         ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
@@ -364,6 +364,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Invalid GraphDef", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_1', 'TF',
@@ -371,6 +372,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("INPUTS not specified.", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_2', 'PORCH', DEVICE,
@@ -378,6 +380,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("unsupported backend", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_3', 'TORCH', DEVICE,
@@ -392,6 +395,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("INPUTS not specified.", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_5', 'TF', DEVICE,
@@ -399,6 +403,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("WRONGTYPE Operation against a key holding the wrong kind of value", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_6', 'TF', DEVICE,
@@ -406,12 +411,14 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Output node named \"mult\" not found in TF graph.", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_7', 'TF', DEVICE, model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Insufficient arguments, INPUTS and OUTPUTS not specified.", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
@@ -419,6 +426,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Invalid GraphDef", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
@@ -426,6 +434,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Invalid GraphDef", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
@@ -433,6 +442,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Invalid GraphDef", exception.__str__())
 
     # ERR Invalid GraphDef
     try:
@@ -448,12 +458,14 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("tensor key is empty", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm', 'OUTPUTS', 'c')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("INPUTS not specified.", exception.__str__())
 
 
 @skip_if_no_TF

--- a/test/tests_tensorflow.py
+++ b/test/tests_tensorflow.py
@@ -372,7 +372,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("INPUTS not specified.", exception.__str__())
+        env.assertEqual("INPUTS not specified", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_2', 'PORCH', DEVICE,
@@ -395,7 +395,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("INPUTS not specified.", exception.__str__())
+        env.assertEqual("INPUTS not specified", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_5', 'TF', DEVICE,
@@ -411,14 +411,14 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Output node named \"mult\" not found in TF graph.", exception.__str__())
+        env.assertEqual("Output node named \"mult\" not found in TF graph", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_7', 'TF', DEVICE, model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Insufficient arguments, INPUTS and OUTPUTS not specified.", exception.__str__())
+        env.assertEqual("Insufficient arguments, INPUTS and OUTPUTS not specified", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
@@ -465,7 +465,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("INPUTS not specified.", exception.__str__())
+        env.assertEqual("INPUTS not specified", exception.__str__())
 
 
 @skip_if_no_TF

--- a/test/tests_tflite.py
+++ b/test/tests_tflite.py
@@ -106,7 +106,7 @@ def test_run_tflite_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Insufficient arguments, missing model BLOB.", exception.__str__())
+        env.assertEqual("Insufficient arguments, missing model BLOB", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_2', model_pb)
@@ -148,21 +148,21 @@ def test_run_tflite_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("INPUTS not specified.", exception.__str__())
+        env.assertEqual("INPUTS not specified", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm_2', 'OUTPUTS', 'c')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("INPUTS not specified.", exception.__str__())
+        env.assertEqual("INPUTS not specified", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm', 'OUTPUTS', 'c')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("INPUTS not specified.", exception.__str__())
+        env.assertEqual("INPUTS not specified", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'b')
@@ -218,7 +218,7 @@ def test_run_tflite_model_autobatch(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Auto-batching not supported by the TFLITE backend.", exception.__str__())
+        env.assertEqual("Auto-batching not supported by the TFLITE backend", exception.__str__())
 
     # env.assertEqual(ret, b'OK')
 

--- a/test/tests_tflite.py
+++ b/test/tests_tflite.py
@@ -56,69 +56,6 @@ def test_run_tflite_model(env):
     # env.assertEqual(ret[0], b'TFLITE')
     # env.assertEqual(ret[1], b'CPU')
 
-    try:
-        con.execute_command('AI.MODELSET', 'm_1', 'TFLITE', model_pb)
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
-    ret = con.execute_command('AI.MODELSET', 'm_2', 'TFLITE', 'CPU', model_pb2)
-    ensureSlaveSynced(con, env)
-
-    try:
-        con.execute_command('AI.MODELSET', 'm_2', model_pb)
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
-    try:
-        con.execute_command('AI.MODELRUN', 'm_2', 'INPUTS', 'a', 'OUTPUTS')
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
-    try:
-        con.execute_command('AI.MODELRUN', 'm_2', 'INPUTS', 'a', 'b', 'c')
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
-    try:
-        con.execute_command('AI.MODELRUN', 'm_2', 'a', 'b', 'c')
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
-    try:
-        con.execute_command('AI.MODELRUN', 'm_2', 'OUTPUTS', 'c')
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
-    try:
-        con.execute_command('AI.MODELRUN', 'm', 'OUTPUTS', 'c')
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
-    try:
-        con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'b')
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
-    try:
-        con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'OUTPUTS')
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
-    try:
-        con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'OUTPUTS', 'b')
-    except Exception as e:
-        exception = e
-        env.assertEqual(type(exception), redis.exceptions.ResponseError)
-
     con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'OUTPUTS', 'b', 'c')
 
     ensureSlaveSynced(con, env)
@@ -127,6 +64,133 @@ def test_run_tflite_model(env):
     value = tensor[-1][0]
 
     env.assertEqual(value, 1)
+
+
+def test_run_tflite_model_errors(env):
+    if not TEST_TFLITE:
+        env.debugPrint("skipping {} since TEST_TFLITE=0".format(sys._getframe().f_code.co_name), force=True)
+        return
+
+    con = env.getConnection()
+
+    test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
+    model_filename = os.path.join(test_data_path, 'mnist_model_quant.tflite')
+    wrong_model_filename = os.path.join(test_data_path, 'graph.pb')
+    sample_filename = os.path.join(test_data_path, 'one.raw')
+
+    with open(model_filename, 'rb') as f:
+        model_pb = f.read()
+
+    with open(model_filename, 'rb') as f:
+        model_pb2 = f.read()
+
+    with open(wrong_model_filename, 'rb') as f:
+        wrong_model_pb = f.read()
+
+    with open(sample_filename, 'rb') as f:
+        sample_raw = f.read()
+
+    ret = con.execute_command('AI.MODELSET', 'm_2', 'TFLITE', 'CPU', model_pb2)
+    env.assertEqual(ret, b'OK')
+
+    ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', 'TAG', 'asdf', model_pb)
+    env.assertEqual(ret, b'OK')
+
+    ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 1, 1, 28, 28, 'BLOB', sample_raw)
+    env.assertEqual(ret, b'OK')
+
+    ensureSlaveSynced(con, env)
+
+    try:
+        con.execute_command('AI.MODELSET', 'm_1', 'TFLITE', model_pb)
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Insufficient arguments, missing model BLOB.", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELSET', 'm_2', model_pb)
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("wrong number of arguments for 'AI.MODELSET' command", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm_2', 'INPUTS', 'EMPTY_TENSOR', 'OUTPUTS')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("tensor key is empty", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm_2')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("wrong number of arguments for 'AI.MODELRUN' command", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'EMPTY', 'INPUTS')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("model key is empty", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm_2', 'INPUTS', 'a', 'b', 'c')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("tensor key is empty", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm_2', 'a', 'b', 'c')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("INPUTS not specified.", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm_2', 'OUTPUTS', 'c')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("INPUTS not specified.", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm', 'OUTPUTS', 'c')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("INPUTS not specified.", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'b')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("tensor key is empty", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'OUTPUTS')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Inconsistent number of inputs", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'OUTPUTS')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Inconsistent number of outputs", exception.__str__())
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'OUTPUTS', 'b')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Inconsistent number of outputs", exception.__str__())
 
 
 # TODO: Autobatch is tricky with TFLITE because TFLITE expects a fixed batch
@@ -153,7 +217,8 @@ def test_run_tflite_model_autobatch(env):
                                   'BATCHSIZE', 2, 'MINBATCHSIZE', 2, model_pb)
     except Exception as e:
         exception = e
-    env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Auto-batching not supported by the TFLITE backend.", exception.__str__())
 
     # env.assertEqual(ret, b'OK')
 


### PR DESCRIPTION
Current WIP
- [add] simplified argument processing on RedisAI_ModelRun_RedisCommand (only 1 full-loop vs 5)
- [add] code refactoring to reduce duplicates and reduce complexity. 
- [add] enforced error reply string comparison on tests. 
- [fix] error messages consistent across commands for tensor getting, etc...
- removes usage of `RedisModule_AutoMemory(ctx)` from `RedisAI_TensorGet_RedisCommand`, `RedisAI_ModelSet_RedisCommand`, `RedisAI_ModelGet_RedisCommand`, `RedisAI_ModelDel_RedisCommand`, `RedisAI_ModelRun_RedisCommand`, `RedisAI_ScriptDel_RedisCommand`
- moves `queue` from `redisai.c` to `util/queue.c`
