### PR TITLE
Fix for get_deps.sh

### DIFF
--- a/get_deps.sh
+++ b/get_deps.sh
@@ -46,6 +46,8 @@ else
 	fi
 fi
 
+git submodule update --init --recursive || true
+
 OS=$(python3 $HERE/opt/readies/bin/platform --os)
 ARCH=$(python3 $HERE/opt/readies/bin/platform --arch)
 
@@ -65,8 +67,6 @@ LIBTFLITE=libtensorflow-lite
 LIBTORCH=libtorch
 MKL=mkl
 ONNXRUNTIME=onnxruntime
-
-git submodule update --init --recursive || true
 
 ######################################################################################## DLPACK
 


### PR DESCRIPTION
submodule pull should happen before
```shell
OS=$(python3 $HERE/opt/readies/bin/platform --os)
ARCH=$(python3 $HERE/opt/readies/bin/platform --arch)
```

These lines require `readies/bin` folder