### PR TITLE
Revamp GET methods (breaking change for clients)

### DIFF
--- a/src/redisai.c
+++ b/src/redisai.c
@@ -411,21 +411,6 @@ int RedisAI_ModelScan_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
 
 /**
  * AI.MODELRUN model_key INPUTS input_key1 ... OUTPUTS output_key1 ...
- *
- * The request is queued and evaded asynchronously from a separate thread. The
- * client blocks until the computation finishes.
- *
- * 1. clone inputs as needed in the main thread (only the alternative is to
- * lock)
- * 2. spawn the new thread for running the model
- * 3. have reply callback put the data back into the key
- * 
- * This way we avoid any race condition. The only gotcha is making sure no one
- * overwrites the model until it's done computing.
- * This means that setModel will decode on a candidate pointer, and will then
- * be picked up on the next round. We also need to signal when it's time to
- * dispose of the old model. The key is having a single thread looping
- * forexecution
  */
 int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
                                   int argc) {

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -1008,7 +1008,7 @@ int RAI_parseTensorGetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
   }
 
   if (!meta && values) {
-    int ret = RedisAI_TensorReplyWithValues(ctx, t);
+    int ret = RAI_TensorReplyWithValues(ctx, t);
     if (ret == -1) {
       return -1;
     }
@@ -1054,7 +1054,7 @@ int RAI_parseTensorGetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
   }
   else if (values) {
     RedisModule_ReplyWithCString(ctx, "values");
-    int ret = RedisAI_TensorReplyWithValues(ctx, t);
+    int ret = RAI_TensorReplyWithValues(ctx, t);
     if (ret != REDISMODULE_OK) {
       return -1;
     }

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -922,28 +922,107 @@ int RAI_parseTensorSetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
   return argpos;
 }
 
+int RAI_TensorReplyWithValues(RedisModuleCtx *ctx, RAI_Tensor* t) {
+  long long ndims = RAI_TensorNumDims(t);
+  long long len = 1;
+  long long i;
+  for (i=0; i<ndims; i++) {
+    len *= RAI_TensorDim(t, i);
+  }
+
+  DLDataType dtype = RAI_TensorDataType(t);
+
+  RedisModule_ReplyWithArray(ctx, len);
+
+  if (dtype.code == kDLFloat) {
+    double val;
+    for (i=0; i<len; i++) {
+      int ret = RAI_TensorGetValueAsDouble(t, i, &val);
+      if (!ret) {
+        RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
+        return -1;
+      }
+      RedisModule_ReplyWithDouble(ctx, val);
+    }
+  }
+  else {
+    long long val;
+    for (i=0; i<len; i++) {
+      int ret = RAI_TensorGetValueAsLongLong(t, i, &val);
+      if (!ret) {
+        RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
+        return -1;
+      }
+      RedisModule_ReplyWithLongLong(ctx, val);
+    }
+  }
+
+  return 0;
+}
+
 int RAI_parseTensorGetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RAI_Tensor *t){
-  if (argc < 3) {
+  if (argc < 2 || argc > 4) {
     RedisModule_WrongArity(ctx);
     return -1;
   }
 
   int datafmt;
-  long long resplen = 2;
-  const char *fmtstr = RedisModule_StringPtrLen(argv[2], NULL);
-  if (!strcasecmp(fmtstr, "BLOB")) {
-    datafmt = REDISAI_DATA_BLOB;
-    resplen = 3;
-  } else if (!strcasecmp(fmtstr, "VALUES")) {
-    datafmt = REDISAI_DATA_VALUES;
-    resplen = 3;
-  } else if (!strcasecmp(fmtstr, "META")) {
-    datafmt = REDISAI_DATA_NONE;
-  } else {
-    RedisModule_ReplyWithError(ctx, "ERR unsupported data format");
+  int meta = 0;
+  int blob = 0;
+  int values = 0;
+  for (int i=2; i<argc; i++) {
+    const char *fmtstr = RedisModule_StringPtrLen(argv[i], NULL);
+    if (!strcasecmp(fmtstr, "BLOB")) {
+      blob = 1;
+      datafmt = REDISAI_DATA_BLOB;
+    } else if (!strcasecmp(fmtstr, "VALUES")) {
+      values = 1;
+      datafmt = REDISAI_DATA_VALUES;
+    } else if (!strcasecmp(fmtstr, "META")) {
+      meta = 1;
+      datafmt = REDISAI_DATA_NONE;
+    } else {
+      RedisModule_ReplyWithError(ctx, "ERR unsupported data format");
+      return -1;
+    }
+  }
+
+  if (blob && values) {
+    RedisModule_ReplyWithError(ctx, "ERR both BLOB and VALUES specified");
     return -1;
   }
 
+  if (!meta && !blob && !values) {
+    RedisModule_ReplyWithError(ctx, "ERR no META, BLOB or VALUES specified");
+    return -1;
+  }
+
+  if (!meta && blob) {
+    long long size = RAI_TensorByteSize(t);
+    char *data = RAI_TensorData(t);
+    int ret = RedisModule_ReplyWithStringBuffer(ctx, data, size);
+    if (ret == -1) {
+      return -1;
+    }
+    return argc;
+  }
+
+  if (!meta && values) {
+    int ret = RedisAI_TensorReplyWithValues(ctx, t);
+    if (ret == -1) {
+      return -1;
+    }
+    return argc;
+  }
+
+  long long resplen = 4;
+
+  if (blob || values) {
+    resplen += 2;
+  }
+
+  const long long ndims = RAI_TensorNumDims(t);
+  
   RedisModule_ReplyWithArray(ctx, resplen);
 
   char *dtypestr = NULL;
@@ -952,58 +1031,35 @@ int RAI_parseTensorGetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     RedisModule_ReplyWithError(ctx, "ERR unsupported dtype");
     return -1;
   }
-  RedisModule_ReplyWithStringBuffer(ctx,dtypestr,strlen(dtypestr));
-  if(dtypestr){
-    RedisModule_Free(dtypestr);
-  }
+  RedisModule_ReplyWithCString(ctx, "dtype");
+  RedisModule_ReplyWithCString(ctx, dtypestr);
 
-  const long long ndims = RAI_TensorNumDims(t);
+  RedisModule_ReplyWithCString(ctx, "shape");
   RedisModule_ReplyWithArray(ctx, ndims);
   for (long long i=0; i<ndims; i++) {
     const long long dim = RAI_TensorDim(t, i);
     RedisModule_ReplyWithLongLong(ctx, dim);
   }
 
-  if (datafmt == REDISAI_DATA_BLOB) {
+  if (blob) {
     long long size = RAI_TensorByteSize(t);
     char *data = RAI_TensorData(t);
-    RedisModule_ReplyWithStringBuffer(ctx, data, size);
-  }
-  else if (datafmt == REDISAI_DATA_VALUES) {
-    long long ndims = RAI_TensorNumDims(t);
-    long long len = 1;
-    long long i;
-    for (i=0; i<ndims; i++) {
-      len *= RAI_TensorDim(t, i);
-    }
 
-    DLDataType dtype = RAI_TensorDataType(t);
+    RedisModule_ReplyWithCString(ctx, "blob");
+    int ret = RedisModule_ReplyWithStringBuffer(ctx, data, size);
 
-    RedisModule_ReplyWithArray(ctx, len);
-
-    if (dtype.code == kDLFloat) {
-      double val;
-      for (i=0; i<len; i++) {
-        int ret = RAI_TensorGetValueAsDouble(t, i, &val);
-        if (!ret) {
-          RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
-          return -1;
-        }
-        RedisModule_ReplyWithDouble(ctx, val);
-      }
-    }
-    else {
-      long long val;
-      for (i=0; i<len; i++) {
-        int ret = RAI_TensorGetValueAsLongLong(t, i, &val);
-        if (!ret) {
-          RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
-          return -1;
-        }
-        RedisModule_ReplyWithLongLong(ctx, val);
-      }
+    if (ret != REDISMODULE_OK) {
+      return -1;
     }
   }
+  else if (values) {
+    RedisModule_ReplyWithCString(ctx, "values");
+    int ret = RedisAI_TensorReplyWithValues(ctx, t);
+    if (ret != REDISMODULE_OK) {
+      return -1;
+    }
+  }
+
   // return command arity as the number of processed args
-  return 3;
+  return argc;
 }

--- a/test/tests_common.py
+++ b/test/tests_common.py
@@ -19,15 +19,15 @@ def test_common_tensorset(env):
 
     # AI.TENSORGET in BLOB format and set in a new key
     for datatype in tested_datatypes:
-        tensor_dtype, tensor_dim, tensor_blob = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype),
-                                                                    'BLOB')
+        _, tensor_dtype, _, tensor_dim, _, tensor_blob = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype),
+                                                                             'META', 'BLOB')
         ret = con.execute_command('AI.TENSORSET', 'tensor_blob_{0}'.format(datatype), datatype, 2, 'BLOB', tensor_blob)
         env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
 
     reply_types = ["META", "VALUES", "BLOB"]
