### PR TITLE
added low level api return redis types

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -645,3 +645,7 @@ int RedisAI_Parse_ModelRun_RedisCommand(RedisModuleCtx *ctx,
   }
   return argpos;
 }
+
+RedisModuleType *RAI_getModelRedisType(void) {
+    return RedisAI_ModelType;
+}

--- a/src/model.h
+++ b/src/model.h
@@ -225,4 +225,11 @@ int RedisAI_Parse_ModelRun_RedisCommand(
     RAI_ModelRunCtx** mctx, RedisModuleString*** outkeys, RAI_Model** mto,
     int useLocalContext, AI_dict** localContextDict, int use_chaining_operator,
     const char* chaining_operator, RAI_Error* error);
+
+/**
+ * @brief  Returns the redis module type representing a model.
+ * @return redis module type representing a model.
+ */
+RedisModuleType *RAI_ModelRedisType(void);
+
 #endif /* SRC_MODEL_H_ */

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -966,6 +966,7 @@ static int RedisAI_RegisterApi(RedisModuleCtx* ctx) {
   REGISTER_API(TensorDim, ctx);
   REGISTER_API(TensorByteSize, ctx);
   REGISTER_API(TensorData, ctx);
+  REGISTER_API(TensorRedisType, ctx);
 
   REGISTER_API(ModelCreate, ctx);
   REGISTER_API(ModelFree, ctx);
@@ -978,6 +979,7 @@ static int RedisAI_RegisterApi(RedisModuleCtx* ctx) {
   REGISTER_API(ModelRun, ctx);
   REGISTER_API(ModelSerialize, ctx);
   REGISTER_API(ModelGetShallowCopy, ctx);
+  REGISTER_API(ModelRedisType, ctx);
 
   REGISTER_API(ScriptCreate, ctx);
   REGISTER_API(ScriptFree, ctx);
@@ -989,6 +991,7 @@ static int RedisAI_RegisterApi(RedisModuleCtx* ctx) {
   REGISTER_API(ScriptRunCtxFree, ctx);
   REGISTER_API(ScriptRun, ctx);
   REGISTER_API(ScriptGetShallowCopy, ctx);
+  REGISTER_API(ScriptRedisType, ctx);
 
   return REDISMODULE_OK;
 }

--- a/src/redisai.h
+++ b/src/redisai.h
@@ -78,6 +78,7 @@ int MODULE_API_FUNC(RedisAI_TensorNumDims)(RAI_Tensor* t);
 long long MODULE_API_FUNC(RedisAI_TensorDim)(RAI_Tensor* t, int dim);
 size_t MODULE_API_FUNC(RedisAI_TensorByteSize)(RAI_Tensor* t);
 char* MODULE_API_FUNC(RedisAI_TensorData)(RAI_Tensor* t);
+RedisModuleType MODULE_API_FUNC(RedisAI_TensorRedisType)(void);
 
 RAI_Model* MODULE_API_FUNC(RedisAI_ModelCreate)(int backend, char* devicestr, char* tag, RAI_ModelOpts opts,
                                                 size_t ninputs, const char **inputs,
@@ -93,6 +94,7 @@ void MODULE_API_FUNC(RedisAI_ModelRunCtxFree)(RAI_ModelRunCtx* mctx);
 int MODULE_API_FUNC(RedisAI_ModelRun)(RAI_ModelRunCtx** mctx, long long n, RAI_Error* err);
 RAI_Model* MODULE_API_FUNC(RedisAI_ModelGetShallowCopy)(RAI_Model* model);
 int MODULE_API_FUNC(RedisAI_ModelSerialize)(RAI_Model *model, char **buffer, size_t *len, RAI_Error *err);
+RedisModuleType MODULE_API_FUNC(RedisAI_ModelRedisType)(void);
 
 RAI_Script* MODULE_API_FUNC(RedisAI_ScriptCreate)(char* devicestr, char* tag, const char* scriptdef, RAI_Error* err);
 void MODULE_API_FUNC(RedisAI_ScriptFree)(RAI_Script* script, RAI_Error* err);
@@ -104,6 +106,7 @@ RAI_Tensor* MODULE_API_FUNC(RedisAI_ScriptRunCtxOutputTensor)(RAI_ScriptRunCtx* 
 void MODULE_API_FUNC(RedisAI_ScriptRunCtxFree)(RAI_ScriptRunCtx* sctx);
 int MODULE_API_FUNC(RedisAI_ScriptRun)(RAI_ScriptRunCtx* sctx, RAI_Error* err);
 RAI_Script* MODULE_API_FUNC(RedisAI_ScriptGetShallowCopy)(RAI_Script* script);
+RedisModuleType MODULE_API_FUNC(RedisAI_ScriptRedisType)(void);
 
 int MODULE_API_FUNC(RedisAI_GetLLAPIVersion)();
 
@@ -145,6 +148,7 @@ static int RedisAI_Initialize(RedisModuleCtx* ctx){
   REDISAI_MODULE_INIT_FUNCTION(ctx, TensorDim);
   REDISAI_MODULE_INIT_FUNCTION(ctx, TensorByteSize);
   REDISAI_MODULE_INIT_FUNCTION(ctx, TensorData);
+  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorRedisType);
 
   REDISAI_MODULE_INIT_FUNCTION(ctx, ModelCreate);
   REDISAI_MODULE_INIT_FUNCTION(ctx, ModelFree);
@@ -157,6 +161,7 @@ static int RedisAI_Initialize(RedisModuleCtx* ctx){
   REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRun);
   REDISAI_MODULE_INIT_FUNCTION(ctx, ModelGetShallowCopy);
   REDISAI_MODULE_INIT_FUNCTION(ctx, ModelSerialize);
+  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRedisType);
 
   REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptCreate);
   REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptFree);
@@ -168,6 +173,7 @@ static int RedisAI_Initialize(RedisModuleCtx* ctx){
   REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxFree);
   REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRun);
   REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptGetShallowCopy);
