### PR TITLE
Enable chunking for large models in AOF, RDB, replication and MODELGET

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -220,7 +220,7 @@ An array of alternating key-value pairs as follows:
 1. **MINBATCHSIZE**: The minimum size of any batch of incoming requests.
 1. **INPUTS**: array reply with one or more names of the model's input nodes (applicable only for TensorFlow models)
 1. **OUTPUTS**: array reply with one or more names of the model's output nodes (applicable only for TensorFlow models)
-1. **BLOB**: a blob containing the serialized model (when called with the `BLOB` argument) as a String
+1. **BLOB**: a blob containing the serialized model (when called with the `BLOB` argument) as a String. If the size of the serialized model exceeds `MODEL_CHUNK_SIZE` (see `AI.CONFIG` command), then an array of chunks is returned. The full serialized model can be obtained by concatenating the chunks.
 
 **Examples**
 
@@ -719,6 +719,7 @@ _Arguments_
     * **TFLITE**: The TensorFlow Lite backend
     * **TORCH**: The PyTorch backend
     * **ONNX**: ONNXRuntime backend
+* **MODEL_CHUNK_SIZE**: Sets the size of chunks (in bytes) in which model payloads are split for serialization, replication and `MODELGET`. Default is `511 * 1024 * 1024`.
 
 _Return_
 
@@ -744,5 +745,12 @@ This loads the PyTorch backend with a full path:
 
 ```
 redis> AI.CONFIG LOADBACKEND TORCH /usr/lib/redis/modules/redisai/backends/redisai_torch/redisai_torch.so
+OK
+```
+
+This sets model chunk size to one megabyte (not recommended):
+
+```
+redis> AI.CONFIG MODEL_CHUNK_SIZE 1048576
 OK
 ```