-    # Confirm that tensor_{0} and tensor_blog_{0} are equal for META VALUES BLOB
+    # Confirm that tensor_{0} and tensor_blob_{0} are equal for META VALUES BLOB
     for datatype in tested_datatypes:
         for reply_type in reply_types:
             tensor_1_reply = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype), reply_type)
@@ -167,8 +167,7 @@ def test_common_tensorget(env):
 
     # AI.TENSORGET in BLOB format and set in a new key
     for datatype in tested_datatypes:
-        tensor_dtype, tensor_dim, tensor_blob = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype),
-                                                                    'BLOB')
+        tensor_blob = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype), 'BLOB')
         ret = con.execute_command('AI.TENSORSET', 'tensor_blob_{0}'.format(datatype), datatype, 2, 'BLOB', tensor_blob)
         env.assertEqual(ret, b'OK')
 
@@ -184,14 +183,14 @@ def test_common_tensorget(env):
 
     # Confirm that the output is the expected for META
     for datatype in tested_datatypes:
-        tensor_dtype, tensor_dim = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype), "META")
+        _, tensor_dtype, _, tensor_dim = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype), "META")
         env.assertEqual(datatype.encode('utf-8'), tensor_dtype)
         env.assertEqual([2], tensor_dim)
 
     # Confirm that the output is the expected for VALUES
     for datatype in tested_datatypes:
-        tensor_dtype, tensor_dim, tensor_values = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype),
-                                                                      "VALUES")
+        _, tensor_dtype, _, tensor_dim, _, tensor_values = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype),
+                                                                               'META', 'VALUES')
         env.assertEqual(datatype.encode('utf-8'), tensor_dtype)
         env.assertEqual([2], tensor_dim)
         if datatype in tested_datatypes_fp:
@@ -201,8 +200,8 @@ def test_common_tensorget(env):
 
     # Confirm that the output is the expected for BLOB
     for datatype in tested_datatypes:
-        tensor_dtype, tensor_dim, tensor_blog = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype),
-                                                                    "BLOB")
+        _, tensor_dtype, _, tensor_dim, _, tensor_blob = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype),
+                                                                             'META', 'BLOB')
         env.assertEqual(datatype.encode('utf-8'), tensor_dtype)
         env.assertEqual([2], tensor_dim)
 
