### PR TITLE
AI.SCRIPTSET example doesn't work

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -381,7 +381,7 @@ def addtwo(a, b):
 It can be stored as a RedisAI script using the CPU device with [`redis-cli`](https://redis.io/topics/rediscli) as follows:
 
 ```
-$ cat addtwo.py | redis-cli -x AI.SCRIPTSET myscript addtwo CPU TAG myscript:v0.1 SOURCE
+$ cat addtwo.py | redis-cli -x AI.SCRIPTSET myscript CPU TAG myscript:v0.1 SOURCE
 OK
 ```
 


### PR DESCRIPTION
AI.SCRIPTSET example has a key name of "myscript" and function name of "addtwo". AI.SCRIPTSET does not take a function name argument so the example is incorrect (and generates a syntax error). This pull request corrects the documentation.