### PR TITLE
[fix] fixed title, and intro.md examples on modelset and scriptset

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -207,13 +207,13 @@ redis-cli doesn't provide a way to read files' contents, so to load the model wi
 
 ```
 cat graph.pb | docker exec -i redisai redis-cli -x \
-               AI.MODELSET mymodel TF CPU INPUTS a b OUTPUTS c
+               AI.MODELSET mymodel TF CPU INPUTS a b OUTPUTS c BLOB
 ```
 
 ??? example "Example: loading a model from command line"
     ```
     $ cat graph.pb | docker exec -i redisai redis-cli -x \
-               AI.MODELSET mymodel TF CPU INPUTS a b OUTPUTS c
+               AI.MODELSET mymodel TF CPU INPUTS a b OUTPUTS c BLOB
     OK
     ```
 
@@ -313,7 +313,7 @@ def multiply(a, b):
 Assuming that the script is stored in the 'myscript.py' file it can be uploaded via command line and the `AI.SCRIPTSET` command as follows:
 
 ```
-cat myscript.py | docker exec -i redisai redis-cli -x AI.SCRIPTSET myscript CPU
+cat myscript.py | docker exec -i redisai redis-cli -x AI.SCRIPTSET myscript CPU SOURCE
 ```
 
 This will store the PyTorch Script from 'myscript.py' under the 'myscript' key and will associate it with the CPU device for execution. Once loaded, the script can be run with the following:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: RedisAI - A Server for Maching and Deep Learning Models
+site_name: RedisAI - A Server for Machine and Deep Learning Models
 site_url: http://redisai.io
 repo_url: https://github.com/RedisAI/RedisAI
 repo_name: RedisAI/RedisAI


### PR DESCRIPTION
@lantiga just verified that the intro.md doc is not update to the `SOURCE` and `BLOB` added keywords. Also fixes the typo on the title of docs
try
```
cat graph.pb | docker exec -i redisai redis-cli -x \
               AI.MODELSET mymodel TF CPU INPUTS a b OUTPUTS c
```
error
```
(error) ERR Insufficient arguments, missing model BLOB
```
----------------------------------------
try
```
cat myscript.py | docker exec -i redisai redis-cli -x AI.SCRIPTSET myscript CPU
```
error
```
(error) ERR Insufficient arguments, missing script SOURCE
```