@@ -244,8 +243,7 @@ def test_common_tensorset_multiproc(env):
 
     con = env.getConnection()
     ensureSlaveSynced(con, env)
-    tensor = con.execute_command('AI.TENSORGET', 'x', 'VALUES')
-    values = tensor[-1]
+    values = con.execute_command('AI.TENSORGET', 'x', 'VALUES')
     env.assertEqual(values, [b'2', b'3'])
 
 
@@ -261,10 +259,10 @@ def test_common_tensorset_multiproc_blob(env):
 
     # AI.TENSORGET in BLOB format and set in a new key
     for datatype in tested_datatypes:
-        tensor_dtype, tensor_dim, tensor_blob = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype),
+        tensor_blob = con.execute_command('AI.TENSORGET', 'tensor_{0}'.format(datatype),
                                                                     'BLOB')
         ret = con.execute_command('AI.TENSORSET', 'tensor_blob_{0}'.format(datatype), datatype, 1, 256, 'BLOB', tensor_blob)
-        tested_datatypes_map[datatype]=tensor_blob
+        tested_datatypes_map[datatype] = tensor_blob
         env.assertEqual(ret, b'OK')
 
     def funcname(env, blob, repetitions, same_key):
@@ -291,5 +289,5 @@ def test_tensorget_disconnect(env):
     red = env.getConnection()
     ret = red.execute_command('AI.TENSORSET', 't_FLOAT', 'FLOAT', 2, 'VALUES', 2, 3)
     env.assertEqual(ret, b'OK')
-    ret = send_and_disconnect(('AI.TENSORGET', 't_FLOAT'), red)
+    ret = send_and_disconnect(('AI.TENSORGET', 't_FLOAT', 'META'), red)
     env.assertEqual(ret, None)

--- a/test/tests_dag.py
+++ b/test/tests_dag.py
@@ -161,8 +161,8 @@ def test_dag_local_tensorset_persist(env):
     ret = con.execute_command("EXISTS tensor1")
     env.assertEqual(ret, 1 )
 
-    ret = con.execute_command("AI.TENSORGET tensor1 VALUES")
-    env.assertEqual(ret, [b'FLOAT', [1, 2], [b'5', b'10']])
+    ret = con.execute_command("AI.TENSORGET tensor1 META VALUES")
+    env.assertEqual(ret, [b'dtype', b'FLOAT', b'shape', [1, 2], b'values', [b'5', b'10']])
 
 
 def test_dag_multilocal_tensorset_persist(env):
@@ -194,8 +194,8 @@ def test_dag_multilocal_tensorset_persist(env):
     ret = con.execute_command("EXISTS tensor4")
     env.assertEqual(ret, 0 )
 
-    ret = con.execute_command("AI.TENSORGET tensor3 VALUES")
-    env.assertEqual(ret, [b'FLOAT', [1, 2], [b'5', b'10']])
+    ret = con.execute_command("AI.TENSORGET tensor3 META VALUES")
+    env.assertEqual(ret, [b'dtype', b'FLOAT', b'shape', [1, 2], b'values', [b'5', b'10']])
 
 def test_dag_local_tensorset_tensorget_persist(env):
     con = env.getConnection()
@@ -205,10 +205,10 @@ def test_dag_local_tensorset_tensorget_persist(env):
         "AI.TENSORGET tensor1 VALUES"
 
     ret = con.execute_command(command)
-    env.assertEqual(ret, [b'OK', [b'FLOAT', [1, 2], [b'5', b'10']]])
+    env.assertEqual(ret, [b'OK', [b'5', b'10']])
 
     ret = con.execute_command("AI.TENSORGET tensor1 VALUES")
-    env.assertEqual(ret, [b'FLOAT', [1, 2], [b'5', b'10']])
+    env.assertEqual(ret, [b'5', b'10'])
 
 
 def test_dag_local_multiple_tensorset_on_same_tensor(env):
@@ -217,20 +217,20 @@ def test_dag_local_multiple_tensorset_on_same_tensor(env):
     command = "AI.DAGRUN "\
                      "PERSIST 1 tensor1 |> "\
         "AI.TENSORSET tensor1 FLOAT 1 2 VALUES 5 10 |> "\
-        "AI.TENSORGET tensor1 VALUES |> "\
+        "AI.TENSORGET tensor1 META VALUES |> "\
         "AI.TENSORSET tensor1 FLOAT 1 4 VALUES 20 40 60 80 |> "\
-        "AI.TENSORGET tensor1 VALUES"
+        "AI.TENSORGET tensor1 META VALUES"
 
     ret = con.execute_command(command)
     env.assertEqual([
                      b'OK', 
-                    [b'FLOAT', [1, 2], [b'5', b'10']],
+                    [b'dtype', b'FLOAT', b'shape', [1, 2], b'values', [b'5', b'10']],
                      b'OK', 
-                    [b'FLOAT', [1, 4], [b'20', b'40', b'60', b'80']]
+                    [b'dtype', b'FLOAT', b'shape', [1, 4], b'values', [b'20', b'40', b'60', b'80']]
                     ], ret)
 
-    ret = con.execute_command("AI.TENSORGET tensor1 VALUES")
-    env.assertEqual([b'FLOAT', [1, 4], [b'20', b'40',b'60',b'80']],ret)
+    ret = con.execute_command("AI.TENSORGET tensor1 META VALUES")
+    env.assertEqual([b'dtype', b'FLOAT', b'shape', [1, 4], b'values', [b'20', b'40',b'60',b'80']],ret)
 
 
 def test_dag_load_persist_tensorset_tensorget(env):