--- a/src/config.c
+++ b/src/config.c
@@ -244,44 +244,31 @@ int RAI_configParamParse(RedisModuleCtx *ctx, const char *key,
   else if (strcasecmp((key), "THREADS_PER_QUEUE") == 0) {
     ret = RedisAI_Config_QueueThreads(rsval);
     if (ret == REDISMODULE_OK) {
-      char *buffer = RedisModule_Alloc(
-          (3 + strlen(REDISAI_INFOMSG_THREADS_PER_QUEUE) + strlen((val))) *
-          sizeof(*buffer));
-      sprintf(buffer, "%s: %s", REDISAI_INFOMSG_THREADS_PER_QUEUE, (val));
-      RedisModule_Log(ctx, "notice", buffer);
-      RedisModule_Free(buffer);
+      RedisModule_Log(ctx, "notice", "%s: %s",
+                      REDISAI_INFOMSG_THREADS_PER_QUEUE,
+                      (val));
     }
   } else if (strcasecmp((key), "INTRA_OP_PARALLELISM") == 0) {
     ret = RedisAI_Config_IntraOperationParallelism(rsval);
     if (ret == REDISMODULE_OK) {
-      char *buffer = RedisModule_Alloc(
-          (3 + strlen(REDISAI_INFOMSG_INTRA_OP_PARALLELISM) + strlen((val))) *
-          sizeof(*buffer));
-      sprintf(buffer, "%s: %lld", REDISAI_INFOMSG_INTRA_OP_PARALLELISM,
-              getBackendsIntraOpParallelism());
-      RedisModule_Log(ctx, "notice", buffer);
-      RedisModule_Free(buffer);
+      RedisModule_Log(ctx, "notice", "%s: %lld",
+                      REDISAI_INFOMSG_INTRA_OP_PARALLELISM,
+                      getBackendsIntraOpParallelism());
     }
   } else if (strcasecmp((key), "INTER_OP_PARALLELISM") == 0) {
     ret = RedisAI_Config_InterOperationParallelism(rsval);
     if (ret == REDISMODULE_OK) {
-      char *buffer = RedisModule_Alloc(
-          (3 + strlen(REDISAI_INFOMSG_INTER_OP_PARALLELISM) + strlen((val))) *
-          sizeof(*buffer));
-      sprintf(buffer, "%s: %lld", REDISAI_INFOMSG_INTER_OP_PARALLELISM,
-              getBackendsInterOpParallelism());
-      RedisModule_Log(ctx, "notice", buffer);
-      RedisModule_Free(buffer);
+      RedisModule_Log(ctx, "notice", "%s: %lld",
+                      REDISAI_INFOMSG_INTER_OP_PARALLELISM,
+                      getBackendsInterOpParallelism());
     }
   } else if (strcasecmp((key), "MODEL_CHUNK_SIZE") == 0) {
-    RedisAI_Config_ModelChunkSize(rsval);
-    char *buffer = RedisModule_Alloc(
-        (3 + strlen(REDISAI_INFOMSG_MODEL_CHUNK_SIZE) + strlen((val))) *
-        sizeof(*buffer));
-    sprintf(buffer, "%s: %lld", REDISAI_INFOMSG_MODEL_CHUNK_SIZE,
-            getModelChunkSize());
-    RedisModule_Log(ctx, "notice", buffer);
-    RedisModule_Free(buffer);
+    ret = RedisAI_Config_ModelChunkSize(rsval);
+    if (ret == REDISMODULE_OK) {
+      RedisModule_Log(ctx, "notice", "%s: %lld",
+                      REDISAI_INFOMSG_MODEL_CHUNK_SIZE,
+                      getModelChunkSize());
+    }
   } else if (strcasecmp((key), "BACKENDSPATH") == 0) {
     // already taken care of
   } else {

--- a/src/config.c
+++ b/src/config.c
@@ -20,6 +20,7 @@ long long backends_intra_op_parallelism;  //  number of threads used within an
 long long
     backends_inter_op_parallelism;  //  number of threads used for parallelism
                                     //  between independent operations.
+long long model_chunk_size;  // size of chunks used to break up model payloads.
 
 /**
  *
@@ -64,6 +65,30 @@ int setBackendsIntraOpParallelism(long long num_threads) {
   int result = 1;
   if (num_threads >= 0) {
     backends_intra_op_parallelism = num_threads;
+    result = 0;
+  }
+  return result;
+}
+
+/**
+ * @return size of chunks (in bytes) in which models are split for
+ * set, get, serialization and replication.
+ */
+long long getModelChunkSize() {
+  return model_chunk_size;
+}
+
+/**
+ * Set size of chunks (in bytes) in which models are split for set,
+ * get, serialization and replication.
+ *
+ * @param size
+ * @return 0 on success, or 1  if failed
+ */
+int setModelChunkSize(long long size) {
+  int result = 1;
+  if (size > 0) {
+    model_chunk_size = size;
     result = 0;
   }
   return result;
@@ -176,6 +201,25 @@ int RedisAI_Config_IntraOperationParallelism(
 }
 
 /**
+ * Set size of chunks in which model payloads are split for set,
+ * get, serialization and replication.
+ *
+ * @param chunk_size_string string containing chunk size (in bytes)
+ * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
+ */
+int RedisAI_Config_ModelChunkSize(RedisModuleString *chunk_size_string) {
+  long long temp;
+  int result = RedisModule_StringToLongLong(chunk_size_string, &temp);
+  // make sure chunk size is a positive integer
+  // if not set the value to the default
+  if (result == REDISMODULE_OK && temp < 1) {
+    temp = REDISAI_DEFAULT_MODEL_CHUNK_SIZE;
+    result = REDISMODULE_ERR;
+  }
+  return result;
+}
+
+/**
  *
  * @param ctx Context in which Redis modules operate
  * @param key
@@ -228,6 +272,15 @@ int RAI_configParamParse(RedisModuleCtx *ctx, const char *key,
       RedisModule_Log(ctx, "notice", buffer);
       RedisModule_Free(buffer);
     }
+  } else if (strcasecmp((key), "MODEL_CHUNK_SIZE") == 0) {
+    RedisAI_Config_ModelChunkSize(rsval);
+    char *buffer = RedisModule_Alloc(
+        (3 + strlen(REDISAI_INFOMSG_MODEL_CHUNK_SIZE) + strlen((val))) *
+        sizeof(*buffer));
+    sprintf(buffer, "%s: %lld", REDISAI_INFOMSG_MODEL_CHUNK_SIZE,
+            getModelChunkSize());
+    RedisModule_Log(ctx, "notice", buffer);
+    RedisModule_Free(buffer);
   } else if (strcasecmp((key), "BACKENDSPATH") == 0) {
     // already taken care of
   } else {

--- a/src/config.c
+++ b/src/config.c
@@ -216,6 +216,7 @@ int RedisAI_Config_ModelChunkSize(RedisModuleString *chunk_size_string) {
     temp = REDISAI_DEFAULT_MODEL_CHUNK_SIZE;
     result = REDISMODULE_ERR;
   }
+  result = setModelChunkSize(temp);
   return result;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -142,6 +142,16 @@ int RedisAI_Config_IntraOperationParallelism(
     RedisModuleString *num_threads_string);
 
 /**
+ * Set size of chunks in which model payloads are split for set,
+ * get, serialization and replication.
+ *
+ * @param chunk_size_string string containing chunk size (in bytes)
+ * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
+ */
+int RedisAI_Config_ModelChunkSize(
+    RedisModuleString *chunk_size_string);
+
+/**
  *
  * @param ctx Context in which Redis modules operate
  * @param key

--- a/src/config.h
+++ b/src/config.h
@@ -23,6 +23,7 @@ typedef enum { RAI_DEVICE_CPU = 0, RAI_DEVICE_GPU = 1 } RAI_Device;
 #define REDISAI_DEFAULT_THREADS_PER_QUEUE 1
 #define REDISAI_DEFAULT_INTRA_OP_PARALLELISM 0
 #define REDISAI_DEFAULT_INTER_OP_PARALLELISM 0
+#define REDISAI_DEFAULT_MODEL_CHUNK_SIZE 535822336 // (511 * 1024 * 1024)
 #define REDISAI_ERRORMSG_PROCESSING_ARG "ERR error processing argument"
 #define REDISAI_ERRORMSG_THREADS_PER_QUEUE \
   "ERR error setting THREADS_PER_QUEUE to"
@@ -37,6 +38,8 @@ typedef enum { RAI_DEVICE_CPU = 0, RAI_DEVICE_GPU = 1 } RAI_Device;
   "Setting INTRA_OP_PARALLELISM parameter to"
 #define REDISAI_INFOMSG_INTER_OP_PARALLELISM \
   "Setting INTER_OP_PARALLELISM parameter to"
+#define REDISAI_INFOMSG_MODEL_CHUNK_SIZE \
+  "Setting MODEL_CHUNK_SIZE parameter to"
 
 /**
  * Get number of threads used for parallelism between independent operations, by
@@ -71,6 +74,21 @@ long long getBackendsIntraOpParallelism();
  * @return 0 on success, or 1  if failed
  */
 int setBackendsIntraOpParallelism(long long num_threads);
+
+/**
+ * @return size of chunks (in bytes) in which models are split for
+ * set, get, serialization and replication.
+ */
+long long getModelChunkSize();
+
+/**
+ * Set size of chunks (in bytes) in which models are split for set,
+ * get, serialization and replication.
+ *
+ * @param size
+ * @return 0 on success, or 1  if failed
+ */
+int setModelChunkSize(long long size);
 
 /**
  * Helper method for AI.CONFIG LOADBACKEND <backend_identifier>

--- a/src/model_struct.h
+++ b/src/model_struct.h
@@ -46,6 +46,4 @@ typedef struct RAI_ModelRunCtx {
   RAI_ModelCtxParam* outputs;
 } RAI_ModelRunCtx;
 
-static const size_t RAI_CHUNK_LEN = 511 * 1024 * 1024;
-
 #endif /* SRC_MODEL_STRUCT_H_ */

--- a/src/model_struct.h
+++ b/src/model_struct.h
@@ -46,4 +46,6 @@ typedef struct RAI_ModelRunCtx {
   RAI_ModelCtxParam* outputs;
 } RAI_ModelRunCtx;
 
+static const size_t RAI_CHUNK_LEN = 511 * 1024 * 1024;
+
 #endif /* SRC_MODEL_STRUCT_H_ */

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -456,7 +456,12 @@ int RedisAI_ModelGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   if (meta && blob) {
     RedisModule_ReplyWithCString(ctx, "blob");
-    RedisModule_ReplyWithStringBuffer(ctx, buffer, len);
+    const size_t n_chunks = len / RAI_CHUNK_LEN + 1;
+    RedisModule_ReplyWithArray(ctx, (long)n_chunks);
+    for (size_t i=0; i<n_chunks; i++) {
+      size_t chunk_len = i < n_chunks - 1 ? RAI_CHUNK_LEN : len % RAI_CHUNK_LEN;
+      RedisModule_ReplyWithStringBuffer(ctx, buffer + i * RAI_CHUNK_LEN, chunk_len);
+    }
     RedisModule_Free(buffer);
   }
 

--- a/src/script.c
+++ b/src/script.c
@@ -14,6 +14,7 @@
 #include "stats.h"
 #include "util/arr_rm_alloc.h"
 #include <pthread.h>
+#include "version.h"
 
 RedisModuleType* RedisAI_ScriptType = NULL;
 
@@ -83,8 +84,8 @@ static void RAI_Script_AofRewrite(RedisModuleIO* aof, RedisModuleString* key,
                                   void* value) {
   RAI_Script* script = (RAI_Script*)value;
 
-  RedisModule_EmitAOF(aof, "AI.SCRIPTSET", "sccc", key, script->devicestr,
-                      script->tag, script->scriptdef);
+  RedisModule_EmitAOF(aof, "AI.SCRIPTSET", "scccc", key, script->devicestr,
+                      script->tag, "SOURCE", script->scriptdef);
 }
 
 static void RAI_Script_DTFree(void* value) {
@@ -106,7 +107,7 @@ int RAI_ScriptInit(RedisModuleCtx* ctx) {
                                      .digest = NULL};
 
   RedisAI_ScriptType =
-      RedisModule_CreateDataType(ctx, "AI_SCRIPT", 0, &tmScript);
+      RedisModule_CreateDataType(ctx, "AI_SCRIPT", RAI_ENC_VER_MM, &tmScript);
   return RedisAI_ScriptType != NULL;
 }
 

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -242,7 +242,7 @@ int RAI_TensorInit(RedisModuleCtx* ctx){
       .free = RAI_Tensor_DTFree,
       .digest = NULL,
   };
-  RedisAI_TensorType = RedisModule_CreateDataType(ctx, "AI_TENSOR", 0, &tmTensor);
+  RedisAI_TensorType = RedisModule_CreateDataType(ctx, "AI_TENSOR", RAI_ENC_VER_MM, &tmTensor);
   return RedisAI_TensorType != NULL;
 }
 

--- a/src/version.h
+++ b/src/version.h
@@ -6,4 +6,9 @@
 /* API versions. */
 #define REDISAI_LLAPI_VERSION 1
 
+/* This is the major / minor encver, to be used as
+   argument to RM_CreateDataType, which expects
+   encver to be < 1024 */
+static const long long RAI_ENC_VER_MM = RAI_ENC_VER == 999999 ? 1023 : RAI_ENC_VER / 100;
+
 #endif /* SRC_VERSION_H_ */

--- a/test/tests_pytorch.py
+++ b/test/tests_pytorch.py
@@ -32,6 +32,16 @@ def test_pytorch_chunked_modelset(env):
 
     env.assertEqual(model1, model2)
 
+    ret = con.execute_command('AI.CONFIG', 'MODEL_CHUNK_SIZE', chunk_size)
+
+    model2 = con.execute_command('AI.MODELGET', 'm2', 'BLOB')
+    env.assertEqual(len(model2), len(model_chunks))
+    env.assertTrue(all([el1 == el2 for el1, el2 in zip(model2, model_chunks)]))
+
+    model3 = con.execute_command('AI.MODELGET', 'm2', 'META', 'BLOB')[-1]
+    env.assertEqual(len(model3), len(model_chunks))
+    env.assertTrue(all([el1 == el2 for el1, el2 in zip(model3, model_chunks)]))
+
 
 def test_pytorch_modelrun(env):
     if not TEST_PT:


### PR DESCRIPTION
Addresses #386 

Tests are missing, we need a strategy for downloading a large (512 MB) model from CI.

Note: this PR changes the format of RDB. Versioning is handled, ie older RDB are still loaded correctly.