+  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRedisType);
 
   if(RedisAI_GetLLAPIVersion() < REDISAI_LLAPI_VERSION){
     return REDISMODULE_ERR;

--- a/src/script.c
+++ b/src/script.c
@@ -335,3 +335,7 @@ void RedisAI_ReplyOrSetError(RedisModuleCtx *ctx, RAI_Error *error, RAI_ErrorCod
         RedisModule_ReplyWithError(ctx, errorMessage);
     }
 }
+
+RedisModuleType *RAI_ScriptRedisType(void) {
+    return RedisAI_ScriptType;
+}

--- a/src/script.h
+++ b/src/script.h
@@ -192,4 +192,10 @@ int RedisAI_Parse_ScriptRun_RedisCommand(RedisModuleCtx *ctx,
  */
 void RedisAI_ReplyOrSetError(RedisModuleCtx *ctx, RAI_Error *error, RAI_ErrorCode code, const char* errorMessage );
 
+/**
+ * @brief  Returns the redis module type representing a script.
+ * @return redis module type representing a script.
+ */
+RedisModuleType *RAI_ScriptRedisType(void);
+
 #endif /* SRC_SCRIPT_H_ */

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -1072,3 +1072,7 @@ int RAI_parseTensorGetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
   // return command arity as the number of processed args
   return argc;
 }
+
+RedisModuleType *RAI_TensorRedisType(void) {
+    return RedisAI_TensorType;
+}

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -378,4 +378,10 @@ int RAI_parseTensorSetArgs(RedisModuleCtx* ctx, RedisModuleString** argv,
 int RAI_parseTensorGetArgs(RedisModuleCtx* ctx, RedisModuleString** argv,
                            int argc, RAI_Tensor* t);
 
+/**
+ * @brief  Returns the redis module type representing a tensor.
+ * @return redis module type representing a tensor.
+ */
+RedisModuleType *RAI_TensorRedisType(void);
+
 #endif /* SRC_TENSOR_H_ */


### PR DESCRIPTION
This PR allows external modules to get RedisAI key types, so they can read AI keys from keyspace or write AI low-level API objects to keyspace, at their will.
This also makes #394 redundant.


@lantiga please tell me if there is a need to update low-level API version