@@ -246,15 +246,15 @@ def test_dag_load_persist_tensorset_tensorget(env):
 
     command = "AI.DAGRUN LOAD 2 persisted_tensor_1 persisted_tensor_2 PERSIST 1 volatile_tensor_persisted |> "\
         "AI.TENSORSET volatile_tensor_persisted FLOAT 1 2 VALUES 5 10 |> "\
-        "AI.TENSORGET persisted_tensor_1 VALUES |> "\
-        "AI.TENSORGET persisted_tensor_2 VALUES "
+        "AI.TENSORGET persisted_tensor_1 META VALUES |> "\
+        "AI.TENSORGET persisted_tensor_2 META VALUES "
 
     ret = con.execute_command(command)
-    env.assertEqual(ret, [b'OK', [b'FLOAT', [1, 2], [b'5', b'10']], [
-                    b'FLOAT', [1, 3], [b'0', b'0', b'0']]])
+    env.assertEqual(ret, [b'OK', [b'dtype', b'FLOAT', b'shape', [1, 2], b'values', [b'5', b'10']], [
+                    b'dtype', b'FLOAT', b'shape', [1, 3], b'values', [b'0', b'0', b'0']]])
 
-    ret = con.execute_command("AI.TENSORGET volatile_tensor_persisted VALUES")
-    env.assertEqual(ret, [b'FLOAT', [1, 2], [b'5', b'10']])
+    ret = con.execute_command("AI.TENSORGET volatile_tensor_persisted META VALUES")
+    env.assertEqual(ret, [b'dtype', b'FLOAT', b'shape', [1, 2], b'values', [b'5', b'10']])
 
 
 def test_dag_local_tensorset_tensorget(env):
@@ -262,10 +262,10 @@ def test_dag_local_tensorset_tensorget(env):
 
     command = "AI.DAGRUN "\
         "AI.TENSORSET volatile_tensor FLOAT 1 2 VALUES 5 10 |> "\
-        "AI.TENSORGET volatile_tensor VALUES"
+        "AI.TENSORGET volatile_tensor META VALUES"
 
     ret = con.execute_command(command)
-    env.assertEqual(ret, [b'OK', [b'FLOAT', [1, 2], [b'5', b'10']]])
+    env.assertEqual(ret, [b'OK', [b'dtype', b'FLOAT', b'shape', [1, 2], b'values', [b'5', b'10']]])
 
 
 def test_dag_keyspace_tensorget(env):
@@ -279,7 +279,7 @@ def test_dag_keyspace_tensorget(env):
         "AI.TENSORGET persisted_tensor VALUES"
 
     ret = con.execute_command(command)
-    env.assertEqual(ret, [[b'FLOAT', [1, 2], [b'5', b'10']]])
+    env.assertEqual(ret, [[b'5', b'10']])
 
 
 def test_dag_keyspace_and_localcontext_tensorget(env):
@@ -295,8 +295,7 @@ def test_dag_keyspace_and_localcontext_tensorget(env):
         "AI.TENSORGET volatile_tensor VALUES"
 
     ret = con.execute_command(command)
-    env.assertEqual(ret, [b'OK', [b'FLOAT', [1, 2], [b'5', b'10']], [
-                    b'FLOAT', [1, 2], [b'5', b'10']]])
+    env.assertEqual(ret, [b'OK', [b'5', b'10'], [b'5', b'10']])
 
 
 def test_dag_modelrun_financialNet_separate_tensorget(env):
@@ -310,7 +309,7 @@ def test_dag_modelrun_financialNet_separate_tensorget(env):
 
     tensor_number = 1
     for reference_tensor in creditcard_referencedata[:5]:
