### PR TITLE
Add support for variadic arguments to SCRIPT

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -458,14 +458,16 @@ The **`AI.SCRIPTRUN`** command runs a script stored as a key's value on its spec
 **Redis API**
 
 ```
-AI.SCRIPTRUN <key> <function> INPUTS <input> [input ...] OUTPUTS <output> [output ...]
+AI.SCRIPTRUN <key> <function> INPUTS <input> [input ...] [$ input ...] OUTPUTS <output> [output ...]
 ```
 
 _Arguments_
 
 * **key**: the script's key name
 * **function**: the name of the function to run
-* **INPUTS**: denotes the beginning of the input tensors keys' list, followed by one or more key names
+* **INPUTS**: denotes the beginning of the input tensors keys' list, followed by one or more key names;
+              variadic arguments are supported by prepending the list with `$`, in this case the
+              script is expected an argument of type `List[Tensor]` as its last argument
 * **OUTPUTS**: denotes the beginning of the output tensors keys' list, followed by one or more key names
 
 _Return_
@@ -482,6 +484,29 @@ OK
 redis> AI.TENSORSET mytensor2 FLOAT 1 VALUES 2
 OK
 redis> AI.SCRIPTRUN myscript addtwo INPUTS mytensor1 mytensor2 OUTPUTS result
+OK
+redis> AI.TENSORGET result VALUES
+1) FLOAT
+2) 1) (integer) 1
+3) 1) "42"
+```
+
+If 'myscript' supports variadic arguments:
+```python
+def addn(a, args : List[Tensor]):
+    return a + torch.stack(args).sum()
+```
+
+then one can provide an arbitrary number of inputs after the `$` sign:
+
+```
+redis> AI.TENSORSET mytensor1 FLOAT 1 VALUES 40
+OK
+redis> AI.TENSORSET mytensor2 FLOAT 1 VALUES 1
+OK
+redis> AI.TENSORSET mytensor3 FLOAT 1 VALUES 1
+OK
+redis> AI.SCRIPTRUN myscript addn INPUTS mytensor1 $ mytensor2 mytensor3 OUTPUTS result
 OK
 redis> AI.TENSORGET result VALUES
 1) FLOAT

