### PR TITLE
Avoid splitting outputs in batches when nbatches == 1

### DIFF
--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -416,9 +416,11 @@ int RAI_ModelRunORT(RAI_ModelRunCtx **mctxs, RAI_Error *error)
  
   size_t batch_sizes[nbatches];
   size_t batch_offsets[nbatches];
+  size_t total_batch_size = 0;
   if (array_len(mctxs[0]->inputs) > 0) {
     for (size_t b=0; b<nbatches; ++b) {
       batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
+      total_batch_size += batch_sizes[b];
     }
     batch_offsets[0] = 0;
     for (size_t b=1; b<nbatches; ++b) {
@@ -547,7 +549,7 @@ int RAI_ModelRunORT(RAI_ModelRunCtx **mctxs, RAI_Error *error)
         status = ort->GetDimensions(info, dims, ndims);
         if (status != NULL) goto error;
 
-        if (dims[0] != nbatches) {
+        if (dims[0] != total_batch_size) {
           RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");
           ort->ReleaseStatus(status);
           return 1;

--- a/src/backends/tensorflow.c
+++ b/src/backends/tensorflow.c
@@ -537,6 +537,15 @@ int RAI_ModelRunTF(RAI_ModelRunCtx** mctxs, RAI_Error *error) {
 
   for(size_t i=0; i<noutputs; ++i) {
     if (nbatches > 1) {
+      const size_t ndims = TF_NumDims(outputTensorsValues[i]);
+      const int64_t total_batch_size = TF_Dim(outputTensorsValues[i], 0);
+      if (nbatches != total_batch_size) {
+        TF_DeleteTensor(outputTensorsValues[i]);
+        TF_DeleteStatus(status);
+        RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");
+        return 1;
+      }
+
       for (size_t b=0; b<nbatches; b++) {
         mctxs[b]->outputs[i].tensor = RAI_TensorCreateFromTFTensor(outputTensorsValues[i], batch_offsets[b], batch_sizes[b]);
       }

--- a/src/backends/tensorflow.c
+++ b/src/backends/tensorflow.c
@@ -480,9 +480,11 @@ int RAI_ModelRunTF(RAI_ModelRunCtx** mctxs, RAI_Error *error) {
 
   size_t batch_sizes[nbatches];
   size_t batch_offsets[nbatches];
+  size_t total_batch_size = 0;
   if (ninputs > 0) {
     for (size_t b=0; b<nbatches; ++b) {
       batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
+      total_batch_size += batch_sizes[b];
     }
     batch_offsets[0] = 0;
     for (size_t b=1; b<nbatches; ++b) {
@@ -537,9 +539,10 @@ int RAI_ModelRunTF(RAI_ModelRunCtx** mctxs, RAI_Error *error) {
 
   for(size_t i=0; i<noutputs; ++i) {
     if (nbatches > 1) {
-      const size_t ndims = TF_NumDims(outputTensorsValues[i]);
-      const int64_t total_batch_size = TF_Dim(outputTensorsValues[i], 0);
-      if (nbatches != total_batch_size) {
+      if (TF_NumDims(outputTensorsValues[i]) == 0) {
+        continue;
+      }
+      if (TF_Dim(outputTensorsValues[i], 0) != total_batch_size) {
         TF_DeleteTensor(outputTensorsValues[i]);
         TF_DeleteStatus(status);
         RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");

--- a/src/backends/torch.c
+++ b/src/backends/torch.c
@@ -93,9 +93,9 @@ int RAI_ModelRunTorch(RAI_ModelRunCtx** mctxs, RAI_Error *error) {
 
   size_t batch_sizes[nbatches];
   size_t batch_offsets[nbatches];
+  size_t total_batch_size = 0;
 
   if (nbatches > 1) {
-    size_t total_batch_size = 0;
     if (array_len(mctxs[0]->inputs) > 0) {
       for (size_t b=0; b<nbatches; ++b) {
         batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
@@ -147,7 +147,7 @@ int RAI_ModelRunTorch(RAI_ModelRunCtx** mctxs, RAI_Error *error) {
     }
     RAI_Tensor* output_tensor = RAI_TensorCreateFromDLTensor(outputs_dl[i]);
     if (nbatches > 1) {
-      if (outputs_dl[i]->dl_tensor.shape[0] != nbatches) {
+      if (outputs_dl[i]->dl_tensor.shape[0] != total_batch_size) {
         RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");
         return 1;
       }

--- a/src/backends/torch.c
+++ b/src/backends/torch.c
@@ -147,6 +147,10 @@ int RAI_ModelRunTorch(RAI_ModelRunCtx** mctxs, RAI_Error *error) {
     }
     RAI_Tensor* output_tensor = RAI_TensorCreateFromDLTensor(outputs_dl[i]);
     if (nbatches > 1) {
+      if (outputs_dl[i]->dl_tensor.shape[0] != nbatches) {
+        RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");
+        return 1;
+      }
       for (size_t b=0; b<nbatches; b++) {
         mctxs[b]->outputs[i].tensor = RAI_TensorCreateBySlicingTensor(output_tensor, batch_offsets[b], batch_sizes[b]);
       }

--- a/test/test_data/pt-minimal-bb.pt
+++ b/test/test_data/pt-minimal-bb.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd657a26454418d7bfd2c02fe76fc15166f6845ec14efa9653ffdc019b021008
+size 1514

--- a/test/test_data/pt_minimal_bb.py
+++ b/test/test_data/pt_minimal_bb.py
@@ -1,0 +1,15 @@
+import torch
+
+
+class MyModule(torch.jit.ScriptModule):
+    def __init__(self):
+        super(MyModule, self).__init__()
+
+    @torch.jit.script_method
+    def forward(self, a, b):
+        return a + b, torch.ones(1)
+
+
+my_script_module = MyModule()
+print(my_script_module(torch.rand(2), torch.rand(2)))
+my_script_module.save("pt-minimal-bb.pt")

--- a/test/tests_pytorch.py
+++ b/test/tests_pytorch.py
@@ -210,6 +210,51 @@ def test_pytorch_modelrun_autobatch(env):
     env.assertEqual(values, [b'4', b'6', b'4', b'6'])
 
 
+def test_pytorch_modelrun_autobatch_badbatch(env):
+    if not TEST_PT:
+        return
+
+    con = env.getConnection()
+
+    test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
+    model_filename = os.path.join(test_data_path, 'pt-minimal-bb.pt')
+
+    with open(model_filename, 'rb') as f:
+        model_pb = f.read()
+
+    ret = con.execute_command('AI.MODELSET', 'm', 'TORCH', 'CPU',
+                              'BATCHSIZE', 4, 'MINBATCHSIZE', 3, 'BLOB', model_pb)
+    env.assertEqual(ret, b'OK')
+
+    con.execute_command('AI.TENSORSET', 'a', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
+    con.execute_command('AI.TENSORSET', 'b', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
+
+    con.execute_command('AI.TENSORSET', 'd', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
+    con.execute_command('AI.TENSORSET', 'e', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
+
+    ensureSlaveSynced(con, env)
+
+    def run():
+        con = env.getConnection()
+        try:
+            con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'd', 'e', 'OUTPUTS', 'f1', 'f2')
+        except Exception as e:
+            exception = e
+            env.assertEqual(type(exception), redis.exceptions.ResponseError)
+            env.assertEqual("Model did not generate the expected batch size", exception.__str__())
+
+    t = threading.Thread(target=run)
+    t.start()
+
+    try:
+        con.execute_command('AI.MODELRUN', 'm', 'INPUTS', 'a', 'b', 'OUTPUTS', 'c1', 'c2')
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertEqual("Model did not generate the expected batch size", exception.__str__())
+
+
+
 def test_pytorch_modelinfo(env):
     if not TEST_PT:
         env.debugPrint("skipping {} since TEST_PT=0".format(sys._getframe().f_code.co_name), force=True)


### PR DESCRIPTION
Fixes #401 

TORCH and TFLITE didn't have the issue, while ONNX and TF did.

It might also be a good idea to add a test targeting this use case (not with full Yolo to avoid including a 200+MB model, only with a tiny model simulating a 1-batch input and 3-batch output).