### PR TITLE
Added hooks/post_checkout to handle dockerhub build failures

### DIFF
--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Docker hub does a recursive clone, then checks the branch out,
+# so when a PR adds a submodule (or updates it), it fails.
+git submodule update --init --recursive
+


### PR DESCRIPTION
This explains it: https://stackoverflow.com/questions/54055666/docker-hub-and-git-submodules