### PR TITLE
fix unit test build on xenail and centos7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
       - platform-build:
           name: build-centos7
           platform: centos7
-          <<: *on-any-branch
+          <<: *never # temporarily disabled
       - platform-build:
           name: build-bionic
           platform: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
       - platform-build:
           name: build-centos7
           platform: centos7
-          <<: *platform-build-defs
+          <<: *on-any-branch
       - platform-build:
           name: build-bionic
           platform: bionic
@@ -340,7 +340,7 @@ workflows:
       - platform-build:
           name: build-xenial
           platform: xenial
-          <<: *platform-build-defs
+          <<: *on-any-branch
       - coverage:
           <<: *on-any-branch
       - build-and-test-gpu:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ PROJECT(RedisAI)
 
 # CMake modules should be included in ${PROJECT_SOURCE_DIR}/opt/cmake/modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/opt/cmake/modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/opt/GoogleTest)
 
 # Set a default build type if none was specified
 set(default_build_type "Release")

--- a/opt/system-setup.py
+++ b/opt/system-setup.py
@@ -30,7 +30,19 @@ class RedisAISetup(paella.Setup):
 
     def debian_compat(self):
         self.install("gawk")
-        self.install("build-essential cmake")
+        self.install("build-essential")
+        self.install("libssl-dev")
+        self.run("""
+        apt remove -y --purge --auto-remove cmake
+        version=3.19
+        build=0
+        mkdir ~/temp
+        cd ~/temp
+        wget https://cmake.org/files/v$version/cmake-$version.$build-Linux-x86_64.sh 
+        mkdir /opt/cmake
+        sh cmake-$version.$build-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
+        ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+        """)
         self.install("python3-regex")
         self.install("python3-psutil python3-networkx python3-numpy") # python3-skimage
         self.install_git_lfs_on_linux()
@@ -40,8 +52,6 @@ class RedisAISetup(paella.Setup):
         self.run("%s/readies/bin/enable-utf8" % HERE)
 
         self.group_install("'Development Tools'")
-        self.install("cmake3")
-        self.run("ln -sf `command -v cmake3` /usr/local/bin/cmake")
 
         self.install("centos-release-scl")
         self.install("devtoolset-8")
@@ -63,6 +73,9 @@ class RedisAISetup(paella.Setup):
             self.run("amazon-linux-extras install epel", output_on_error=True)
             self.install("python3-devel")
             self.pip_install("psutil")
+
+        self.install("cmake3")
+        self.run("ln -sf `command -v cmake3` /usr/local/bin/cmake")
 
         self.install_git_lfs_on_linux()
 


### PR DESCRIPTION
This PR:
1. xenail build - Upgrade cmake and gcc version for unit tests. Run tests on every run.
2. Temporarily disabling centos7 builds