### PR TITLE
Safely add to arrays + fix for #443

### DIFF
--- a/src/backends/tensorflow.c
+++ b/src/backends/tensorflow.c
@@ -392,12 +392,12 @@ RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char* devicestr, RAI_Mod
 
   char **inputs_ = array_new(char*, ninputs);
   for (long long i=0; i<ninputs; i++) {
-    array_append(inputs_, RedisModule_Strdup(inputs[i]));
+    inputs_ = array_append(inputs_, RedisModule_Strdup(inputs[i]));
   }
 
   char **outputs_ = array_new(char*, noutputs);
   for (long long i=0; i<noutputs; i++) {
-    array_append(outputs_, RedisModule_Strdup(outputs[i]));
+    outputs_ = array_append(outputs_, RedisModule_Strdup(outputs[i]));
   }
 
   char* buffer = RedisModule_Calloc(modellen, sizeof(*buffer));

--- a/src/background_workers.c
+++ b/src/background_workers.c
@@ -143,8 +143,8 @@ void *RedisAI_Run_ThreadMain(void *arg) {
 
         // We add the current item to the list of evicted items. If it's the
         // first time around this will be the queue front.
-        array_append(evicted_items, item);
-        array_append(batch_rinfo, rinfo);
+        evicted_items = array_append(evicted_items, item);
+        batch_rinfo = array_append(batch_rinfo, rinfo);
 
         // If the item is a scriptrun, we stop looking for matching items to
         // batch because there's no batching for script
@@ -208,8 +208,8 @@ void *RedisAI_Run_ThreadMain(void *arg) {
 
           // If all previous checks pass, then keep track of the item
           // in the list of evicted items
-          array_append(evicted_items, next_item);
-          array_append(batch_rinfo, next_rinfo);
+          evicted_items = array_append(evicted_items, next_item);
+          batch_rinfo = array_append(batch_rinfo, next_rinfo);
 
           // Update the batchsize and go to the next item to see if
           // there's anything else to batch

--- a/src/dag.c
+++ b/src/dag.c
@@ -878,7 +878,7 @@ int RedisAI_DagRunSyntaxParser(RedisModuleCtx *ctx, RedisModuleString **argv,
     const char* devicestr = rinfo->dagOps[i]->devicestr;
     bool found = false;
     for (long long j=0; j<array_len(devices); j++) {
-      if (strcmp(devicestr, devices[j]) == 0) {
+      if (strcasecmp(devicestr, devices[j]) == 0) {
         found = true;
         break;
       }

--- a/src/dag.c
+++ b/src/dag.c
@@ -86,7 +86,7 @@ void RedisAI_DagRunSession_TensorGet_Step(RedisAI_RunInfo *rinfo, RAI_DagOp *cur
     RAI_Tensor *outTensor = NULL;
     // TODO: check tensor copy return value
     RAI_TensorDeepCopy(t, &outTensor);
-    array_append(currentOp->outTensors, outTensor);
+    currentOp->outTensors = array_append(currentOp->outTensors, outTensor);
   }
 }
 
@@ -624,7 +624,7 @@ int RedisAI_DagRunSyntaxParser(RedisModuleCtx *ctx, RedisModuleString **argv,
   rinfo->use_local_context = 1;
   RAI_DagOp *currentDagOp = NULL;
   RAI_InitDagOp(&currentDagOp);
-  array_append(rinfo->dagOps, currentDagOp);
+  rinfo->dagOps = array_append(rinfo->dagOps, currentDagOp);
 
   int persistFlag = 0;
   int loadFlag = 0;
@@ -666,7 +666,7 @@ int RedisAI_DagRunSyntaxParser(RedisModuleCtx *ctx, RedisModuleString **argv,
         rinfo->dagNumberCommands++;
         RAI_DagOp *currentDagOp = NULL;
         RAI_InitDagOp(&currentDagOp);
-        array_append(rinfo->dagOps, currentDagOp);
+        rinfo->dagOps = array_append(rinfo->dagOps, currentDagOp);
       }
       chainingOpCount++;
     } else {

--- a/src/model.c
+++ b/src/model.c
@@ -193,11 +193,11 @@ static void RAI_Model_AofRewrite(RedisModuleIO *aof, RedisModuleString *key, voi
   RedisModuleCtx *ctx = RedisModule_GetContextFromIO(aof);
 
   for (size_t i=0; i<model->ninputs; i++) {
-    array_append(inputs_, RedisModule_CreateString(ctx, model->inputs[i], strlen(model->inputs[i])));
+    inputs_ = array_append(inputs_, RedisModule_CreateString(ctx, model->inputs[i], strlen(model->inputs[i])));
   }
 
   for (size_t i=0; i<model->noutputs; i++) {
-    array_append(outputs_, RedisModule_CreateString(ctx, model->outputs[i], strlen(model->outputs[i])));
+    outputs_ = array_append(outputs_, RedisModule_CreateString(ctx, model->outputs[i], strlen(model->outputs[i])));
   }
 
   long long chunk_size = getModelChunkSize();
@@ -206,7 +206,7 @@ static void RAI_Model_AofRewrite(RedisModuleIO *aof, RedisModuleString *key, voi
 
   for (size_t i=0; i<n_chunks; i++) {
     size_t chunk_len = i < n_chunks - 1 ? chunk_size : len % chunk_size;
-    array_append(buffers_, RedisModule_CreateString(ctx, buffer + i * chunk_size, chunk_len));
+    buffers_ = array_append(buffers_, RedisModule_CreateString(ctx, buffer + i * chunk_size, chunk_len));
   }
 
   if (buffer) {

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -825,7 +825,7 @@ int RAI_parseTensorSetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         return -1;
       }
       ndims++;
-      array_append(dims, dimension);
+      dims = array_append(dims, dimension);
       len *= dimension;
     }
   }

--- a/test/tests_sanitizer.py
+++ b/test/tests_sanitizer.py
@@ -12,7 +12,7 @@ def test_sanitizer_dagrun_mobilenet_v1(env):
     if (not TEST_TF or not TEST_PT):
         return
     con = env.getConnection()
-    mem_allocator = con.execute_command('info', 'memory')['mem_allocator']
+    mem_allocator = con.info()['mem_allocator']
     if 'jemalloc' in mem_allocator:
         print("exiting sanitizer test given we're not using stdlib allocator")
         return
@@ -48,7 +48,7 @@ def test_sanitizer_modelrun_mobilenet_v1(env):
     if (not TEST_TF or not TEST_PT):
         return
     con = env.getConnection()
-    mem_allocator = con.execute_command('info', 'memory')['mem_allocator']
+    mem_allocator = con.info()['mem_allocator']
     if 'jemalloc' in mem_allocator:
         print("exiting sanitizer test given we're not using stdlib allocator")
         return


### PR DESCRIPTION
This PR stems from fixing #443.

The segfault itself was due to https://github.com/RedisAI/RedisAI/blob/master/src/dag.c#L881 being `strcmp` instead of `strcasecmp`. The device check case sensitive here and only here, which lead to erratic behavior and memory corruption downstream when users specified a non-uppercase device string.

In the process, I spotted a few places where `array_append` was not reassigned, leading to potential problems.