### PR TITLE
The display title of the site has a typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,4 @@ If you have questions, want to provide feedback or perhaps report an issue or [c
   * [Repository](https://github.com/RedisAI/RedisAI/issues)
 
 ## License
-RedisAI is licensed under the [Redis Source Available License Agreement](https://github.com/RedisAI/RedisAI/blob/master/LICENSE).
+RedisAI is licensed under the [Redis Source Available License Agreement](https://github.com/RedisAI/RedisAI/blob/master/LICENSE). 


### PR DESCRIPTION
https://oss.redislabs.com/redisai/ shows 
RedisAI - A Server for Maching and Deep Learning Models
s/Maching/Machine/ is the fix.
I added a whitespace at the end of this file, for the fix, but it is not here, it's elsewhere.