--- a/src/backends/torch.c
+++ b/src/backends/torch.c
@@ -252,6 +252,7 @@ int RAI_ScriptRunTorch(RAI_ScriptRunCtx* sctx, RAI_Error* error) {
 
   char* error_descr = NULL;
   torchRunScript(sctx->script->script, sctx->fnname,
+                 sctx->variadic,
                  nInputs, inputs, nOutputs, outputs,
                  &error_descr, RedisModule_Alloc);
 

--- a/src/libtorch_c/torch_c.h
+++ b/src/libtorch_c/torch_c.h
@@ -19,7 +19,7 @@ void* torchCompileScript(const char* script, DLDeviceType device, int64_t device
 void* torchLoadModel(const char* model, size_t modellen, DLDeviceType device, int64_t device_id,
                      char **error, void* (*alloc)(size_t));
 
-void torchRunScript(void* scriptCtx, const char* fnName,
+void torchRunScript(void* scriptCtx, const char* fnName, int variadic,
                     long nInputs, DLManagedTensor** inputs,
                     long nOutputs, DLManagedTensor** outputs,
                     char **error, void* (*alloc)(size_t));

--- a/src/script.c
+++ b/src/script.c
@@ -150,6 +150,7 @@ RAI_ScriptRunCtx* RAI_ScriptRunCtxCreate(RAI_Script* script,
   sctx->inputs = array_new(RAI_ScriptCtxParam, PARAM_INITIAL_SIZE);
   sctx->outputs = array_new(RAI_ScriptCtxParam, PARAM_INITIAL_SIZE);
   sctx->fnname = RedisModule_Strdup(fnname);
+  sctx->variadic = -1;
   return sctx;
 }
 
@@ -285,6 +286,10 @@ int RedisAI_Parse_ScriptRun_RedisCommand(RedisModuleCtx *ctx,
             is_input = 1;
             outputs_flag_count = 1;
         } else {
+            if (!strcasecmp(arg_string, "$")) {
+              (*sctx)->variadic = argpos - 4;
+              continue;
+            }
             RedisModule_RetainString(ctx, argv[argpos]);
             if (is_input == 0) {
                 RAI_Tensor *inputTensor;
@@ -299,18 +304,18 @@ int RedisAI_Parse_ScriptRun_RedisCommand(RedisModuleCtx *ctx,
                     RedisModule_CloseKey(tensorKey);
                 } else {
                     const int get_result = RAI_getTensorFromLocalContext(
-                            ctx, *localContextDict, arg_string, &inputTensor,error);
+                            ctx, *localContextDict, arg_string, &inputTensor, error);
                     if (get_result == REDISMODULE_ERR) {
                         return -1;
                     }
                 }
                 if (!RAI_ScriptRunCtxAddInput(*sctx, inputTensor)) {
-                    RedisAI_ReplyOrSetError(ctx,error,RAI_ESCRIPTRUN, "ERR Input key not found");
+                    RedisAI_ReplyOrSetError(ctx, error, RAI_ESCRIPTRUN, "ERR Input key not found");
                     return -1;
                 }
             } else {
                 if (!RAI_ScriptRunCtxAddOutput(*sctx)) {
-                    RedisAI_ReplyOrSetError(ctx,error,RAI_ESCRIPTRUN, "ERR Output key not found");
+                    RedisAI_ReplyOrSetError(ctx, error, RAI_ESCRIPTRUN, "ERR Output key not found");
                     return -1;
                 }
                 *outkeys=array_append(*outkeys,argv[argpos]);

--- a/src/script_struct.h
+++ b/src/script_struct.h
@@ -27,6 +27,7 @@ typedef struct RAI_ScriptRunCtx {
   char* fnname;
   RAI_ScriptCtxParam* inputs;
   RAI_ScriptCtxParam* outputs;
+  int variadic;
 } RAI_ScriptRunCtx;
 
 #endif /* SRC_SCRIPT_STRUCT_H_ */

--- a/test/test_data/script.txt
+++ b/test/test_data/script.txt
@@ -1,2 +1,5 @@
 def bar(a, b):
     return a + b
+
+def bar_variadic(a, args : List[Tensor]):
+    return args[0] + args[1]

--- a/test/tests_pytorch.py
+++ b/test/tests_pytorch.py
@@ -426,6 +426,61 @@ def test_pytorch_scriptrun(env):
         values2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')
         env.assertEqual(values2, values)
 
+
+def test_pytorch_scriptrun_variadic(env):
+    if not TEST_PT:
+        env.debugPrint("skipping {} since TEST_PT=0".format(sys._getframe().f_code.co_name), force=True)
+        return
+
+    con = env.getConnection()
+
+    test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
+    script_filename = os.path.join(test_data_path, 'script.txt')
+
+    with open(script_filename, 'rb') as f:
+        script = f.read()
+
+    ret = con.execute_command('AI.SCRIPTSET', 'myscript', DEVICE, 'TAG', 'version1', 'SOURCE', script)
+    env.assertEqual(ret, b'OK')
+
+    ret = con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
+    env.assertEqual(ret, b'OK')
+    ret = con.execute_command('AI.TENSORSET', 'b1', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
+    env.assertEqual(ret, b'OK')
+    ret = con.execute_command('AI.TENSORSET', 'b2', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
+    env.assertEqual(ret, b'OK')
+
+    ensureSlaveSynced(con, env)
+
+    for _ in range( 0,100):
+        ret = con.execute_command('AI.SCRIPTRUN', 'myscript', 'bar_variadic', 'INPUTS', 'a', '$', 'b1', 'b2', 'OUTPUTS', 'c')
+        env.assertEqual(ret, b'OK')
+
+    ensureSlaveSynced(con, env)
+
+    info = con.execute_command('AI.INFO', 'myscript')
+    info_dict_0 = info_to_dict(info)
+
+    env.assertEqual(info_dict_0['key'], 'myscript')
+    env.assertEqual(info_dict_0['type'], 'SCRIPT')
+    env.assertEqual(info_dict_0['backend'], 'TORCH')
+    env.assertEqual(info_dict_0['tag'], 'version1')
+    env.assertTrue(info_dict_0['duration'] > 0)
+    env.assertEqual(info_dict_0['samples'], -1)
+    env.assertEqual(info_dict_0['calls'], 100)
+    env.assertEqual(info_dict_0['errors'], 0)
+
+    values = con.execute_command('AI.TENSORGET', 'c', 'VALUES')
+    env.assertEqual(values, [b'4', b'6', b'4', b'6'])
+
+    ensureSlaveSynced(con, env)
+
+    if env.useSlaves:
+        con2 = env.getSlaveConnection()
+        values2 = con2.execute_command('AI.TENSORGET', 'c', 'VALUES')
+        env.assertEqual(values2, values)
+
+
 def test_pytorch_scriptrun_errors(env):
     if not TEST_PT:
         env.debugPrint("skipping {} since TEST_PT=0".format(sys._getframe().f_code.co_name), force=True)


### PR DESCRIPTION
This PR addresses #392.
A slightly different command API was chosen to keep things efficient.

We use the `$` sign to signal that `INPUTS` following that sign will be passed to the script as a list:
```
redis-cli -x AI.SCRIPTSET foo CPU SOURCE < foo.py
redis-cli AI.TENSORSET a FLOAT 1 1 VALUES 1
redis-cli AI.TENSORSET b FLOAT 1 1 VALUES 1
redis-cli AI.TENSORSET c FLOAT 1 1 VALUES 1
redis-cli AI.SCRIPTRUN foo foo INPUTS a $ b c OUTPUTS d
redis-cli AI.TENSORGET d META VALUES
```

The corresponding script will need to be type-annotated with `List[Tensor]` for the last argument
```
def foo(a : Tensor, args: List[Tensor]):
    return a + torch.stack(args).sum()
```

Within the script, `args` will act as a standard Python list containing tensors.

Test has been added and docs have been updated.