-        ret = con.execute_command(  'AI.TENSORSET', 'referenceTensor:{0}'.format(tensor_number),
+        ret = con.execute_command('AI.TENSORSET', 'referenceTensor:{0}'.format(tensor_number),
                                   'FLOAT', 1, 256,
                                   'BLOB', reference_tensor.tobytes())
         env.assertEqual(ret, b'OK')
@@ -330,7 +329,7 @@ def test_dag_modelrun_financialNet_separate_tensorget(env):
 
         ret = con.execute_command("AI.TENSORGET classificationTensor:{} META".format(
             tensor_number))
-        env.assertEqual([b'FLOAT', [1, 2]],ret)
+        env.assertEqual([b'dtype', b'FLOAT', b'shape', [1, 2]], ret)
 
         # assert that transaction tensor does not exist
         ret = con.execute_command("EXISTS transactionTensor:{} META".format(
@@ -349,7 +348,7 @@ def test_dag_modelrun_financialNet(env):
 
     tensor_number = 1
     for reference_tensor in creditcard_referencedata[:5]:
-        ret = con.execute_command(  'AI.TENSORSET', 'referenceTensor:{0}'.format(tensor_number),
+        ret = con.execute_command('AI.TENSORSET', 'referenceTensor:{0}'.format(tensor_number),
                                   'FLOAT', 1, 256,
                                   'BLOB', reference_tensor.tobytes())
         env.assertEqual(ret, b'OK')
@@ -366,7 +365,7 @@ def test_dag_modelrun_financialNet(env):
                            'OUTPUTS', 'classificationTensor:{}'.format(tensor_number), '|>',
             'AI.TENSORGET', 'classificationTensor:{}'.format(tensor_number), 'META',
         )
-        env.assertEqual([b'OK',b'OK',[b'FLOAT', [1, 2]]],ret)
+        env.assertEqual([b'OK',b'OK',[b'dtype', b'FLOAT', b'shape', [1, 2]]], ret)
 
         # assert that transaction tensor does not exist
         ret = con.execute_command("EXISTS transactionTensor:{}".format(
@@ -385,7 +384,7 @@ def test_dag_modelrun_financialNet_no_writes(env):
 
     tensor_number = 1
     for reference_tensor in creditcard_referencedata:
-        ret = con.execute_command(  'AI.TENSORSET', 'referenceTensor:{0}'.format(tensor_number),
+        ret = con.execute_command('AI.TENSORSET', 'referenceTensor:{0}'.format(tensor_number),
                                   'FLOAT', 1, 256,
                                   'BLOB', reference_tensor.tobytes())
         env.assertEqual(ret, b'OK')
@@ -404,9 +403,9 @@ def test_dag_modelrun_financialNet_no_writes(env):
                 'AI.TENSORGET', 'classificationTensor:{}'.format(tensor_number), 'VALUES'
             )
             env.assertEqual(4, len(ret))
-            env.assertEqual([b'OK',b'OK'], ret[:2])
-            env.assertEqual([b'FLOAT', [1, 2]], ret[2])
-            dtype, shape, values = ret[3]
+            env.assertEqual([b'OK', b'OK'], ret[:2])
+            env.assertEqual([b'dtype', b'FLOAT', b'shape', [1, 2]], ret[2])
+            values = ret[3]
             # Assert that resulting classification is within [0,1]
             env.assertEqual(True, 0 <= float(values[0]) <= 1)
             env.assertEqual(True, 0 <= float(values[1]) <= 1)
@@ -434,7 +433,7 @@ def test_dag_modelrun_financialNet_no_writes_multiple_modelruns(env):
 
     tensor_number = 1
     for reference_tensor in creditcard_referencedata:
-        ret = con.execute_command(  'AI.TENSORSET', 'referenceTensor:{0}'.format(tensor_number),
+        ret = con.execute_command('AI.TENSORSET', 'referenceTensor:{0}'.format(tensor_number),
                                   'FLOAT', 1, 256,
                                   'BLOB', reference_tensor.tobytes())
         env.assertEqual(ret, b'OK')
@@ -448,18 +447,18 @@ def test_dag_modelrun_financialNet_no_writes_multiple_modelruns(env):
             'AI.MODELRUN', 'financialNet', 
                            'INPUTS', 'transactionTensor:{}'.format(tensor_number), 'referenceTensor:{}'.format(tensor_number),
                            'OUTPUTS', 'classificationTensor:{}'.format(tensor_number), '|>',
-            'AI.TENSORGET', 'classificationTensor:{}'.format(tensor_number), 'VALUES',  '|>',
+            'AI.TENSORGET', 'classificationTensor:{}'.format(tensor_number), 'META', 'VALUES', '|>',
             'AI.MODELRUN', 'financialNet', 
                            'INPUTS', 'transactionTensor:{}'.format(tensor_number), 'referenceTensor:{}'.format(tensor_number),
                            'OUTPUTS', 'classificationTensor:{}'.format(tensor_number), '|>',
-            'AI.TENSORGET', 'classificationTensor:{}'.format(tensor_number), 'VALUES', 
+            'AI.TENSORGET', 'classificationTensor:{}'.format(tensor_number), 'META', 'VALUES', 
         )
         env.assertEqual(5, len(ret))
-        env.assertEqual([b'OK',b'OK'],ret[:2])
-        env.assertEqual([b'FLOAT', [1, 2]],ret[2][:2])
-        env.assertEqual(b'OK',ret[3])
-        env.assertEqual([b'FLOAT', [1, 2]],ret[4][:2])
-        for dtype, shape, values in [ret[2], ret[4]]:
+        env.assertEqual([b'OK', b'OK'], ret[:2])
+        env.assertEqual([b'dtype', b'FLOAT', b'shape', [1, 2]], ret[2][:4])
+        env.assertEqual(b'OK', ret[3])
+        env.assertEqual([b'dtype', b'FLOAT', b'shape', [1, 2]], ret[4][:4])
+        for _, dtype, _, shape, _, values in [ret[2], ret[4]]:
             # Assert that resulting classification is within [0,1]
             env.assertEqual(True, 0 <= float(values[0]) <= 1)
             env.assertEqual(True, 0 <= float(values[1]) <= 1)
@@ -467,10 +466,10 @@ def test_dag_modelrun_financialNet_no_writes_multiple_modelruns(env):
         # assert that transactionTensor does not exist
         ret = con.execute_command("EXISTS transactionTensor:{}".format(
             tensor_number))
-        env.assertEqual(ret, 0 )
+        env.assertEqual(ret, 0)
 
         # assert that classificationTensor does not exist
         ret = con.execute_command("EXISTS classificationTensor:{}".format(
             tensor_number))
-        env.assertEqual(ret, 0 )
+        env.assertEqual(ret, 0)
         tensor_number = tensor_number + 1

--- a/test/tests_pytorch.py
+++ b/test/tests_pytorch.py
@@ -35,7 +35,7 @@ def test_pytorch_modelrun(env):
 
     ensureSlaveSynced(con, env)
 
-    ret = con.execute_command('AI.MODELGET', 'm')
+    ret = con.execute_command('AI.MODELGET', 'm', 'META')
     env.assertEqual(len(ret), 6)
     env.assertEqual(ret[-1], b'')
 
@@ -44,7 +44,7 @@ def test_pytorch_modelrun(env):
 
     ensureSlaveSynced(con, env)
 
-    ret = con.execute_command('AI.MODELGET', 'm')
+    ret = con.execute_command('AI.MODELGET', 'm', 'META')
     env.assertEqual(len(ret), 6)
     env.assertEqual(ret[-1], b'asdf')
 
@@ -123,14 +123,13 @@ def test_pytorch_modelrun(env):
 
     ensureSlaveSynced(con, env)
 
-    tensor = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
-    values = tensor[-1]
+    values = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
     env.assertEqual(values, [b'4', b'6', b'4', b'6'])
 
     if env.useSlaves:
         con2 = env.getSlaveConnection()
-        tensor2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')
-        env.assertEqual(tensor2, tensor)
+        values2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')
+        env.assertEqual(values2, values)
 
 
 def test_pytorch_modelrun_autobatch(env):
@@ -169,12 +168,10 @@ def test_pytorch_modelrun_autobatch(env):
 
     ensureSlaveSynced(con, env)
 
-    tensor = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
-    values = tensor[-1]
+    values = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
     env.assertEqual(values, [b'4', b'6', b'4', b'6'])
 
-    tensor = con.execute_command('AI.TENSORGET', 'f', 'VALUES')
-    values = tensor[-1]
+    values = con.execute_command('AI.TENSORGET', 'f', 'VALUES')
     env.assertEqual(values, [b'4', b'6', b'4', b'6'])
 
 
@@ -211,26 +208,26 @@ def test_pytorch_modelinfo(env):
         info = con.execute_command('AI.INFO', 'm')
         info_dict_0 = info_to_dict(info)
 
-        env.assertEqual(info_dict_0['KEY'], 'm')
-        env.assertEqual(info_dict_0['TYPE'], 'MODEL')
-        env.assertEqual(info_dict_0['BACKEND'], 'TORCH')
-        env.assertEqual(info_dict_0['DEVICE'], DEVICE)
-        env.assertEqual(info_dict_0['TAG'], 'asdf')
-        env.assertTrue(info_dict_0['DURATION'] > previous_duration)
-        env.assertEqual(info_dict_0['SAMPLES'], 2 * call)
-        env.assertEqual(info_dict_0['CALLS'], call)
-        env.assertEqual(info_dict_0['ERRORS'], 0)
+        env.assertEqual(info_dict_0['key'], 'm')
+        env.assertEqual(info_dict_0['type'], 'MODEL')
+        env.assertEqual(info_dict_0['backend'], 'TORCH')
+        env.assertEqual(info_dict_0['device'], DEVICE)
+        env.assertEqual(info_dict_0['tag'], 'asdf')
+        env.assertTrue(info_dict_0['duration'] > previous_duration)
+        env.assertEqual(info_dict_0['samples'], 2 * call)
+        env.assertEqual(info_dict_0['calls'], call)
+        env.assertEqual(info_dict_0['errors'], 0)
 
-        previous_duration = info_dict_0['DURATION']
+        previous_duration = info_dict_0['duration']
 
     res = con.execute_command('AI.INFO', 'm', 'RESETSTAT')
     env.assertEqual(res, b'OK')
     info = con.execute_command('AI.INFO', 'm')
     info_dict_0 = info_to_dict(info)
-    env.assertEqual(info_dict_0['DURATION'], 0)
-    env.assertEqual(info_dict_0['SAMPLES'], 0)
-    env.assertEqual(info_dict_0['CALLS'], 0)
-    env.assertEqual(info_dict_0['ERRORS'], 0)
+    env.assertEqual(info_dict_0['duration'], 0)
+    env.assertEqual(info_dict_0['samples'], 0)
+    env.assertEqual(info_dict_0['calls'], 0)
+    env.assertEqual(info_dict_0['errors'], 0)
 
 
 def test_pytorch_scriptset(env):
@@ -452,25 +449,24 @@ def test_pytorch_scriptrun(env):
     info = con.execute_command('AI.INFO', 'ket')
     info_dict_0 = info_to_dict(info)
 
-    env.assertEqual(info_dict_0['KEY'], 'ket')
-    env.assertEqual(info_dict_0['TYPE'], 'SCRIPT')
-    env.assertEqual(info_dict_0['BACKEND'], 'TORCH')
-    env.assertEqual(info_dict_0['TAG'], 'asdf')
-    env.assertTrue(info_dict_0['DURATION'] > 0)
-    env.assertEqual(info_dict_0['SAMPLES'], -1)
-    env.assertEqual(info_dict_0['CALLS'], 4)
-    env.assertEqual(info_dict_0['ERRORS'], 3)
+    env.assertEqual(info_dict_0['key'], 'ket')
+    env.assertEqual(info_dict_0['type'], 'SCRIPT')
+    env.assertEqual(info_dict_0['backend'], 'TORCH')
+    env.assertEqual(info_dict_0['tag'], 'asdf')
+    env.assertTrue(info_dict_0['duration'] > 0)
+    env.assertEqual(info_dict_0['samples'], -1)
+    env.assertEqual(info_dict_0['calls'], 4)
+    env.assertEqual(info_dict_0['errors'], 3)
 
-    tensor = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
-    values = tensor[-1]
+    values = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
     env.assertEqual(values, [b'4', b'6', b'4', b'6'])
 
     ensureSlaveSynced(con, env)
 
     if env.useSlaves:
         con2 = env.getSlaveConnection()
-        tensor2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')
-        env.assertEqual(tensor2, tensor)
+        values2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')
+        env.assertEqual(values2, values)
 
 
 def test_pytorch_scriptinfo(env):
@@ -508,25 +504,25 @@ def test_pytorch_scriptinfo(env):
         info = con.execute_command('AI.INFO', 'ket_script')
         info_dict_0 = info_to_dict(info)
 
-        env.assertEqual(info_dict_0['KEY'], 'ket_script')
-        env.assertEqual(info_dict_0['TYPE'], 'SCRIPT')
-        env.assertEqual(info_dict_0['BACKEND'], 'TORCH')
-        env.assertEqual(info_dict_0['DEVICE'], DEVICE)
-        env.assertTrue(info_dict_0['DURATION'] > previous_duration)
-        env.assertEqual(info_dict_0['SAMPLES'], -1)
-        env.assertEqual(info_dict_0['CALLS'], call)
-        env.assertEqual(info_dict_0['ERRORS'], 0)
+        env.assertEqual(info_dict_0['key'], 'ket_script')
+        env.assertEqual(info_dict_0['type'], 'SCRIPT')
+        env.assertEqual(info_dict_0['backend'], 'TORCH')
+        env.assertEqual(info_dict_0['device'], DEVICE)
+        env.assertTrue(info_dict_0['duration'] > previous_duration)
+        env.assertEqual(info_dict_0['samples'], -1)
+        env.assertEqual(info_dict_0['calls'], call)
+        env.assertEqual(info_dict_0['errors'], 0)
 
-        previous_duration = info_dict_0['DURATION']
+        previous_duration = info_dict_0['duration']
 
     res = con.execute_command('AI.INFO', 'ket_script', 'RESETSTAT')
     env.assertEqual(res, b'OK')
     info = con.execute_command('AI.INFO', 'ket_script')
     info_dict_0 = info_to_dict(info)
-    env.assertEqual(info_dict_0['DURATION'], 0)
-    env.assertEqual(info_dict_0['SAMPLES'], -1)
-    env.assertEqual(info_dict_0['CALLS'], 0)
-    env.assertEqual(info_dict_0['ERRORS'], 0)
+    env.assertEqual(info_dict_0['duration'], 0)
+    env.assertEqual(info_dict_0['samples'], -1)
+    env.assertEqual(info_dict_0['calls'], 0)
+    env.assertEqual(info_dict_0['errors'], 0)
 
 
 def test_pytorch_scriptrun_disconnect(env):
@@ -592,7 +588,7 @@ def test_pytorch_modelrun_disconnect(env):
     env.assertEqual(ret, None)
 
 
-def test_pytorch_modellist_scriptlist(env):
+def test_pytorch_modelscan_scriptscan(env):
     if not TEST_PT:
         env.debugPrint("skipping {} since TEST_PT=0".format(sys._getframe().f_code.co_name), force=True)
         return
@@ -624,12 +620,12 @@ def test_pytorch_modellist_scriptlist(env):
 
     ensureSlaveSynced(con, env)
 
-    ret = con.execute_command('AI._MODELLIST')
+    ret = con.execute_command('AI._MODELSCAN')
 
     env.assertEqual(ret[0], [b'm1', b'm:v1'])
     env.assertEqual(ret[1], [b'm2', b'm:v1'])
 
-    ret = con.execute_command('AI._SCRIPTLIST')
+    ret = con.execute_command('AI._SCRIPTSCAN')
 
     env.assertEqual(ret[0], [b's1', b's:v1'])
     env.assertEqual(ret[1], [b's2', b's:v1'])
@@ -660,7 +656,7 @@ def test_pytorch_model_rdb_save_load(env):
     con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
     con.execute_command('AI.TENSORSET', 'b', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
     con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'b', 'OUTPUTS', 'c')
-    dtype_memory, shape_memory, data_memory = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
+    _, dtype_memory, _, shape_memory, _, data_memory = con.execute_command('AI.TENSORGET', 'c', 'META', 'VALUES')
 
     ret = con.execute_command('SAVE')
     env.assertEqual(ret, True)
@@ -670,7 +666,7 @@ def test_pytorch_model_rdb_save_load(env):
     con = env.getConnection()
     model_serialized_after_rdbload = con.execute_command('AI.MODELGET', 'm', 'BLOB')
     con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'b', 'OUTPUTS', 'c')
-    dtype_after_rdbload, shape_after_rdbload, data_after_rdbload = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
+    _, dtype_after_rdbload, _, shape_after_rdbload, _, data_after_rdbload = con.execute_command('AI.TENSORGET', 'c', 'META', 'VALUES')
 
     # Assert in memory model metadata is equal to loaded model metadata
     env.assertTrue(model_serialized_memory[1:6] == model_serialized_after_rdbload[1:6])

--- a/test/tests_tflite.py
+++ b/test/tests_tflite.py
@@ -34,14 +34,14 @@ def test_run_tflite_model(env):
     ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', model_pb)
     env.assertEqual(ret, b'OK')
 
-    ret = con.execute_command('AI.MODELGET', 'm')
+    ret = con.execute_command('AI.MODELGET', 'm', 'META')
     env.assertEqual(len(ret), 6)
     env.assertEqual(ret[-1], b'')
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', 'TAG', 'asdf', model_pb)
     env.assertEqual(ret, b'OK')
 
-    ret = con.execute_command('AI.MODELGET', 'm')
+    ret = con.execute_command('AI.MODELGET', 'm', 'META')
     env.assertEqual(len(ret), 6)
     env.assertEqual(ret[-1], b'asdf')
 
@@ -50,7 +50,7 @@ def test_run_tflite_model(env):
 
     ensureSlaveSynced(con, env)
 
-    ret = con.execute_command('AI.MODELGET', 'm')
+    ret = con.execute_command('AI.MODELGET', 'm', 'META')
     env.assertEqual(len(ret), 6)
     # TODO: enable me
     # env.assertEqual(ret[0], b'TFLITE')
@@ -60,10 +60,9 @@ def test_run_tflite_model(env):
 
     ensureSlaveSynced(con, env)
 
-    tensor = con.execute_command('AI.TENSORGET', 'b', 'VALUES')
-    value = tensor[-1][0]
+    values = con.execute_command('AI.TENSORGET', 'b', 'VALUES')
 
-    env.assertEqual(value, 1)
+    env.assertEqual(values[0], 1)
 
 
 def test_run_tflite_model_errors(env):
@@ -234,15 +233,13 @@ def test_run_tflite_model_autobatch(env):
 
     # con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'OUTPUTS', 'b', 'b2')
 
-    # tensor = con.execute_command('AI.TENSORGET', 'b', 'VALUES')
-    # value = tensor[-1][0]
+    # values = con.execute_command('AI.TENSORGET', 'b', 'VALUES')
 
-    # env.assertEqual(value, 1)
+    # env.assertEqual(values[0], 1)
 
-    # tensor = con.execute_command('AI.TENSORGET', 'd', 'VALUES')
-    # value = tensor[-1][0]
+    # values = con.execute_command('AI.TENSORGET', 'd', 'VALUES')
 
-    # env.assertEqual(value, 1)
+    # env.assertEqual(values[0], 1)
 
 
 def test_tflite_modelinfo(env):
@@ -282,25 +279,25 @@ def test_tflite_modelinfo(env):
         info = con.execute_command('AI.INFO', 'mnist')
         info_dict_0 = info_to_dict(info)
 
-        env.assertEqual(info_dict_0['KEY'], 'mnist')
-        env.assertEqual(info_dict_0['TYPE'], 'MODEL')
-        env.assertEqual(info_dict_0['BACKEND'], 'TFLITE')
-        env.assertEqual(info_dict_0['DEVICE'], DEVICE)
-        env.assertTrue(info_dict_0['DURATION'] > previous_duration)
-        env.assertEqual(info_dict_0['SAMPLES'], call)
-        env.assertEqual(info_dict_0['CALLS'], call)
-        env.assertEqual(info_dict_0['ERRORS'], 0)
+        env.assertEqual(info_dict_0['key'], 'mnist')
+        env.assertEqual(info_dict_0['type'], 'MODEL')
+        env.assertEqual(info_dict_0['backend'], 'TFLITE')
+        env.assertEqual(info_dict_0['device'], DEVICE)
+        env.assertTrue(info_dict_0['duration'] > previous_duration)
+        env.assertEqual(info_dict_0['samples'], call)
+        env.assertEqual(info_dict_0['calls'], call)
+        env.assertEqual(info_dict_0['errors'], 0)
 
-        previous_duration = info_dict_0['DURATION']
+        previous_duration = info_dict_0['duration']
 
     res = con.execute_command('AI.INFO', 'mnist', 'RESETSTAT')
     env.assertEqual(res, b'OK')
     info = con.execute_command('AI.INFO', 'mnist')
     info_dict_0 = info_to_dict(info)
-    env.assertEqual(info_dict_0['DURATION'], 0)
-    env.assertEqual(info_dict_0['SAMPLES'], 0)
-    env.assertEqual(info_dict_0['CALLS'], 0)
-    env.assertEqual(info_dict_0['ERRORS'], 0)
+    env.assertEqual(info_dict_0['duration'], 0)
+    env.assertEqual(info_dict_0['samples'], 0)
+    env.assertEqual(info_dict_0['calls'], 0)
+    env.assertEqual(info_dict_0['errors'], 0)
 
 
 def test_tflite_modelrun_disconnect(env):
@@ -357,8 +354,8 @@ def test_tflite_model_rdb_save_load(env):
     con = env.getConnection()
     model_serialized_after_rdbload = con.execute_command('AI.MODELGET', 'mnist', 'BLOB')
     env.assertEqual(len(model_serialized_memory), len(model_serialized_after_rdbload))
-    env.assertEqual(len(model_pb), len(model_serialized_after_rdbload[7]))
+    env.assertEqual(len(model_pb), len(model_serialized_after_rdbload))
     # Assert in memory model binary is equal to loaded model binary
     env.assertTrue(model_serialized_memory == model_serialized_after_rdbload)
     # Assert input model binary is equal to loaded model binary
-    env.assertTrue(model_pb == model_serialized_after_rdbload[7])
+    env.assertTrue(model_pb == model_serialized_after_rdbload)


### PR DESCRIPTION
Addresses #329 

Specifically, with this PR, get methods have a uniform signature and behavior
```
TENSORGET key [META] [BLOB | VALUES]
MODELGET key [META] [BLOB]
SCRIPTGET key [META] [SOURCE]
```

If META is not specified, all methods return a raw binary BLOB, an array VALUES or a raw SOURCE string. This helps, for instance, with dumping a buffer out of a model or a tensor from the CLI.

If only META is specified, all methods return meta data in [key, val, key, val] form. This is a breaking change with respect to the previous behavior (TENSORGET would return [dtype, shape, blob] and not ['dtype', dtype, 'shape', shape, 'blob', blob]), so **THIS CHANGE WILL BREAK CLIENTS AND USER CODE**.

However, this is our last call to make the API uniform and ready for RESP3.

Other notable changes:
- keys in [key, value, ...] responses are now lowercase (including `AI.INFO`)
- all commands returning strings other than "OK" or "ERR" now return bulk strings 
- the experimental `_MODELLIST` command has been renamed to `_MODELSCAN` (to prepare for the upcoming `TENSORLIST` data type)

Tests and docs have been updated.