### PR TITLE
Include per background thread cpu usage info on info modules output

### DIFF
--- a/src/redisai.c
+++ b/src/redisai.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <pthread.h>
 #include <sys/time.h>
+#include <sys/resource.h>
 #include <unistd.h>
 #include <stdbool.h>
 #include "backends/util.h"
@@ -1092,11 +1093,56 @@ static int RedisAI_RegisterApi(RedisModuleCtx* ctx) {
 void RAI_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
     RedisModule_InfoAddSection(ctx, "git");
     RedisModule_InfoAddFieldCString(ctx, "git_sha", REDISAI_GIT_SHA);
-
     RedisModule_InfoAddSection(ctx, "load_time_configs");
     RedisModule_InfoAddFieldLongLong(ctx, "threads_per_queue", perqueueThreadPoolSize);
     RedisModule_InfoAddFieldLongLong(ctx, "inter_op_parallelism", getBackendsInterOpParallelism());
     RedisModule_InfoAddFieldLongLong(ctx, "intra_op_parallelism", getBackendsIntraOpParallelism());
+    struct rusage self_ru, c_ru;
+    // Return resource usage statistics for the calling process,
+    // which is the sum of resources used by all threads in the
+    // process
+    getrusage(RUSAGE_SELF, &self_ru);
+    // Return resource usage statistics for all of its
+    // terminated child processes
+    getrusage(RUSAGE_CHILDREN, &c_ru);
+    sds self_used_cpu_sys = sdscatprintf(sdsempty(),"%ld.%06ld",(long)self_ru.ru_stime.tv_sec,(long)self_ru.ru_stime.tv_usec);
+    sds self_used_cpu_user = sdscatprintf(sdsempty(),"%ld.%06ld",(long)self_ru.ru_utime.tv_sec, (long)self_ru.ru_utime.tv_usec);
+    sds children_used_cpu_sys = sdscatprintf(sdsempty(),"%ld.%06ld",(long)c_ru.ru_stime.tv_sec,(long)c_ru.ru_stime.tv_usec);
+    sds children_used_cpu_user = sdscatprintf(sdsempty(),"%ld.%06ld",(long)c_ru.ru_utime.tv_sec, (long)c_ru.ru_utime.tv_usec);
+    RedisModule_InfoAddSection(ctx, "cpu");
+    RedisModule_InfoAddFieldCString(ctx, "self_used_cpu_sys", self_used_cpu_sys);
+    RedisModule_InfoAddFieldCString(ctx, "self_used_cpu_user", self_used_cpu_user);
+    RedisModule_InfoAddFieldCString(ctx, "children_used_cpu_sys", children_used_cpu_sys);
+    RedisModule_InfoAddFieldCString(ctx, "children_used_cpu_user", children_used_cpu_user);
+
+    AI_dictIterator *iter = AI_dictGetSafeIterator(run_queues);
+    AI_dictEntry *entry = AI_dictNext(iter);
+    while (entry) {
+      char *queue_name = (char *)AI_dictGetKey(entry);
+      RunQueueInfo *run_queue_info = (RunQueueInfo *)AI_dictGetVal(entry);
+      if(run_queue_info){
+        for (int i = 0; i < perqueueThreadPoolSize; i++) {
+          pthread_t current_bg_threads = run_queue_info->threads[i];
+          struct timespec ts;
+          clockid_t cid;
+          sds queue_used_cpu_total = sdscatprintf(sdsempty(),"queue_%s_bthread_#%d_used_cpu_total",queue_name,i+1);
+          sds bthread_used_cpu_total = sdsempty();
+          const int status = pthread_getcpuclockid(current_bg_threads,&cid);
+          if (status != 0){
+            bthread_used_cpu_total = sdscatprintf(bthread_used_cpu_total,"N/A");
+          } else {
+            if (clock_gettime(cid, &ts) == -1){
+              bthread_used_cpu_total = sdscatprintf(bthread_used_cpu_total,"N/A");
+            } else {
+                bthread_used_cpu_total = sdscatprintf(bthread_used_cpu_total,"%ld.%06ld",(long)ts.tv_sec, (long)(ts.tv_nsec / 1000000));
+            }
+          }
+          RedisModule_InfoAddFieldCString(ctx, queue_used_cpu_total, bthread_used_cpu_total);
+        }
+      }
+      entry = AI_dictNext(iter);
+    }
+    AI_dictReleaseIterator(iter);
 }
 
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {

--- a/test/tests_common.py
+++ b/test/tests_common.py
@@ -291,3 +291,14 @@ def test_tensorget_disconnect(env):
     env.assertEqual(ret, b'OK')
     ret = send_and_disconnect(('AI.TENSORGET', 't_FLOAT', 'META'), red)
     env.assertEqual(ret, None)
+
+def test_info_modules(env):
+    red = env.getConnection()
+    ret = red.execute_command('INFO','MODULES')
+    env.assertEqual( ret['ai_threads_per_queue'], 1 )
+    # minimum cpu properties
+    env.assertEqual( 'ai_self_used_cpu_sys' in ret, True )
+    env.assertEqual( 'ai_self_used_cpu_user' in ret, True )
+    env.assertEqual( 'ai_children_used_cpu_sys' in ret, True )
+    env.assertEqual( 'ai_children_used_cpu_user' in ret, True )
+    env.assertEqual( 'ai_queue_CPU_bthread_#1_used_cpu_total' in ret, True )


### PR DESCRIPTION
The following PR allows queering per background thread cpu usage info on `info modules` command output using [pthread_getcpuclockid](https://man7.org/linux/man-pages/man3/pthread_getcpuclockid.3.html)
Sample output when running a standalone redis-server with RedisAI and `THREAD_PER_QUEUE 10`:
```
$ redis-cli info modules
# Modules
module:name=ai,ver=999999,api=1,filters=0,usedby=[],using=[],options=[]
# ai_git
ai_git_sha:30196294c6f240e80ff4b64aa00bc54098ec81fb
# ai_load_time_configs
ai_threads_per_queue:10
ai_inter_op_parallelism:0
ai_intra_op_parallelism:0
# ai_cpu
ai_self_used_cpu_sys:24.336690
ai_self_used_cpu_user:71.894460
ai_children_used_cpu_sys:0.000000
ai_children_used_cpu_user:0.000000
ai_queue_CPU_bthread_#1_used_cpu_total:2.000469
ai_queue_CPU_bthread_#2_used_cpu_total:2.000419
ai_queue_CPU_bthread_#3_used_cpu_total:2.000436
ai_queue_CPU_bthread_#4_used_cpu_total:2.000415
ai_queue_CPU_bthread_#5_used_cpu_total:2.000421
ai_queue_CPU_bthread_#6_used_cpu_total:2.000413
ai_queue_CPU_bthread_#7_used_cpu_total:2.000427
ai_queue_CPU_bthread_#8_used_cpu_total:2.000407
ai_queue_CPU_bthread_#9_used_cpu_total:2.000414
ai_queue_CPU_bthread_#10_used_cpu_total:2.000424
```

- on `ai_self_used_cpu_*` we see sum of resources used by all threads in the process ( user + sys ) ( this info is also available via `info cpu` )
- on `ai_children_used_cpu_*` we usage statistics for all of its terminated child processes  ( user + sys )  ( this info is also available via `info cpu` )
- on `ai_queue_CPU_bthread_*` we see total cpu time per redisai background thread ( the ones we control via THREADS_PER_QUEUE  and that the ones doing the backend work )

Ideally we will be able to understand what of the 2 components ( main thread, queues + backends ) are the bottleneck