### PR TITLE
Add possibility to provide a model in chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Note that Redis config is located at `/usr/local/etc/redis/redis.conf` which can
 
 On the client, set the model
 ```sh
-redis-cli -x AI.MODELSET foo TF CPU INPUTS a b OUTPUTS c < test/test_data/graph.pb
+redis-cli -x AI.MODELSET foo TF CPU INPUTS a b OUTPUTS c BLOB < test/test_data/graph.pb
 ```
 
 Then create the input tensors, run the computation graph and get the output tensor (see `load_model.sh`). Note the signatures:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -123,7 +123,7 @@ AI.TENSORGET foo META VALUES
 Set a model.
 
 ```sql
-AI.MODELSET model_key backend device [TAG tag] [BATCHSIZE n [MINBATCHSIZE m]] [INPUTS name1 name2 ... OUTPUTS name1 name2 ...] model_blob
+AI.MODELSET model_key backend device [TAG tag] [BATCHSIZE n [MINBATCHSIZE m]] [INPUTS name1 name2 ... OUTPUTS name1 name2 ...] BLOB model_blob
 ```
 
 * model_key - Key for storing the model
@@ -142,28 +142,29 @@ AI.MODELSET model_key backend device [TAG tag] [BATCHSIZE n [MINBATCHSIZE m]] [I
                    Default is 0 (no minimum batch size).
 * INPUTS name1 name2 ... - Name of the nodes in the provided graph corresponding to inputs [`TF` backend only]
 * OUTPUTS name1 name2 ... - Name of the nodes in the provided graph corresponding to outputs [`TF` backend only]
-* model_blob - Binary buffer containing the model protobuf saved from a supported backend
+* BLOB model_blob - Binary buffer containing the model protobuf saved from a supported backend. Since Redis supports strings
+                    up to 512MB, blobs for very large models need to be chunked, e.g. `BLOB chunk1 chunk2 ...`.
 
 ### MODELSET Example
 
 ```sql
-AI.MODELSET resnet18 TORCH GPU < foo.pt
+AI.MODELSET resnet18 TORCH GPU BLOB < foo.pt
 ```
 
 ```sql
-AI.MODELSET resnet18 TF CPU INPUTS in1 OUTPUTS linear4 < foo.pb
+AI.MODELSET resnet18 TF CPU INPUTS in1 OUTPUTS linear4 BLOB < foo.pb
 ```
 
 ```sql
-AI.MODELSET mnist_net ONNX CPU TAG mnist:lenet:v0.1 < mnist.onnx
+AI.MODELSET mnist_net ONNX CPU TAG mnist:lenet:v0.1 BLOB < mnist.onnx
 ```
 
 ```sql
-AI.MODELSET mnist_net ONNX CPU BATCHSIZE 10 < mnist.onnx
+AI.MODELSET mnist_net ONNX CPU BATCHSIZE 10 BLOB < mnist.onnx
 ```
 
 ```sql
-AI.MODELSET resnet18 TF CPU BATCHSIZE 10 MINBATCHSIZE 6 INPUTS in1 OUTPUTS linear4 < foo.pb
+AI.MODELSET resnet18 TF CPU BATCHSIZE 10 MINBATCHSIZE 6 INPUTS in1 OUTPUTS linear4 BLOB < foo.pb
 ```
 
 ## AI.MODELGET
@@ -284,13 +285,13 @@ AI._MODELSCAN
 Set a script.
 
 ```sql
-AI.SCRIPTSET script_key device [TAG tag] script_source
+AI.SCRIPTSET script_key device [TAG tag] SOURCE script_source
 ```
 
 * script_key - Key for storing the script
 * device - The device where the script will execute
 * TAG tag - Optional string tagging the script, such as a version number or other identifier
-* script_source - A string containing [TorchScript](https://pytorch.org/docs/stable/jit.html) source code
+* SOURCE script_source - A string containing [TorchScript](https://pytorch.org/docs/stable/jit.html) source code
 
 ### SCRIPTSET Example
 
@@ -302,11 +303,11 @@ def addtwo(a, b):
 ```
 
 ```sql
-AI.SCRIPTSET addscript GPU < addtwo.txt
+AI.SCRIPTSET addscript GPU SOURCE < addtwo.txt
 ```
 
 ```sql
-AI.SCRIPTSET addscript GPU TAG myscript:v0.1 < addtwo.txt
+AI.SCRIPTSET addscript GPU TAG myscript:v0.1 SOURCE < addtwo.txt
 ```
 
 ## AI.SCRIPTGET

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ docker run -p 6379:6379 -it --rm redisai/redisai
 On the client, load a backend (TF, TORCH or ONNX), and set the model
 ```sh
 redis-cli AI.CONFIG LOADBACKEND TF install/backends/redisai_tensorflow/redisai_tensorflow.so
-redis-cli -x AI.MODELSET foo TF CPU INPUTS a b OUTPUTS c < test/test_data/graph.pb
+redis-cli -x AI.MODELSET foo TF CPU INPUTS a b OUTPUTS c BLOB < test/test_data/graph.pb
 ```
 
 Then create the input tensors, run the computation graph and get the output tensor (see `load_model.sh`). Note the signatures:

--- a/test/tests_dag.py
+++ b/test/tests_dag.py
@@ -144,7 +144,7 @@ def test_dag_modelrun_financialNet_errors(env):
     model_pb, creditcard_transactions, creditcard_referencedata = load_creditcardfraud_data(
         env)
     ret = con.execute_command('AI.MODELSET', 'financialNet', 'TF', "CPU",
-                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', model_pb)
+                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     tensor_number=1
@@ -390,7 +390,7 @@ def test_dag_modelrun_financialNet_separate_tensorget(env):
     model_pb, creditcard_transactions, creditcard_referencedata = load_creditcardfraud_data(
         env)
     ret = con.execute_command('AI.MODELSET', 'financialNet', 'TF', "CPU",
-                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', model_pb)
+                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     tensor_number = 1
@@ -432,7 +432,7 @@ def test_dag_modelrun_financialNet(env):
     model_pb, creditcard_transactions, creditcard_referencedata = load_creditcardfraud_data(
         env)
     ret = con.execute_command('AI.MODELSET', 'financialNet', 'TF', "CPU",
-                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', model_pb)
+                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     tensor_number = 1
@@ -471,7 +471,7 @@ def test_dag_modelrun_financialNet_no_writes(env):
     model_pb, creditcard_transactions, creditcard_referencedata = load_creditcardfraud_data(
         env)
     ret = con.execute_command('AI.MODELSET', 'financialNet', 'TF', "CPU",
-                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', model_pb)
+                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     tensor_number = 1
@@ -522,7 +522,7 @@ def test_dagro_modelrun_financialNet_no_writes_multiple_modelruns(env):
     model_pb, creditcard_transactions, creditcard_referencedata = load_creditcardfraud_data(
         env)
     ret = con.execute_command('AI.MODELSET', 'financialNet', 'TF', DEVICE,
-                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', model_pb)
+                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     tensor_number = 1

--- a/test/tests_onnx.py
+++ b/test/tests_onnx.py
@@ -30,7 +30,7 @@ def test_onnx_modelrun_mnist(env):
     with open(sample_filename, 'rb') as f:
         sample_raw = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -39,7 +39,7 @@ def test_onnx_modelrun_mnist(env):
     env.assertEqual(len(ret), 6)
     env.assertEqual(ret[-1], b'')
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, 'TAG', 'asdf', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, 'TAG', 'asdf', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -53,14 +53,14 @@ def test_onnx_modelrun_mnist(env):
     # env.assertEqual(ret[1], b'CPU')
 
     try:
-        con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, wrong_model_pb)
+        con.execute_command('AI.MODELSET', 'm', 'ONNX', DEVICE, 'BLOB', wrong_model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
         env.assertEqual("No graph was found in the protobuf.", exception.__str__())
 
     try:
-        con.execute_command('AI.MODELSET', 'm_1', 'ONNX', model_pb)
+        con.execute_command('AI.MODELSET', 'm_1', 'ONNX', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -163,7 +163,7 @@ def test_onnx_modelrun_mnist_autobatch(env):
         sample_raw = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'm', 'ONNX', 'CPU',
-                              'BATCHSIZE', 2, 'MINBATCHSIZE', 2, model_pb)
+                              'BATCHSIZE', 2, 'MINBATCHSIZE', 2, 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 1, 1, 28, 28, 'BLOB', sample_raw)
@@ -213,10 +213,10 @@ def test_onnx_modelrun_iris(env):
     with open(logreg_model_filename, 'rb') as f:
         logreg_model = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, linear_model)
+    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, 'BLOB', linear_model)
     env.assertEqual(ret, b'OK')
 
-    ret = con.execute_command('AI.MODELSET', 'logreg', 'ONNX', DEVICE, logreg_model)
+    ret = con.execute_command('AI.MODELSET', 'logreg', 'ONNX', DEVICE, 'BLOB', logreg_model)
     env.assertEqual(ret, b'OK')
 
     con.execute_command('AI.TENSORSET', 'features', 'FLOAT', 1, 4, 'VALUES', 5.1, 3.5, 1.4, 0.2)
@@ -254,7 +254,7 @@ def test_onnx_modelinfo(env):
     with open(linear_model_filename, 'rb') as f:
         linear_model = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, linear_model)
+    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, 'BLOB', linear_model)
     env.assertEqual(ret, b'OK')
 
     model_serialized_master = con.execute_command('AI.MODELGET', 'linear', 'META')
@@ -309,7 +309,7 @@ def test_onnx_modelrun_disconnect(env):
     with open(linear_model_filename, 'rb') as f:
         linear_model = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, linear_model)
+    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, 'BLOB', linear_model)
     env.assertEqual(ret, b'OK')
 
     model_serialized_master = con.execute_command('AI.MODELGET', 'linear', 'META')
@@ -338,7 +338,7 @@ def test_onnx_model_rdb_save_load(env):
         model_pb = f.read()
 
     con = env.getConnection()
-    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, model_pb)
+    ret = con.execute_command('AI.MODELSET', 'linear', 'ONNX', DEVICE, 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     model_serialized_memory = con.execute_command('AI.MODELGET', 'linear', 'BLOB')

--- a/test/tests_pytorch.py
+++ b/test/tests_pytorch.py
@@ -30,7 +30,7 @@ def test_pytorch_modelrun(env):
     with open(wrong_model_filename, 'rb') as f:
         wrong_model_pb = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -39,7 +39,7 @@ def test_pytorch_modelrun(env):
     env.assertEqual(len(ret), 6)
     env.assertEqual(ret[-1], b'')
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, 'TAG', 'asdf', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, 'TAG', 'asdf', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -54,19 +54,19 @@ def test_pytorch_modelrun(env):
     # env.assertEqual(ret[1], b'CPU')
 
     try:
-        con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, wrong_model_pb)
+        con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, 'BLOB', wrong_model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_1', 'TORCH', model_pb)
+        con.execute_command('AI.MODELSET', 'm_1', 'TORCH', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
-        con.execute_command('AI.MODELSET', 'm_2', model_pb)
+        con.execute_command('AI.MODELSET', 'm_2', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -145,7 +145,7 @@ def test_pytorch_modelrun_autobatch(env):
         model_pb = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', 'CPU',
-                              'BATCHSIZE', 4, 'MINBATCHSIZE', 3, model_pb)
+                              'BATCHSIZE', 4, 'MINBATCHSIZE', 3, 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
@@ -188,7 +188,7 @@ def test_pytorch_modelinfo(env):
     with open(model_filename, 'rb') as f:
         model_pb = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, 'TAG', 'asdf', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, 'TAG', 'asdf', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
@@ -238,13 +238,19 @@ def test_pytorch_scriptset(env):
     con = env.getConnection()
 
     try:
-        con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, 'return 1')
+        con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, 'SOURCE', 'return 1')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
         con.execute_command('AI.SCRIPTSET', 'nope')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+
+    try:
+        con.execute_command('AI.SCRIPTSET', 'nope', 'SOURCE')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -261,7 +267,7 @@ def test_pytorch_scriptset(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    ret = con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, script)
+    ret = con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, 'SOURCE', script)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -269,7 +275,7 @@ def test_pytorch_scriptset(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    ret = con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, 'TAG', 'asdf', script)
+    ret = con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, 'TAG', 'asdf', 'SOURCE', script)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -297,7 +303,7 @@ def test_pytorch_scriptdel(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    ret = con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, script)
+    ret = con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, 'SOURCE', script)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -345,7 +351,7 @@ def test_pytorch_scriptrun(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    ret = con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, 'TAG', 'asdf', script)
+    ret = con.execute_command('AI.SCRIPTSET', 'ket', DEVICE, 'TAG', 'asdf', 'SOURCE', script)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
@@ -485,7 +491,7 @@ def test_pytorch_scriptinfo(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    ret = con.execute_command('AI.SCRIPTSET', 'ket_script', DEVICE, script)
+    ret = con.execute_command('AI.SCRIPTSET', 'ket_script', DEVICE, 'SOURCE', script)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
@@ -542,7 +548,7 @@ def test_pytorch_scriptrun_disconnect(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    ret = con.execute_command('AI.SCRIPTSET', 'ket_script', DEVICE, script)
+    ret = con.execute_command('AI.SCRIPTSET', 'ket_script', DEVICE, 'SOURCE', script)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
@@ -573,7 +579,7 @@ def test_pytorch_modelrun_disconnect(env):
     with open(model_filename, 'rb') as f:
         model_pb = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
@@ -601,10 +607,10 @@ def test_pytorch_modelscan_scriptscan(env):
     with open(model_filename, 'rb') as f:
         model_pb = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm1', 'TORCH', DEVICE, 'TAG', 'm:v1', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm1', 'TORCH', DEVICE, 'TAG', 'm:v1', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
-    ret = con.execute_command('AI.MODELSET', 'm2', 'TORCH', DEVICE, 'TAG', 'm:v1', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm2', 'TORCH', DEVICE, 'TAG', 'm:v1', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     script_filename = os.path.join(test_data_path, 'script.txt')
@@ -612,10 +618,10 @@ def test_pytorch_modelscan_scriptscan(env):
     with open(script_filename, 'rb') as f:
         script = f.read()
 
-    ret = con.execute_command('AI.SCRIPTSET', 's1', DEVICE, 'TAG', 's:v1', script)
+    ret = con.execute_command('AI.SCRIPTSET', 's1', DEVICE, 'TAG', 's:v1', 'SOURCE', script)
     env.assertEqual(ret, b'OK')
 
-    ret = con.execute_command('AI.SCRIPTSET', 's2', DEVICE, 'TAG', 's:v1', script)
+    ret = con.execute_command('AI.SCRIPTSET', 's2', DEVICE, 'TAG', 's:v1', 'SOURCE', script)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -648,7 +654,7 @@ def test_pytorch_model_rdb_save_load(env):
 
     con = env.getConnection()
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     model_serialized_memory = con.execute_command('AI.MODELGET', 'm', 'BLOB')

--- a/test/tests_tensorflow.py
+++ b/test/tests_tensorflow.py
@@ -30,7 +30,7 @@ def test_run_mobilenet(env):
     model_pb, labels, img = load_mobilenet_test_data()
 
     con.execute_command('AI.MODELSET', 'mobilenet', 'TF', DEVICE,
-                        'INPUTS', input_var, 'OUTPUTS', output_var, model_pb)
+                        'INPUTS', input_var, 'OUTPUTS', output_var, 'BLOB', model_pb)
 
     ensureSlaveSynced(con, env)
 
@@ -99,7 +99,7 @@ def test_run_mobilenet_multiproc(env):
 
     model_pb, labels, img = load_mobilenet_test_data()
     con.execute_command('AI.MODELSET', 'mobilenet', 'TF', DEVICE,
-                        'INPUTS', input_var, 'OUTPUTS', output_var, model_pb)
+                        'INPUTS', input_var, 'OUTPUTS', output_var, 'BLOB', model_pb)
     ensureSlaveSynced(con, env)
 
     run_test_multiproc(env, 30, run_mobilenet, (img, input_var, output_var))
@@ -138,7 +138,7 @@ def test_del_tf_model(env):
         model_pb = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
-                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -181,7 +181,7 @@ def test_run_tf_model(env):
         model_pb = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
-                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -191,7 +191,7 @@ def test_run_tf_model(env):
     env.assertEqual(ret[-1], b'')
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE, 'TAG', 'asdf',
-                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -252,7 +252,7 @@ def test_run_tf2_model(env):
         model_pb = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
-                              'INPUTS', 'x', 'OUTPUTS', 'Identity', model_pb)
+                              'INPUTS', 'x', 'OUTPUTS', 'Identity', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -262,7 +262,7 @@ def test_run_tf2_model(env):
     env.assertEqual(ret[-1], b'')
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE, 'TAG', 'asdf',
-                              'INPUTS', 'x', 'OUTPUTS', 'Identity', model_pb)
+                              'INPUTS', 'x', 'OUTPUTS', 'Identity', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -322,7 +322,7 @@ def test_run_tf_model_errors(env):
         wrong_model_pb = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
-                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ensureSlaveSynced(con, env)
@@ -358,7 +358,7 @@ def test_run_tf_model_errors(env):
 
     try:
         ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
-                                  'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', wrong_model_pb)
+                                  'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', wrong_model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -366,15 +366,15 @@ def test_run_tf_model_errors(env):
 
     try:
         con.execute_command('AI.MODELSET', 'm_1', 'TF',
-                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("INPUTS not specified", exception.__str__())
+        env.assertEqual("Invalid DEVICE", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_2', 'PORCH', DEVICE,
-                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -382,22 +382,22 @@ def test_run_tf_model_errors(env):
 
     try:
         con.execute_command('AI.MODELSET', 'm_3', 'TORCH', DEVICE,
-                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
 
     try:
         con.execute_command('AI.MODELSET', 'm_4', 'TF',
-                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("INPUTS not specified", exception.__str__())
+        env.assertEqual("Invalid DEVICE", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_5', 'TF', DEVICE,
-                            'INPUTS', 'a', 'b', 'c', 'OUTPUTS', 'mul', model_pb)
+                            'INPUTS', 'a', 'b', 'c', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -405,14 +405,14 @@ def test_run_tf_model_errors(env):
 
     try:
         con.execute_command('AI.MODELSET', 'm_6', 'TF', DEVICE,
-                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mult', model_pb)
+                            'INPUTS', 'a', 'b', 'OUTPUTS', 'mult', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
         env.assertEqual("Output node named \"mult\" not found in TF graph", exception.__str__())
 
     try:
-        con.execute_command('AI.MODELSET', 'm_7', 'TF', DEVICE, model_pb)
+        con.execute_command('AI.MODELSET', 'm_7', 'TF', DEVICE, 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -424,7 +424,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Invalid GraphDef", exception.__str__())
+        env.assertEqual("Insufficient arguments, missing model BLOB", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
@@ -432,7 +432,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Invalid GraphDef", exception.__str__())
+        env.assertEqual("Insufficient arguments, missing model BLOB", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
@@ -440,16 +440,15 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Invalid GraphDef", exception.__str__())
+        env.assertEqual("Insufficient arguments, missing model BLOB", exception.__str__())
 
-    # ERR Invalid GraphDef
     try:
         con.execute_command('AI.MODELSET', 'm_8', 'TF', DEVICE,
                             'INPUTS', 'a', 'b', 'OUTPUTS')
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Invalid GraphDef",exception.__str__())
+        env.assertEqual("Insufficient arguments, missing model BLOB",exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'b')
@@ -481,7 +480,7 @@ def test_run_tf_model_autobatch(env):
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', 'CPU',
                               'BATCHSIZE', 4, 'MINBATCHSIZE', 3,
-                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     con.execute_command('AI.TENSORSET', 'a', 'FLOAT',
@@ -526,7 +525,7 @@ def test_tensorflow_modelinfo(env):
         model_pb = f.read()
 
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
-                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
     info = con.execute_command('AI.INFO', 'm')  # Getting initial info before modelrun
     info_dict0 = info_to_dict(info)
@@ -536,7 +535,7 @@ def test_tensorflow_modelinfo(env):
 
     # second modelset; a corner case
     ret = con.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
-                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
     info = con.execute_command('AI.INFO', 'm')  # this will fail
     info_dict1 = info_to_dict(info)
@@ -594,7 +593,7 @@ def test_tensorflow_modelrun_disconnect(env):
         model_pb = f.read()
 
     ret = red.execute_command('AI.MODELSET', 'm', 'TF', DEVICE,
-                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', model_pb)
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ret = red.execute_command(
@@ -628,7 +627,7 @@ def test_tensorflow_modelrun_with_batch_and_minbatch(env):
                         'BATCHSIZE', batch_size, 'MINBATCHSIZE', minbatch_size,
                         'INPUTS', inputvar,
                         'OUTPUTS', outputvar,
-                        model_pb)
+                        'BLOB', model_pb)
     con.execute_command('AI.TENSORSET', 'input',
                         'FLOAT', 1, img.shape[1], img.shape[0], img.shape[2],
                         'BLOB', img.tobytes())
@@ -651,7 +650,7 @@ def test_tensorflow_modelrun_with_batch_and_minbatch(env):
                         'BATCHSIZE', batch_size, 'MINBATCHSIZE', minbatch_size,
                         'INPUTS', inputvar,
                         'OUTPUTS', outputvar,
-                        model_pb)
+                        'BLOB', model_pb)
 
     p1 = mp.Process(target=run, args=(another_model_name, 'final1'))
     p1.start()
@@ -694,7 +693,7 @@ def test_tensorflow_modelrun_financialNet(env):
         tensor_number = tensor_number + 1
 
     ret = con.execute_command('AI.MODELSET', 'financialNet', 'TF', DEVICE,
-                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', model_pb)
+                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     for tensor_number in range(1, 10001):
@@ -728,7 +727,7 @@ def test_tensorflow_modelrun_financialNet_multiproc(env):
         tensor_number = tensor_number + 1
 
     ret = con.execute_command('AI.MODELSET', 'financialNet', 'TF', DEVICE,
-                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', model_pb)
+                              'INPUTS', 'transaction', 'reference', 'OUTPUTS', 'output', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     def functor_financialNet(env, key_max, repetitions):

--- a/test/tests_tflite.py
+++ b/test/tests_tflite.py
@@ -31,14 +31,14 @@ def test_run_tflite_model(env):
     with open(sample_filename, 'rb') as f:
         sample_raw = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.MODELGET', 'm', 'META')
     env.assertEqual(len(ret), 6)
     env.assertEqual(ret[-1], b'')
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', 'TAG', 'asdf', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', 'TAG', 'asdf', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.MODELGET', 'm', 'META')
@@ -89,10 +89,10 @@ def test_run_tflite_model_errors(env):
     with open(sample_filename, 'rb') as f:
         sample_raw = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'm_2', 'TFLITE', 'CPU', model_pb2)
+    ret = con.execute_command('AI.MODELSET', 'm_2', 'TFLITE', 'CPU', 'BLOB', model_pb2)
     env.assertEqual(ret, b'OK')
 
-    ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', 'TAG', 'asdf', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU', 'TAG', 'asdf', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 1, 1, 28, 28, 'BLOB', sample_raw)
@@ -108,11 +108,11 @@ def test_run_tflite_model_errors(env):
         env.assertEqual("Insufficient arguments, missing model BLOB", exception.__str__())
 
     try:
-        con.execute_command('AI.MODELSET', 'm_2', model_pb)
+        con.execute_command('AI.MODELSET', 'm_2', 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("wrong number of arguments for 'AI.MODELSET' command", exception.__str__())
+        env.assertEqual("unsupported backend", exception.__str__())
 
     try:
         con.execute_command('AI.MODELRUN', 'm_2', 'INPUTS', 'EMPTY_TENSOR', 'OUTPUTS')
@@ -213,7 +213,7 @@ def test_run_tflite_model_autobatch(env):
 
     try:
         ret = con.execute_command('AI.MODELSET', 'm', 'TFLITE', 'CPU',
-                                  'BATCHSIZE', 2, 'MINBATCHSIZE', 2, model_pb)
+                                  'BATCHSIZE', 2, 'MINBATCHSIZE', 2, 'BLOB', model_pb)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
@@ -262,7 +262,7 @@ def test_tflite_modelinfo(env):
     with open(sample_filename, 'rb') as f:
         sample_raw = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'mnist', 'TFLITE', 'CPU', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'mnist', 'TFLITE', 'CPU', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 1, 1, 28, 28, 'BLOB', sample_raw)
@@ -316,7 +316,7 @@ def test_tflite_modelrun_disconnect(env):
     with open(sample_filename, 'rb') as f:
         sample_raw = f.read()
 
-    ret = red.execute_command('AI.MODELSET', 'mnist', 'TFLITE', 'CPU', model_pb)
+    ret = red.execute_command('AI.MODELSET', 'mnist', 'TFLITE', 'CPU', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     ret = red.execute_command('AI.TENSORSET', 'a', 'FLOAT', 1, 1, 28, 28, 'BLOB', sample_raw)
@@ -341,7 +341,7 @@ def test_tflite_model_rdb_save_load(env):
     with open(model_filename, 'rb') as f:
         model_pb = f.read()
 
-    ret = con.execute_command('AI.MODELSET', 'mnist', 'TFLITE', 'CPU', model_pb)
+    ret = con.execute_command('AI.MODELSET', 'mnist', 'TFLITE', 'CPU', 'BLOB', model_pb)
     env.assertEqual(ret, b'OK')
 
     model_serialized_memory = con.execute_command('AI.MODELGET', 'mnist', 'BLOB')


### PR DESCRIPTION
While testing on of the HuggingFace models (1.3 GB), `MODELSET` was failing due to the fact that Redis strings are limited to 512 MB.

This PR gives the possibility to provide a large model in chunks, overcoming the limitation (at the cost of a transient allocation + memcpy of a large chunk of memory, but for now there are no alternatives):
```
with open(model_filename, 'rb') as f:
    model = f.read()
chunk_size = 500 * 1024 * 1024
model_chunks = [model[i:i + chunk_size] for i in range(0, len(model), chunk_size)]
ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', DEVICE, 'BLOB', *model_chunks)
```

Note that the API has been changed. One now has to specify `BLOB` to signal the start of chunks:
```
AI.MODELSET foo TORCH CPU BLOB ...
```

For consistency, the same was done for SCRIPTSET, with the addition of `SOURCE`:
```
AI.SCRIPTSET foo CPU SOURCE ...
```

@hhsecond: we need to update the Python client both with `BLOB` and `SOURCE`, as well as chunking (detect if blob is larger than 512 MB and chunk it tansparently)