### PR TITLE
Applied clang-format to src/* files. Failing CI if linter rules not followed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,19 @@ commands:
             aws s3 cp artifacts/ s3://redismodules/$PACKAGE_NAME/ --acl public-read --recursive --exclude "*" --include "*.zip" --include "*.tgz"
 
 jobs:
+  lint:
+    docker:
+      - image: redislabsmodules/llvm-toolset:latest
+    steps:
+      - checkout
+      - run:
+          name: Submodule checkout
+          command: git submodule update --init --recursive 
+      - run:
+          name: lint
+          command: |
+            make -C opt lint
+
   build-debian:
     docker:
       - image: redisfab/rmbuilder:6.0.5-x64-buster
@@ -322,13 +335,18 @@ after-platform-builds: &after-platform-builds
     - build-bionic
     - build-xenial
 
+after-linter: &after-linter
+  requires:
+    - lint
 
 workflows:
   version: 2
   build_and_package:
     jobs:
+      - lint
       - build-debian:
           <<: *on-any-branch
+          <<: *after-linter
       - platform-build:
           name: build-centos7
           platform: centos7
@@ -343,8 +361,10 @@ workflows:
           <<: *platform-build-defs
       - coverage:
           <<: *on-any-branch
+          <<: *after-linter
       - build-and-test-gpu:
           <<: *on-any-branch
+          <<: *after-linter
       - build-macos:
           <<: *never # temporarily disabled
           # <<: *on-version-tags

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+IndentWidth: 4
+ColumnLimit: 100
+SortIncludes: false
+AlignEscapedNewlinesLeft: false
+AlignConsecutiveMacros: true
+SpacesBeforeTrailingComments: 1

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -21,6 +21,9 @@ ifeq ($(COV),1)
 DEBUG ?= 1
 endif
 
+username := $(shell sh -c 'id -u')
+usergroup := $(shell sh -c 'id -g')
+
 #---------------------------------------------------------------------------------------------- 
 
 define HELP
@@ -139,7 +142,7 @@ include $(MK)/defs
 
 #----------------------------------------------------------------------------------------------
 
-.PHONY: fetch deps pack pack_ramp pack_deps test
+.PHONY: fetch deps pack pack_ramp pack_deps test format lint
 
 include $(MK)/rules
 
@@ -178,6 +181,18 @@ setup:
 fetch deps:
 	@echo Fetching dependencies...
 	$(SHOW)VERBOSE=$(_SHOW) $(ROOT)/get_deps.sh $(DEPS_FLAGS)
+
+format:
+	./clang-format-all.sh
+
+format-docker:
+	docker run --rm -v $(abspath $(ROOT))/:/RedisAI/ --user "$(username):$(usergroup)" redislabsmodules/llvm-toolset:latest bash -c "cd RedisAI && make -C opt format"
+
+lint:
+	./clang-check-all.sh
+
+lint-docker:
+	docker run --rm -v $(abspath $(ROOT))/:/RedisAI/ --user "$(username):$(usergroup)" redislabsmodules/llvm-toolset:latest bash -c "cd RedisAI && make -C opt lint"
 
 #----------------------------------------------------------------------------------------------
 

--- a/opt/clang-check-all.sh
+++ b/opt/clang-check-all.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# exit immediatly on error ( no need to keep checking )
+set -e
+
+CLANG_FMT_SRCS=$(find ../src/ \( -name '*.c' -o -name '*.cc'-o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))
+
+for filename in $CLANG_FMT_SRCS; do
+    echo "Checking $filename"
+    clang-format -style=file -Werror --dry-run $filename
+done

--- a/opt/clang-format-all.sh
+++ b/opt/clang-format-all.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# exit immediatly on error ( no need to keep checking )
+set -e
+
+CLANG_FMT_SRCS=$(find ../src/ \( -name '*.c' -o -name '*.cc'-o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))
+
+for filename in $CLANG_FMT_SRCS; do
+    clang-format --verbose -style=file -i $filename
+done

--- a/opt/system-setup.py
+++ b/opt/system-setup.py
@@ -31,6 +31,7 @@ class RedisAISetup(paella.Setup):
     def debian_compat(self):
         self.install("gawk")
         self.install("build-essential cmake")
+        self.install("clang-format")
         self.install("python3-regex")
         self.install("python3-psutil python3-networkx python3-numpy") # python3-skimage
         self.install_git_lfs_on_linux()
@@ -46,6 +47,9 @@ class RedisAISetup(paella.Setup):
         self.install("centos-release-scl")
         self.install("devtoolset-8")
         self.run("cp /opt/rh/devtoolset-8/enable /etc/profile.d/scl-devtoolset-8.sh")
+        
+        self.install("llvm-toolset-7")
+
         paella.mkdir_p("%s/profile.d" % ROOT)
         self.run("cp /opt/rh/devtoolset-8/enable %s/profile.d/scl-devtoolset-8.sh" % ROOT)
 
@@ -54,6 +58,7 @@ class RedisAISetup(paella.Setup):
             (cd $dir; wget -q -O tar.tgz http://redismodules.s3.amazonaws.com/gnu/gnu-tar-1.32-x64-centos7.tgz; tar -xzf tar.tgz -C /; )
             rm -rf $dir
             """)
+        
 
         if not self.dist == "amzn":
             self.install("epel-release")
@@ -71,6 +76,7 @@ class RedisAISetup(paella.Setup):
         self.install("cmake")
         self.run("ln -sf `command -v cmake3` /usr/local/bin/cmake")
         self.install("python3 python3-psutil python3-networkx")
+        self.install("clang")
         self.install_git_lfs_on_linux()
 
     def macos(self):
@@ -81,6 +87,7 @@ class RedisAISetup(paella.Setup):
         self.install("cmake")
         self.install("git-lfs")
         self.install("redis")
+        self.install("clang-format")
 
     def common_last(self):
         self.run("python3 -m pip uninstall -y ramp-packer RLTest || true")

--- a/src/backends.c
+++ b/src/backends.c
@@ -18,462 +18,438 @@
 #include "redismodule.h"
 
 RedisModuleString *RAI_GetModulePath(RedisModuleCtx *ctx) {
-  Dl_info info;
-  RedisModuleString *module_path = NULL;
-  if (dladdr(RAI_GetModulePath, &info)) {
-    char *dli_fname = RedisModule_Strdup(info.dli_fname);
-    const char *dli_dirname = dirname(dli_fname);
-    module_path =
-        RedisModule_CreateString(ctx, dli_dirname, strlen(dli_dirname));
-    RedisModule_Free(dli_fname);
-  }
+    Dl_info info;
+    RedisModuleString *module_path = NULL;
+    if (dladdr(RAI_GetModulePath, &info)) {
+        char *dli_fname = RedisModule_Strdup(info.dli_fname);
+        const char *dli_dirname = dirname(dli_fname);
+        module_path = RedisModule_CreateString(ctx, dli_dirname, strlen(dli_dirname));
+        RedisModule_Free(dli_fname);
+    }
 
-  return module_path;
+    return module_path;
 }
 
 RedisModuleString *RAI_GetBackendsPath(RedisModuleCtx *ctx) {
-  Dl_info info;
-  RedisModuleString *backends_path = NULL;
-  if (RAI_BackendsPath != NULL) {
-    backends_path = RedisModule_CreateString(ctx, RAI_BackendsPath,
-                                             strlen(RAI_BackendsPath));
-  } else {
-    RedisModuleString *module_path = RAI_GetModulePath(ctx);
-    backends_path = RedisModule_CreateStringPrintf(
-        ctx, "%s/backends", RedisModule_StringPtrLen(module_path, NULL));
-  }
+    Dl_info info;
+    RedisModuleString *backends_path = NULL;
+    if (RAI_BackendsPath != NULL) {
+        backends_path = RedisModule_CreateString(ctx, RAI_BackendsPath, strlen(RAI_BackendsPath));
+    } else {
+        RedisModuleString *module_path = RAI_GetModulePath(ctx);
+        backends_path = RedisModule_CreateStringPrintf(ctx, "%s/backends",
+                                                       RedisModule_StringPtrLen(module_path, NULL));
+    }
 
-  return backends_path;
+    return backends_path;
 }
 
 const char *RAI_BackendName(int backend) {
-  switch (backend) {
+    switch (backend) {
     case RAI_BACKEND_TENSORFLOW:
-      return "TF";
+        return "TF";
     case RAI_BACKEND_TFLITE:
-      return "TFLITE";
+        return "TFLITE";
     case RAI_BACKEND_TORCH:
-      return "TORCH";
+        return "TORCH";
     case RAI_BACKEND_ONNXRUNTIME:
-      return "ONNX";
-  }
-  return NULL;
+        return "ONNX";
+    }
+    return NULL;
 }
 
 int RAI_LoadBackend_TensorFlow(RedisModuleCtx *ctx, const char *path) {
-  if (RAI_backends.tf.model_run != NULL) {
-    RedisModule_Log(ctx, "warning",
-                    "Could not load TF backend: backend already loaded");
-    return REDISMODULE_ERR;
-  }
+    if (RAI_backends.tf.model_run != NULL) {
+        RedisModule_Log(ctx, "warning", "Could not load TF backend: backend already loaded");
+        return REDISMODULE_ERR;
+    }
 
-  void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
 
-  if (handle == NULL) {
-    RedisModule_Log(ctx, "warning", "Could not load TF backend from %s: %s",
-                    path, dlerror());
-    return REDISMODULE_ERR;
-  }
+    if (handle == NULL) {
+        RedisModule_Log(ctx, "warning", "Could not load TF backend from %s: %s", path, dlerror());
+        return REDISMODULE_ERR;
+    }
 
-  RAI_LoadedBackend backend = {0};
+    RAI_LoadedBackend backend = {0};
 
-  int (*init_backend)(int (*)(const char *, void *));
-  init_backend = (int (*)(int (*)(const char *, void *)))(unsigned long)dlsym(
-      handle, "RAI_InitBackendTF");
-  if (init_backend == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_InitBackendTF. TF backend not "
-                    "loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
-  init_backend(RedisModule_GetApi);
+    int (*init_backend)(int (*)(const char *, void *));
+    init_backend =
+        (int (*)(int (*)(const char *, void *)))(unsigned long)dlsym(handle, "RAI_InitBackendTF");
+    if (init_backend == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_InitBackendTF. TF backend not "
+                        "loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
+    init_backend(RedisModule_GetApi);
 
-  backend.model_create_with_nodes =
-      (RAI_Model *
-       (*)(RAI_Backend, const char *, RAI_ModelOpts, size_t, const char **,
-           size_t, const char **, const char *, size_t,
-           RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTF");
-  if (backend.model_create_with_nodes == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelCreateTF. TF backend not "
-                    "loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_create_with_nodes =
+        (RAI_Model * (*)(RAI_Backend, const char *, RAI_ModelOpts, size_t, const char **, size_t,
+                         const char **, const char *, size_t,
+                         RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTF");
+    if (backend.model_create_with_nodes == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelCreateTF. TF backend not "
+                        "loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_free = (void (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(
-      handle, "RAI_ModelFreeTF");
-  if (backend.model_free == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelFreeTF. TF backend not "
-                    "loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_free =
+        (void (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelFreeTF");
+    if (backend.model_free == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelFreeTF. TF backend not "
+                        "loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_run = (int (*)(RAI_ModelRunCtx **, RAI_Error *))(
-      unsigned long)dlsym(handle, "RAI_ModelRunTF");
-  if (backend.model_run == NULL) {
-    dlclose(handle);
-    RedisModule_Log(
-        ctx, "warning",
-        "Backend does not export RAI_ModelRunTF. TF backend not loaded from %s",
-        path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_run =
+        (int (*)(RAI_ModelRunCtx **, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelRunTF");
+    if (backend.model_run == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelRunTF. TF backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_serialize =
-      (int (*)(RAI_Model *, char **, size_t *, RAI_Error *))(
-          unsigned long)dlsym(handle, "RAI_ModelSerializeTF");
-  if (backend.model_serialize == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelSerializeTF. TF backend "
-                    "not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_serialize = (int (*)(RAI_Model *, char **, size_t *, RAI_Error *))(
+        unsigned long)dlsym(handle, "RAI_ModelSerializeTF");
+    if (backend.model_serialize == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelSerializeTF. TF backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  RAI_backends.tf = backend;
+    RAI_backends.tf = backend;
 
-  RedisModule_Log(ctx, "notice", "TF backend loaded from %s", path);
+    RedisModule_Log(ctx, "notice", "TF backend loaded from %s", path);
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
 int RAI_LoadBackend_TFLite(RedisModuleCtx *ctx, const char *path) {
-  if (RAI_backends.tflite.model_run != NULL) {
-    RedisModule_Log(ctx, "warning",
-                    "Could not load TFLITE backend: backend already loaded");
-    return REDISMODULE_ERR;
-  }
+    if (RAI_backends.tflite.model_run != NULL) {
+        RedisModule_Log(ctx, "warning", "Could not load TFLITE backend: backend already loaded");
+        return REDISMODULE_ERR;
+    }
 
-  void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
 
-  if (handle == NULL) {
-    RedisModule_Log(ctx, "warning", "Could not load TFLITE backend from %s: %s",
-                    path, dlerror());
-    return REDISMODULE_ERR;
-  }
+    if (handle == NULL) {
+        RedisModule_Log(ctx, "warning", "Could not load TFLITE backend from %s: %s", path,
+                        dlerror());
+        return REDISMODULE_ERR;
+    }
 
-  RAI_LoadedBackend backend = {0};
+    RAI_LoadedBackend backend = {0};
 
-  int (*init_backend)(int (*)(const char *, void *));
-  init_backend = (int (*)(int (*)(const char *, void *)))(unsigned long)dlsym(
-      handle, "RAI_InitBackendTFLite");
-  if (init_backend == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_InitBackendTFLite. TFLITE "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
-  init_backend(RedisModule_GetApi);
+    int (*init_backend)(int (*)(const char *, void *));
+    init_backend = (int (*)(int (*)(const char *, void *)))(unsigned long)dlsym(
+        handle, "RAI_InitBackendTFLite");
+    if (init_backend == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_InitBackendTFLite. TFLITE "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
+    init_backend(RedisModule_GetApi);
 
-  backend.model_create =
-      (RAI_Model *
-       (*)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
-           RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTFLite");
-  if (backend.model_create == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelCreateTFLite. TFLITE "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_create =
+        (RAI_Model * (*)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
+                         RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTFLite");
+    if (backend.model_create == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelCreateTFLite. TFLITE "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_free = (void (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(
-      handle, "RAI_ModelFreeTFLite");
-  if (backend.model_free == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelFreeTFLite. TFLITE "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_free =
+        (void (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelFreeTFLite");
+    if (backend.model_free == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelFreeTFLite. TFLITE "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_run = (int (*)(RAI_ModelRunCtx **, RAI_Error *))(
-      unsigned long)dlsym(handle, "RAI_ModelRunTFLite");
-  if (backend.model_run == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelRunTFLite. TFLITE "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_run = (int (*)(RAI_ModelRunCtx **, RAI_Error *))(unsigned long)dlsym(
+        handle, "RAI_ModelRunTFLite");
+    if (backend.model_run == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelRunTFLite. TFLITE "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_serialize =
-      (int (*)(RAI_Model *, char **, size_t *, RAI_Error *))(
-          unsigned long)dlsym(handle, "RAI_ModelSerializeTFLite");
-  if (backend.model_serialize == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelSerializeTFLite. TFLITE "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_serialize = (int (*)(RAI_Model *, char **, size_t *, RAI_Error *))(
+        unsigned long)dlsym(handle, "RAI_ModelSerializeTFLite");
+    if (backend.model_serialize == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelSerializeTFLite. TFLITE "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  RAI_backends.tflite = backend;
+    RAI_backends.tflite = backend;
 
-  RedisModule_Log(ctx, "notice", "TFLITE backend loaded from %s", path);
+    RedisModule_Log(ctx, "notice", "TFLITE backend loaded from %s", path);
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
 int RAI_LoadBackend_Torch(RedisModuleCtx *ctx, const char *path) {
-  if (RAI_backends.torch.model_run != NULL) {
-    RedisModule_Log(ctx, "warning",
-                    "Could not load TORCH backend: backend already loaded");
-    return REDISMODULE_ERR;
-  }
+    if (RAI_backends.torch.model_run != NULL) {
+        RedisModule_Log(ctx, "warning", "Could not load TORCH backend: backend already loaded");
+        return REDISMODULE_ERR;
+    }
 
-  void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
 
-  if (handle == NULL) {
-    RedisModule_Log(ctx, "warning", "Could not load TORCH backend from %s: %s",
-                    path, dlerror());
-    return REDISMODULE_ERR;
-  }
+    if (handle == NULL) {
+        RedisModule_Log(ctx, "warning", "Could not load TORCH backend from %s: %s", path,
+                        dlerror());
+        return REDISMODULE_ERR;
+    }
 
-  RAI_LoadedBackend backend = {0};
+    RAI_LoadedBackend backend = {0};
 
-  int (*init_backend)(int (*)(const char *, void *));
-  init_backend = (int (*)(int (*)(const char *, void *)))(unsigned long)dlsym(
-      handle, "RAI_InitBackendTorch");
-  if (init_backend == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_InitBackendTorch. TORCH "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
-  init_backend(RedisModule_GetApi);
+    int (*init_backend)(int (*)(const char *, void *));
+    init_backend = (int (*)(int (*)(const char *, void *)))(unsigned long)dlsym(
+        handle, "RAI_InitBackendTorch");
+    if (init_backend == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_InitBackendTorch. TORCH "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
+    init_backend(RedisModule_GetApi);
 
-  backend.model_create =
-      (RAI_Model *
-       (*)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
-           RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTorch");
-  if (backend.model_create == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelCreateTorch. TORCH "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_create =
+        (RAI_Model * (*)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
+                         RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTorch");
+    if (backend.model_create == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelCreateTorch. TORCH "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_free = (void (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(
-      handle, "RAI_ModelFreeTorch");
-  if (backend.model_free == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelFreeTorch. TORCH backend "
-                    "not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_free =
+        (void (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelFreeTorch");
+    if (backend.model_free == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelFreeTorch. TORCH backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_run = (int (*)(RAI_ModelRunCtx **, RAI_Error *))(
-      unsigned long)dlsym(handle, "RAI_ModelRunTorch");
-  if (backend.model_run == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelRunTorch. TORCH backend "
-                    "not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_run =
+        (int (*)(RAI_ModelRunCtx **, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelRunTorch");
+    if (backend.model_run == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelRunTorch. TORCH backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_serialize =
-      (int (*)(RAI_Model *, char **, size_t *, RAI_Error *))(
-          unsigned long)dlsym(handle, "RAI_ModelSerializeTorch");
-  if (backend.model_serialize == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelSerializeTorch. TORCH "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_serialize = (int (*)(RAI_Model *, char **, size_t *, RAI_Error *))(
+        unsigned long)dlsym(handle, "RAI_ModelSerializeTorch");
+    if (backend.model_serialize == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelSerializeTorch. TORCH "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.script_create =
-      (RAI_Script * (*)(const char *, const char *, RAI_Error *))(
-          unsigned long)dlsym(handle, "RAI_ScriptCreateTorch");
-  if (backend.script_create == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ScriptCreateTorch. TORCH "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.script_create = (RAI_Script * (*)(const char *, const char *, RAI_Error *))(
+        unsigned long)dlsym(handle, "RAI_ScriptCreateTorch");
+    if (backend.script_create == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ScriptCreateTorch. TORCH "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.script_free = (void (*)(RAI_Script *, RAI_Error *))(
-      unsigned long)dlsym(handle, "RAI_ScriptFreeTorch");
-  if (backend.script_free == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ScriptFreeTorch. TORCH "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.script_free =
+        (void (*)(RAI_Script *, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ScriptFreeTorch");
+    if (backend.script_free == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ScriptFreeTorch. TORCH "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.script_run = (int (*)(RAI_ScriptRunCtx *, RAI_Error *))(
-      unsigned long)dlsym(handle, "RAI_ScriptRunTorch");
-  if (backend.script_run == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ScriptRunTorch. TORCH backend "
-                    "not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.script_run = (int (*)(RAI_ScriptRunCtx *, RAI_Error *))(unsigned long)dlsym(
+        handle, "RAI_ScriptRunTorch");
+    if (backend.script_run == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ScriptRunTorch. TORCH backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  RAI_backends.torch = backend;
+    RAI_backends.torch = backend;
 
-  RedisModule_Log(ctx, "notice", "TORCH backend loaded from %s", path);
+    RedisModule_Log(ctx, "notice", "TORCH backend loaded from %s", path);
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
 int RAI_LoadBackend_ONNXRuntime(RedisModuleCtx *ctx, const char *path) {
-  if (RAI_backends.onnx.model_run != NULL) {
-    RedisModule_Log(ctx, "warning",
-                    "Could not load ONNX backend: backend already loaded");
-    return REDISMODULE_ERR;
-  }
+    if (RAI_backends.onnx.model_run != NULL) {
+        RedisModule_Log(ctx, "warning", "Could not load ONNX backend: backend already loaded");
+        return REDISMODULE_ERR;
+    }
 
-  void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
 
-  if (handle == NULL) {
-    RedisModule_Log(ctx, "warning", "Could not load ONNX backend from %s: %s",
-                    path, dlerror());
-    return REDISMODULE_ERR;
-  }
+    if (handle == NULL) {
+        RedisModule_Log(ctx, "warning", "Could not load ONNX backend from %s: %s", path, dlerror());
+        return REDISMODULE_ERR;
+    }
 
-  RAI_LoadedBackend backend = {0};
+    RAI_LoadedBackend backend = {0};
 
-  int (*init_backend)(int (*)(const char *, void *));
-  init_backend = (int (*)(int (*)(const char *, void *)))(unsigned long)dlsym(
-      handle, "RAI_InitBackendORT");
-  if (init_backend == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_InitBackendORT. ONNX backend "
-                    "not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
-  init_backend(RedisModule_GetApi);
+    int (*init_backend)(int (*)(const char *, void *));
+    init_backend =
+        (int (*)(int (*)(const char *, void *)))(unsigned long)dlsym(handle, "RAI_InitBackendORT");
+    if (init_backend == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_InitBackendORT. ONNX backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
+    init_backend(RedisModule_GetApi);
 
-  backend.model_create =
-      (RAI_Model *
-       (*)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
-           RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateORT");
-  if (backend.model_create == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelCreateORT. ONNX backend "
-                    "not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_create =
+        (RAI_Model * (*)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
+                         RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateORT");
+    if (backend.model_create == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelCreateORT. ONNX backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_free = (void (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(
-      handle, "RAI_ModelFreeORT");
-  if (backend.model_free == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelFreeORT. ONNX backend "
-                    "not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_free =
+        (void (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelFreeORT");
+    if (backend.model_free == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelFreeORT. ONNX backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_run = (int (*)(RAI_ModelRunCtx **, RAI_Error *))(
-      unsigned long)dlsym(handle, "RAI_ModelRunORT");
-  if (backend.model_run == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelRunORT. ONNX backend not "
-                    "loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_run =
+        (int (*)(RAI_ModelRunCtx **, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelRunORT");
+    if (backend.model_run == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelRunORT. ONNX backend not "
+                        "loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  backend.model_serialize =
-      (int (*)(RAI_Model *, char **, size_t *, RAI_Error *))(
-          unsigned long)dlsym(handle, "RAI_ModelSerializeORT");
-  if (backend.model_serialize == NULL) {
-    dlclose(handle);
-    RedisModule_Log(ctx, "warning",
-                    "Backend does not export RAI_ModelSerializeORT. ONNX "
-                    "backend not loaded from %s",
-                    path);
-    return REDISMODULE_ERR;
-  }
+    backend.model_serialize = (int (*)(RAI_Model *, char **, size_t *, RAI_Error *))(
+        unsigned long)dlsym(handle, "RAI_ModelSerializeORT");
+    if (backend.model_serialize == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_ModelSerializeORT. ONNX "
+                        "backend not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
 
-  RAI_backends.onnx = backend;
+    RAI_backends.onnx = backend;
 
-  RedisModule_Log(ctx, "notice", "ONNX backend loaded from %s", path);
+    RedisModule_Log(ctx, "notice", "ONNX backend loaded from %s", path);
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
 int RAI_LoadBackend(RedisModuleCtx *ctx, int backend, const char *path) {
-  RedisModuleString *fullpath;
+    RedisModuleString *fullpath;
 
-  if (path[0] == '/') {
-    fullpath = RedisModule_CreateString(ctx, path, strlen(path));
-  } else {
-    RedisModuleString *backends_path = RAI_GetBackendsPath(ctx);
-    fullpath = RedisModule_CreateStringPrintf(
-        ctx, "%s/%s", RedisModule_StringPtrLen(backends_path, NULL), path);
-  }
+    if (path[0] == '/') {
+        fullpath = RedisModule_CreateString(ctx, path, strlen(path));
+    } else {
+        RedisModuleString *backends_path = RAI_GetBackendsPath(ctx);
+        fullpath = RedisModule_CreateStringPrintf(
+            ctx, "%s/%s", RedisModule_StringPtrLen(backends_path, NULL), path);
+    }
 
-  int ret;
-  switch (backend) {
+    int ret;
+    switch (backend) {
     case RAI_BACKEND_TENSORFLOW:
-      return RAI_LoadBackend_TensorFlow(
-          ctx, RedisModule_StringPtrLen(fullpath, NULL));
+        return RAI_LoadBackend_TensorFlow(ctx, RedisModule_StringPtrLen(fullpath, NULL));
     case RAI_BACKEND_TFLITE:
-      return RAI_LoadBackend_TFLite(ctx,
-                                    RedisModule_StringPtrLen(fullpath, NULL));
+        return RAI_LoadBackend_TFLite(ctx, RedisModule_StringPtrLen(fullpath, NULL));
     case RAI_BACKEND_TORCH:
-      return RAI_LoadBackend_Torch(ctx,
-                                   RedisModule_StringPtrLen(fullpath, NULL));
+        return RAI_LoadBackend_Torch(ctx, RedisModule_StringPtrLen(fullpath, NULL));
     case RAI_BACKEND_ONNXRUNTIME:
-      return RAI_LoadBackend_ONNXRuntime(
-          ctx, RedisModule_StringPtrLen(fullpath, NULL));
-  }
+        return RAI_LoadBackend_ONNXRuntime(ctx, RedisModule_StringPtrLen(fullpath, NULL));
+    }
 
-  return REDISMODULE_ERR;
+    return REDISMODULE_ERR;
 }
 
 int RAI_LoadDefaultBackend(RedisModuleCtx *ctx, int backend) {
-  switch (backend) {
+    switch (backend) {
     case RAI_BACKEND_TENSORFLOW:
-      return RAI_LoadBackend(ctx, backend,
-                             "redisai_tensorflow/redisai_tensorflow.so");
+        return RAI_LoadBackend(ctx, backend, "redisai_tensorflow/redisai_tensorflow.so");
     case RAI_BACKEND_TFLITE:
-      return RAI_LoadBackend(ctx, backend, "redisai_tflite/redisai_tflite.so");
+        return RAI_LoadBackend(ctx, backend, "redisai_tflite/redisai_tflite.so");
     case RAI_BACKEND_TORCH:
-      return RAI_LoadBackend(ctx, backend, "redisai_torch/redisai_torch.so");
+        return RAI_LoadBackend(ctx, backend, "redisai_torch/redisai_torch.so");
     case RAI_BACKEND_ONNXRUNTIME:
-      return RAI_LoadBackend(ctx, backend,
-                             "redisai_onnxruntime/redisai_onnxruntime.so");
-  }
+        return RAI_LoadBackend(ctx, backend, "redisai_onnxruntime/redisai_onnxruntime.so");
+    }
 
-  return REDISMODULE_ERR;
+    return REDISMODULE_ERR;
 }

--- a/src/backends.h
+++ b/src/backends.h
@@ -40,56 +40,55 @@
  * RAI_ScriptRunCtx pointer.
  */
 typedef struct RAI_LoadedBackend {
-  // ** model_create_with_nodes **:  A callback function pointer that creates a
-  // model given the RAI_ModelOpts and input and output nodes
-  RAI_Model* (*model_create_with_nodes)(RAI_Backend, const char*, RAI_ModelOpts,
-                                        size_t, const char**, size_t,
-                                        const char**, const char*, size_t,
-                                        RAI_Error*);
+    // ** model_create_with_nodes **:  A callback function pointer that creates a
+    // model given the RAI_ModelOpts and input and output nodes
+    RAI_Model *(*model_create_with_nodes)(RAI_Backend, const char *, RAI_ModelOpts, size_t,
+                                          const char **, size_t, const char **, const char *,
+                                          size_t, RAI_Error *);
 
-  // ** model_create **:  A callback function pointer that creates a model given
-  // the RAI_ModelOpts
-  RAI_Model* (*model_create)(RAI_Backend, const char*, RAI_ModelOpts,
-                             const char*, size_t, RAI_Error*);
+    // ** model_create **:  A callback function pointer that creates a model given
+    // the RAI_ModelOpts
+    RAI_Model *(*model_create)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
+                               RAI_Error *);
 
-  // ** model_free **:  A callback function pointer that frees a model given the
-  // RAI_Model pointer
-  void (*model_free)(RAI_Model*, RAI_Error*);
+    // ** model_free **:  A callback function pointer that frees a model given the
+    // RAI_Model pointer
+    void (*model_free)(RAI_Model *, RAI_Error *);
 
-  // ** model_run **:  A callback function pointer that runs a model given the
-  // RAI_ModelRunCtx pointer
-  int (*model_run)(RAI_ModelRunCtx**, RAI_Error*);
+    // ** model_run **:  A callback function pointer that runs a model given the
+    // RAI_ModelRunCtx pointer
+    int (*model_run)(RAI_ModelRunCtx **, RAI_Error *);
 
-  // ** model_serialize **:  A callback function pointer that serializes a model
-  // given the RAI_Model pointer
-  int (*model_serialize)(RAI_Model*, char**, size_t*, RAI_Error*);
+    // ** model_serialize **:  A callback function pointer that serializes a model
+    // given the RAI_Model pointer
+    int (*model_serialize)(RAI_Model *, char **, size_t *, RAI_Error *);
 
-  // ** script_create **:  A callback function pointer that creates a script
-  RAI_Script* (*script_create)(const char*, const char*, RAI_Error*);
+    // ** script_create **:  A callback function pointer that creates a script
+    RAI_Script *(*script_create)(const char *, const char *, RAI_Error *);
 
-  // ** script_free **:  A callback function pointer that frees a script given
-  // the RAI_Script pointer
-  void (*script_free)(RAI_Script*, RAI_Error*);
+    // ** script_free **:  A callback function pointer that frees a script given
+    // the RAI_Script pointer
+    void (*script_free)(RAI_Script *, RAI_Error *);
 
-  // ** script_run **:  A callback function pointer that runs a model given the
-  // RAI_ScriptRunCtx pointer
-  int (*script_run)(RAI_ScriptRunCtx*, RAI_Error*);
+    // ** script_run **:  A callback function pointer that runs a model given the
+    // RAI_ScriptRunCtx pointer
+    int (*script_run)(RAI_ScriptRunCtx *, RAI_Error *);
 
 } RAI_LoadedBackend;
 
 typedef struct RAI_LoadedBackends {
-  RAI_LoadedBackend tf;
-  RAI_LoadedBackend tflite;
-  RAI_LoadedBackend torch;
-  RAI_LoadedBackend onnx;
+    RAI_LoadedBackend tf;
+    RAI_LoadedBackend tflite;
+    RAI_LoadedBackend torch;
+    RAI_LoadedBackend onnx;
 } RAI_LoadedBackends;
 
 RAI_LoadedBackends RAI_backends;
-char* RAI_BackendsPath;
+char *RAI_BackendsPath;
 
-int RAI_LoadBackend(RedisModuleCtx* ctx, int backend, const char* path);
-int RAI_LoadDefaultBackend(RedisModuleCtx* ctx, int backend);
+int RAI_LoadBackend(RedisModuleCtx *ctx, int backend, const char *path);
+int RAI_LoadDefaultBackend(RedisModuleCtx *ctx, int backend);
 
-const char* RAI_BackendName(int backend);
+const char *RAI_BackendName(int backend);
 
 #endif

--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -7,491 +7,478 @@
 #include "onnxruntime_c_api.h"
 
 int RAI_InitBackendORT(int (*get_api_fn)(const char *, void *)) {
-  get_api_fn("RedisModule_Alloc", ((void **)&RedisModule_Alloc));
-  get_api_fn("RedisModule_Calloc", ((void **)&RedisModule_Calloc));
-  get_api_fn("RedisModule_Free", ((void **)&RedisModule_Free));
-  get_api_fn("RedisModule_Realloc", ((void **)&RedisModule_Realloc));
-  get_api_fn("RedisModule_Strdup", ((void **)&RedisModule_Strdup));
+    get_api_fn("RedisModule_Alloc", ((void **)&RedisModule_Alloc));
+    get_api_fn("RedisModule_Calloc", ((void **)&RedisModule_Calloc));
+    get_api_fn("RedisModule_Free", ((void **)&RedisModule_Free));
+    get_api_fn("RedisModule_Realloc", ((void **)&RedisModule_Realloc));
+    get_api_fn("RedisModule_Strdup", ((void **)&RedisModule_Strdup));
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
 ONNXTensorElementDataType RAI_GetOrtDataTypeFromDL(DLDataType dtype) {
-  if (dtype.code == kDLFloat) {
-    switch (dtype.bits) {
-      case 32:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
-      case 64:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
-      default:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    if (dtype.code == kDLFloat) {
+        switch (dtype.bits) {
+        case 32:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+        case 64:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
+        default:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+        }
+    } else if (dtype.code == kDLInt) {
+        switch (dtype.bits) {
+        case 8:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
+        case 16:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
+        case 32:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
+        case 64:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+        default:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+        }
+    } else if (dtype.code == kDLUInt) {
+        switch (dtype.bits) {
+        case 8:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+        case 16:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
+        default:
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+        }
     }
-  }
-  else if (dtype.code == kDLInt) {
-    switch (dtype.bits) {
-      case 8:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
-      case 16:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
-      case 32:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
-      case 64:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
-      default:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
-    }
-  }
-  else if (dtype.code == kDLUInt) {
-    switch (dtype.bits) {
-      case 8:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
-      case 16:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
-      default:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
-    }
-  }
-  return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
 }
 
 DLDataType RAI_GetDLDataTypeFromORT(ONNXTensorElementDataType dtype) {
-  switch (dtype) {
+    switch (dtype) {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
-      return (DLDataType){ .code = kDLFloat, .bits = 32, .lanes = 1 };
+        return (DLDataType){.code = kDLFloat, .bits = 32, .lanes = 1};
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
-      return (DLDataType){ .code = kDLFloat, .bits = 64, .lanes = 1 };
+        return (DLDataType){.code = kDLFloat, .bits = 64, .lanes = 1};
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-      return (DLDataType){ .code = kDLInt, .bits = 8, .lanes = 1 };
+        return (DLDataType){.code = kDLInt, .bits = 8, .lanes = 1};
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
-      return (DLDataType){ .code = kDLInt, .bits = 16, .lanes = 1 };
+        return (DLDataType){.code = kDLInt, .bits = 16, .lanes = 1};
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
-      return (DLDataType){ .code = kDLInt, .bits = 32, .lanes = 1 };
+        return (DLDataType){.code = kDLInt, .bits = 32, .lanes = 1};
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
-      return (DLDataType){ .code = kDLInt, .bits = 64, .lanes = 1 };
+        return (DLDataType){.code = kDLInt, .bits = 64, .lanes = 1};
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-      return (DLDataType){ .code = kDLUInt, .bits = 8, .lanes = 1 };
+        return (DLDataType){.code = kDLUInt, .bits = 8, .lanes = 1};
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
-      return (DLDataType){ .code = kDLUInt, .bits = 16, .lanes = 1 };
+        return (DLDataType){.code = kDLUInt, .bits = 16, .lanes = 1};
     default:
-      return (DLDataType){ .bits = 0 };
-  }
-  return (DLDataType){ .bits = 0 };
+        return (DLDataType){.bits = 0};
+    }
+    return (DLDataType){.bits = 0};
 }
 
-OrtValue* RAI_OrtValueFromTensors(RAI_Tensor** ts, size_t count, RAI_Error *error) {
-  OrtStatus* status = NULL;
-  const OrtApi* ort = OrtGetApiBase()->GetApi(1);
+OrtValue *RAI_OrtValueFromTensors(RAI_Tensor **ts, size_t count, RAI_Error *error) {
+    OrtStatus *status = NULL;
+    const OrtApi *ort = OrtGetApiBase()->GetApi(1);
 
-  if (count == 0) {
-    return NULL;
-  }
+    if (count == 0) {
+        return NULL;
+    }
 
-  OrtAllocator *allocator;
-  status = ort->GetAllocatorWithDefaultOptions(&allocator);
-  if (status != NULL) {
-    return NULL;
-  }
-
-  if (count == 0) {
-    return NULL;
-  }
-
-  size_t batch_size = 0;
-  size_t batch_byte_size = 0;
-
-  for (size_t i=0; i<count; i++) {
-    batch_size += ts[i]->tensor.dl_tensor.shape[0];
-    batch_byte_size += RAI_TensorByteSize(ts[i]);
-  }
-
-  RAI_Tensor* t0 = ts[0];
-
-  const int ndim = t0->tensor.dl_tensor.ndim;
-  int64_t batched_shape[ndim];
-
-  for (size_t i=1; i<ndim; i++) {
-    batched_shape[i] = t0->tensor.dl_tensor.shape[i];
-  }
-
-  batched_shape[0] = batch_size;
-
-  OrtValue* out;
-
-  if (count > 1) {
-    status = ort->CreateTensorAsOrtValue(
-      allocator,
-      batched_shape,
-      t0->tensor.dl_tensor.ndim,
-      RAI_GetOrtDataTypeFromDL(t0->tensor.dl_tensor.dtype),
-      &out);
+    OrtAllocator *allocator;
+    status = ort->GetAllocatorWithDefaultOptions(&allocator);
     if (status != NULL) {
-      goto error;
-    }
- 
-    char *ort_data;
-    status = ort->GetTensorMutableData(out, (void **)&ort_data);
-    if (status != NULL) {
-      goto error;
+        return NULL;
     }
 
-    size_t offset = 0;
-    for (size_t i=0; i<count; i++) {
-      memcpy(ort_data + offset, RAI_TensorData(ts[i]), RAI_TensorByteSize(ts[i]));
-      offset += RAI_TensorByteSize(ts[i]);
+    if (count == 0) {
+        return NULL;
     }
-  }
-  else {
-   status = ort->CreateTensorWithDataAsOrtValue(
-     allocator->Info(allocator),
-     t0->tensor.dl_tensor.data,
-     RAI_TensorByteSize(t0),
-     t0->tensor.dl_tensor.shape,
-     t0->tensor.dl_tensor.ndim,
-     RAI_GetOrtDataTypeFromDL(t0->tensor.dl_tensor.dtype),
-     &out);
 
-    if (status != NULL) {
-      goto error;
+    size_t batch_size = 0;
+    size_t batch_byte_size = 0;
+
+    for (size_t i = 0; i < count; i++) {
+        batch_size += ts[i]->tensor.dl_tensor.shape[0];
+        batch_byte_size += RAI_TensorByteSize(ts[i]);
     }
-  }
 
-  return out;
+    RAI_Tensor *t0 = ts[0];
+
+    const int ndim = t0->tensor.dl_tensor.ndim;
+    int64_t batched_shape[ndim];
+
+    for (size_t i = 1; i < ndim; i++) {
+        batched_shape[i] = t0->tensor.dl_tensor.shape[i];
+    }
+
+    batched_shape[0] = batch_size;
+
+    OrtValue *out;
+
+    if (count > 1) {
+        status =
+            ort->CreateTensorAsOrtValue(allocator, batched_shape, t0->tensor.dl_tensor.ndim,
+                                        RAI_GetOrtDataTypeFromDL(t0->tensor.dl_tensor.dtype), &out);
+        if (status != NULL) {
+            goto error;
+        }
+
+        char *ort_data;
+        status = ort->GetTensorMutableData(out, (void **)&ort_data);
+        if (status != NULL) {
+            goto error;
+        }
+
+        size_t offset = 0;
+        for (size_t i = 0; i < count; i++) {
+            memcpy(ort_data + offset, RAI_TensorData(ts[i]), RAI_TensorByteSize(ts[i]));
+            offset += RAI_TensorByteSize(ts[i]);
+        }
+    } else {
+        status = ort->CreateTensorWithDataAsOrtValue(
+            allocator->Info(allocator), t0->tensor.dl_tensor.data, RAI_TensorByteSize(t0),
+            t0->tensor.dl_tensor.shape, t0->tensor.dl_tensor.ndim,
+            RAI_GetOrtDataTypeFromDL(t0->tensor.dl_tensor.dtype), &out);
+
+        if (status != NULL) {
+            goto error;
+        }
+    }
+
+    return out;
 
 error:
-  RAI_SetError(error, RAI_EMODELCREATE, ort->GetErrorMessage(status));
-  ort->ReleaseStatus(status);
-  return NULL;
+    RAI_SetError(error, RAI_EMODELCREATE, ort->GetErrorMessage(status));
+    ort->ReleaseStatus(status);
+    return NULL;
 }
 
-RAI_Tensor* RAI_TensorCreateFromOrtValue(OrtValue* v, size_t batch_offset, long long batch_size, RAI_Error *error) {
-  OrtStatus* status = NULL;
-  const OrtApi* ort = OrtGetApiBase()->GetApi(1);
+RAI_Tensor *RAI_TensorCreateFromOrtValue(OrtValue *v, size_t batch_offset, long long batch_size,
+                                         RAI_Error *error) {
+    OrtStatus *status = NULL;
+    const OrtApi *ort = OrtGetApiBase()->GetApi(1);
 
-  RAI_Tensor* ret = NULL;
-  int64_t *shape = NULL;
-  int64_t *strides = NULL;
- 
-  int is_tensor;
-  status = ort->IsTensor(v, &is_tensor);
-  if (status != NULL) goto error;
+    RAI_Tensor *ret = NULL;
+    int64_t *shape = NULL;
+    int64_t *strides = NULL;
 
-  if (!is_tensor) {
-    // TODO: if not tensor, flatten the data structure (sequence or map) and store it in a tensor.
-    // If return value is string, emit warning.
-    return NULL;
-  }
+    int is_tensor;
+    status = ort->IsTensor(v, &is_tensor);
+    if (status != NULL)
+        goto error;
 
-  ret = RedisModule_Calloc(1, sizeof(*ret));
+    if (!is_tensor) {
+        // TODO: if not tensor, flatten the data structure (sequence or map) and store it in a
+        // tensor. If return value is string, emit warning.
+        return NULL;
+    }
 
-  DLContext ctx = (DLContext){
-      .device_type = kDLCPU,
-      .device_id = 0
-  };
+    ret = RedisModule_Calloc(1, sizeof(*ret));
 
-  OrtTensorTypeAndShapeInfo* info;
-  status = ort->GetTensorTypeAndShape(v, &info);
-  if (status != NULL) goto error;
+    DLContext ctx = (DLContext){.device_type = kDLCPU, .device_id = 0};
 
-  {
-    size_t ndims;
-    status = ort->GetDimensionsCount(info, &ndims);
-    if (status != NULL) goto error;
+    OrtTensorTypeAndShapeInfo *info;
+    status = ort->GetTensorTypeAndShape(v, &info);
+    if (status != NULL)
+        goto error;
 
-    int64_t dims[ndims];
-    status = ort->GetDimensions(info, dims, ndims);
-    if (status != NULL) goto error;
-
-    enum ONNXTensorElementDataType ort_dtype;
-    status = ort->GetTensorElementType(info, &ort_dtype);
-    if (status != NULL) goto error;
-
-    int64_t total_batch_size = dims[0];
-    total_batch_size = total_batch_size > 0 ? total_batch_size : 1;
-
-    shape = RedisModule_Calloc(ndims, sizeof(*shape));
-    strides = RedisModule_Calloc(ndims, sizeof(*strides));
-    for (int64_t i=0; i<ndims; ++i)
     {
-      shape[i] = dims[i];
-      strides[i] = 1;
-    }
-    if (batch_size != -1) {
-      shape[0] = batch_size;
-    }
-    else {
-      batch_size = total_batch_size;
-    }
-    for (int64_t i = ndims - 2; i >= 0; --i)
-    {
-      strides[i] *= strides[i + 1] * shape[i + 1];
-    }
+        size_t ndims;
+        status = ort->GetDimensionsCount(info, &ndims);
+        if (status != NULL)
+            goto error;
 
-    // size_t sample_bytesize = TF_TensorByteSize(tensor) / total_batch_size;
+        int64_t dims[ndims];
+        status = ort->GetDimensions(info, dims, ndims);
+        if (status != NULL)
+            goto error;
 
-    DLDataType dtype = RAI_GetDLDataTypeFromORT(ort_dtype);
+        enum ONNXTensorElementDataType ort_dtype;
+        status = ort->GetTensorElementType(info, &ort_dtype);
+        if (status != NULL)
+            goto error;
+
+        int64_t total_batch_size = dims[0];
+        total_batch_size = total_batch_size > 0 ? total_batch_size : 1;
+
+        shape = RedisModule_Calloc(ndims, sizeof(*shape));
+        strides = RedisModule_Calloc(ndims, sizeof(*strides));
+        for (int64_t i = 0; i < ndims; ++i) {
+            shape[i] = dims[i];
+            strides[i] = 1;
+        }
+        if (batch_size != -1) {
+            shape[0] = batch_size;
+        } else {
+            batch_size = total_batch_size;
+        }
+        for (int64_t i = ndims - 2; i >= 0; --i) {
+            strides[i] *= strides[i + 1] * shape[i + 1];
+        }
+
+        // size_t sample_bytesize = TF_TensorByteSize(tensor) / total_batch_size;
+
+        DLDataType dtype = RAI_GetDLDataTypeFromORT(ort_dtype);
 #ifdef RAI_COPY_RUN_OUTPUT
-    char *ort_data;
-    status = ort->GetTensorMutableData(v, (void **)&ort_data);
-    if (status != NULL) {
-      goto error;
-    }
-    size_t elem_count;
-    status = ort->GetTensorShapeElementCount(info, &elem_count);
-    if (status != NULL) {
-      goto error;
-    }
+        char *ort_data;
+        status = ort->GetTensorMutableData(v, (void **)&ort_data);
+        if (status != NULL) {
+            goto error;
+        }
+        size_t elem_count;
+        status = ort->GetTensorShapeElementCount(info, &elem_count);
+        if (status != NULL) {
+            goto error;
+        }
 
-    const size_t len = dtype.bits * elem_count / 8;
+        const size_t len = dtype.bits * elem_count / 8;
 
-    const size_t total_bytesize = len * sizeof(char);
-    const size_t sample_bytesize = total_bytesize / total_batch_size;
-    const size_t batch_bytesize = sample_bytesize * batch_size;
+        const size_t total_bytesize = len * sizeof(char);
+        const size_t sample_bytesize = total_bytesize / total_batch_size;
+        const size_t batch_bytesize = sample_bytesize * batch_size;
 
-    char *data = RedisModule_Calloc(batch_bytesize, sizeof(*data));
-    memcpy(data, ort_data + batch_offset * sample_bytesize, batch_bytesize);
+        char *data = RedisModule_Calloc(batch_bytesize, sizeof(*data));
+        memcpy(data, ort_data + batch_offset * sample_bytesize, batch_bytesize);
 #endif
 
-    ort->ReleaseTensorTypeAndShapeInfo(info);
+        ort->ReleaseTensorTypeAndShapeInfo(info);
 
-    // TODO: use manager_ctx to ensure ORT tensor doesn't get deallocated
-    // This applies to outputs
+        // TODO: use manager_ctx to ensure ORT tensor doesn't get deallocated
+        // This applies to outputs
 
-    ret->tensor = (DLManagedTensor){
-        .dl_tensor = (DLTensor){
-            .ctx = ctx,
+        ret->tensor = (DLManagedTensor){.dl_tensor = (DLTensor){.ctx = ctx,
 #ifdef RAI_COPY_RUN_OUTPUT
-            .data = data,
+                                                                .data = data,
 #else
 #error zero-copy passing output memory from ORT not currently supported
 #endif
-            .ndim = ndims,
-            .dtype = dtype,
-            .shape = shape,
-            .strides = strides,
-            .byte_offset = 0},
-        .manager_ctx = NULL,
-        .deleter = NULL};
+                                                                .ndim = ndims,
+                                                                .dtype = dtype,
+                                                                .shape = shape,
+                                                                .strides = strides,
+                                                                .byte_offset = 0},
+                                        .manager_ctx = NULL,
+                                        .deleter = NULL};
 
-    ret->refCount = 1;
-    return ret;
-  }
+        ret->refCount = 1;
+        return ret;
+    }
 
 error:
-  RAI_SetError(error, RAI_EMODELCREATE, ort->GetErrorMessage(status));
-  ort->ReleaseStatus(status);
-  if (shape != NULL) {
-    RedisModule_Free(shape);
-  }
-  if (strides != NULL) {
-    RedisModule_Free(shape);
-  }
-  if (ret != NULL) {
-    RedisModule_Free(ret);
-  }
-  return NULL;
+    RAI_SetError(error, RAI_EMODELCREATE, ort->GetErrorMessage(status));
+    ort->ReleaseStatus(status);
+    if (shape != NULL) {
+        RedisModule_Free(shape);
+    }
+    if (strides != NULL) {
+        RedisModule_Free(shape);
+    }
+    if (ret != NULL) {
+        RedisModule_Free(ret);
+    }
+    return NULL;
 }
 
-OrtEnv* env = NULL;
+OrtEnv *env = NULL;
 
-RAI_Model *RAI_ModelCreateORT(RAI_Backend backend, const char* devicestr, RAI_ModelOpts opts,
-                              const char *modeldef, size_t modellen,
-                              RAI_Error *error) {
-  const OrtApi* ort = OrtGetApiBase()->GetApi(1);
+RAI_Model *RAI_ModelCreateORT(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
+                              const char *modeldef, size_t modellen, RAI_Error *error) {
+    const OrtApi *ort = OrtGetApiBase()->GetApi(1);
 
-  RAI_Device device;
-  int64_t deviceid;
+    RAI_Device device;
+    int64_t deviceid;
 
-  if (!parseDeviceStr(devicestr, &device, &deviceid)) {
-    RAI_SetError(error, RAI_EMODELCREATE, "ERR unsupported device");
-    return NULL;
-  }
+    if (!parseDeviceStr(devicestr, &device, &deviceid)) {
+        RAI_SetError(error, RAI_EMODELCREATE, "ERR unsupported device");
+        return NULL;
+    }
 
-  if (deviceid == -1){
-    // ORT does not like device id as -1
-    deviceid = 0;
-  }
+    if (deviceid == -1) {
+        // ORT does not like device id as -1
+        deviceid = 0;
+    }
 
-  OrtStatus* status = NULL;
+    OrtStatus *status = NULL;
 
-  if (env == NULL) {
-    status = ort->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "test", &env);
-  }
+    if (env == NULL) {
+        status = ort->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "test", &env);
+    }
 
-  if (status != NULL || env == NULL) {
-    goto error;
-  }
+    if (status != NULL || env == NULL) {
+        goto error;
+    }
 
-  // TODO: these options could be configured at the AI.CONFIG level
-  OrtSessionOptions* session_options;
-  status = ort->CreateSessionOptions(&session_options);
-  if (status != NULL) {
-    goto error;
-  }
+    // TODO: these options could be configured at the AI.CONFIG level
+    OrtSessionOptions *session_options;
+    status = ort->CreateSessionOptions(&session_options);
+    if (status != NULL) {
+        goto error;
+    }
 
-  // status = ort->SetSessionThreadPoolSize(session_options, 1);
-  if (status != NULL) {
-    ort->ReleaseSessionOptions(session_options);
-    goto error;
-  }
+    // status = ort->SetSessionThreadPoolSize(session_options, 1);
+    if (status != NULL) {
+        ort->ReleaseSessionOptions(session_options);
+        goto error;
+    }
 
-  status = ort->SetSessionGraphOptimizationLevel(session_options, 1);
-  if (status != NULL) {
-    ort->ReleaseSessionOptions(session_options);
-    goto error;
-  }
-  // TODO: we will need to propose a more dynamic way to request a specific provider,
-  // e.g. given the name, in ONNXRuntime
+    status = ort->SetSessionGraphOptimizationLevel(session_options, 1);
+    if (status != NULL) {
+        ort->ReleaseSessionOptions(session_options);
+        goto error;
+    }
+    // TODO: we will need to propose a more dynamic way to request a specific provider,
+    // e.g. given the name, in ONNXRuntime
 #if RAI_ONNXRUNTIME_USE_CUDA
-  if (device == RAI_DEVICE_GPU) {
-    OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, deviceid);
-  }
+    if (device == RAI_DEVICE_GPU) {
+        OrtSessionOptionsAppendExecutionProvider_CUDA(session_options, deviceid);
+    }
 #else
-  // TODO: Do dynamic device/provider check with GetExecutionProviderType or something on these lines
-  if (device == RAI_DEVICE_GPU) {
-    RAI_SetError(error, RAI_EMODELCREATE, "ERR GPU requested but ONNX couldn't find CUDA");
-    return NULL;
-  }
+    // TODO: Do dynamic device/provider check with GetExecutionProviderType or something on these
+    // lines
+    if (device == RAI_DEVICE_GPU) {
+        RAI_SetError(error, RAI_EMODELCREATE, "ERR GPU requested but ONNX couldn't find CUDA");
+        return NULL;
+    }
 #endif
 
-  OrtSession* session;
+    OrtSession *session;
 
-  status = ort->CreateSessionFromArray(env, modeldef, modellen, session_options, &session);
+    status = ort->CreateSessionFromArray(env, modeldef, modellen, session_options, &session);
 
-  ort->ReleaseSessionOptions(session_options);
+    ort->ReleaseSessionOptions(session_options);
 
-  if (status != NULL) {
-    goto error;
-  }
+    if (status != NULL) {
+        goto error;
+    }
 
-  // Since ONNXRuntime doesn't have a re-serialization function,
-  // we cache the blob in order to re-serialize it.
-  // Not optimal for storage purposes, but again, it may be temporary
-  char* buffer = RedisModule_Calloc(modellen, sizeof(*buffer));
-  memcpy(buffer, modeldef, modellen);
+    // Since ONNXRuntime doesn't have a re-serialization function,
+    // we cache the blob in order to re-serialize it.
+    // Not optimal for storage purposes, but again, it may be temporary
+    char *buffer = RedisModule_Calloc(modellen, sizeof(*buffer));
+    memcpy(buffer, modeldef, modellen);
 
-  RAI_Model* ret = RedisModule_Calloc(1, sizeof(*ret));
-  ret->model = NULL;
-  ret->session = session;
-  ret->backend = backend;
-  ret->devicestr = RedisModule_Strdup(devicestr);
-  ret->refCount = 1;
-  ret->opts = opts;
-  ret->data = buffer;
-  ret->datalen = modellen;
+    RAI_Model *ret = RedisModule_Calloc(1, sizeof(*ret));
+    ret->model = NULL;
+    ret->session = session;
+    ret->backend = backend;
+    ret->devicestr = RedisModule_Strdup(devicestr);
+    ret->refCount = 1;
+    ret->opts = opts;
+    ret->data = buffer;
+    ret->datalen = modellen;
 
-  return ret;
+    return ret;
 
 error:
-  RAI_SetError(error, RAI_EMODELCREATE, ort->GetErrorMessage(status));
-  ort->ReleaseStatus(status);
-  return NULL;
+    RAI_SetError(error, RAI_EMODELCREATE, ort->GetErrorMessage(status));
+    ort->ReleaseStatus(status);
+    return NULL;
 }
 
-void RAI_ModelFreeORT(RAI_Model* model, RAI_Error* error) {
-  const OrtApi* ort = OrtGetApiBase()->GetApi(1);
+void RAI_ModelFreeORT(RAI_Model *model, RAI_Error *error) {
+    const OrtApi *ort = OrtGetApiBase()->GetApi(1);
 
-  RedisModule_Free(model->data);
-  RedisModule_Free(model->devicestr);
-  ort->ReleaseSession(model->session);
+    RedisModule_Free(model->data);
+    RedisModule_Free(model->devicestr);
+    ort->ReleaseSession(model->session);
 
-  model->model = NULL;
-  model->session = NULL;
+    model->model = NULL;
+    model->session = NULL;
 }
 
-int RAI_ModelRunORT(RAI_ModelRunCtx **mctxs, RAI_Error *error)
-{
-  const OrtApi* ort = OrtGetApiBase()->GetApi(1);
+int RAI_ModelRunORT(RAI_ModelRunCtx **mctxs, RAI_Error *error) {
+    const OrtApi *ort = OrtGetApiBase()->GetApi(1);
 
-  OrtSession *session = mctxs[0]->model->session;
+    OrtSession *session = mctxs[0]->model->session;
 
-  if (session == NULL) {
-    RAI_SetError(error, RAI_EMODELRUN, "ERR ONNXRuntime session was not allocated");
-    return 1;
-  }
-
-  const size_t nbatches = array_len(mctxs);
-  if (nbatches == 0) {
-    RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
-    return 1;
-  }
- 
-  size_t batch_sizes[nbatches];
-  size_t batch_offsets[nbatches];
-  size_t total_batch_size = 0;
-  if (array_len(mctxs[0]->inputs) > 0) {
-    for (size_t b=0; b<nbatches; ++b) {
-      batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
-      total_batch_size += batch_sizes[b];
-    }
-    batch_offsets[0] = 0;
-    for (size_t b=1; b<nbatches; ++b) {
-      batch_offsets[b] = batch_offsets[b-1] + batch_sizes[b-1];
-    }
-  }
-
-  OrtStatus *status = NULL;
-
-  OrtAllocator *allocator;
-  status = ort->GetAllocatorWithDefaultOptions(&allocator);
-  if (status != NULL) {
-    goto error;
-  }
-
-  size_t n_input_nodes;
-  status = ort->SessionGetInputCount(session, &n_input_nodes);
-  if (status != NULL) {
-    goto error;
-  }
-
-  size_t n_output_nodes;
-  status = ort->SessionGetOutputCount(session, &n_output_nodes);
-  if (status != NULL) {
-    goto error;
-  }
-
-  {
-    const char *input_names[n_input_nodes];
-    const char *output_names[n_output_nodes];
-
-    OrtValue *inputs[n_input_nodes];
-    OrtValue *outputs[n_output_nodes];
-
-    const size_t ninputs = array_len(mctxs[0]->inputs);
-    const size_t noutputs = array_len(mctxs[0]->outputs);
-
-    if (ninputs != n_input_nodes) {
-      char msg[70];
-      sprintf(msg, "ERR Expected %li inputs but got %li", n_input_nodes, ninputs);
-      RAI_SetError(error, RAI_EMODELRUN, msg);
-      return 1;
-    }
-
-    if (noutputs != n_output_nodes) {
-      char msg[70];
-      sprintf(msg, "ERR Expected %li outputs but got %li", n_output_nodes, noutputs);
-      RAI_SetError(error, RAI_EMODELRUN, msg);
-      return 1;
-    }
-
-    for (size_t i = 0; i < n_input_nodes; i++) {
-      char *input_name;
-      status = ort->SessionGetInputName(session, i, allocator, &input_name);
-      if (status != NULL) {
-        goto error;
-      }
-
-      input_names[i] = input_name;
-
-      RAI_Tensor* batched_input_tensors[nbatches];
-      for (size_t b=0; b<nbatches; b++) {
-        batched_input_tensors[b] = mctxs[b]->inputs[i].tensor;
-      }
-
-      inputs[i] = RAI_OrtValueFromTensors(batched_input_tensors, nbatches, error);
-      if (error->code != RAI_OK) {
-        ort->ReleaseStatus(status);
+    if (session == NULL) {
+        RAI_SetError(error, RAI_EMODELRUN, "ERR ONNXRuntime session was not allocated");
         return 1;
-      }
+    }
+
+    const size_t nbatches = array_len(mctxs);
+    if (nbatches == 0) {
+        RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
+        return 1;
+    }
+
+    size_t batch_sizes[nbatches];
+    size_t batch_offsets[nbatches];
+    size_t total_batch_size = 0;
+    if (array_len(mctxs[0]->inputs) > 0) {
+        for (size_t b = 0; b < nbatches; ++b) {
+            batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
+            total_batch_size += batch_sizes[b];
+        }
+        batch_offsets[0] = 0;
+        for (size_t b = 1; b < nbatches; ++b) {
+            batch_offsets[b] = batch_offsets[b - 1] + batch_sizes[b - 1];
+        }
+    }
+
+    OrtStatus *status = NULL;
+
+    OrtAllocator *allocator;
+    status = ort->GetAllocatorWithDefaultOptions(&allocator);
+    if (status != NULL) {
+        goto error;
+    }
+
+    size_t n_input_nodes;
+    status = ort->SessionGetInputCount(session, &n_input_nodes);
+    if (status != NULL) {
+        goto error;
+    }
+
+    size_t n_output_nodes;
+    status = ort->SessionGetOutputCount(session, &n_output_nodes);
+    if (status != NULL) {
+        goto error;
+    }
+
+    {
+        const char *input_names[n_input_nodes];
+        const char *output_names[n_output_nodes];
+
+        OrtValue *inputs[n_input_nodes];
+        OrtValue *outputs[n_output_nodes];
+
+        const size_t ninputs = array_len(mctxs[0]->inputs);
+        const size_t noutputs = array_len(mctxs[0]->outputs);
+
+        if (ninputs != n_input_nodes) {
+            char msg[70];
+            sprintf(msg, "ERR Expected %li inputs but got %li", n_input_nodes, ninputs);
+            RAI_SetError(error, RAI_EMODELRUN, msg);
+            return 1;
+        }
+
+        if (noutputs != n_output_nodes) {
+            char msg[70];
+            sprintf(msg, "ERR Expected %li outputs but got %li", n_output_nodes, noutputs);
+            RAI_SetError(error, RAI_EMODELRUN, msg);
+            return 1;
+        }
+
+        for (size_t i = 0; i < n_input_nodes; i++) {
+            char *input_name;
+            status = ort->SessionGetInputName(session, i, allocator, &input_name);
+            if (status != NULL) {
+                goto error;
+            }
+
+            input_names[i] = input_name;
+
+            RAI_Tensor *batched_input_tensors[nbatches];
+            for (size_t b = 0; b < nbatches; b++) {
+                batched_input_tensors[b] = mctxs[b]->inputs[i].tensor;
+            }
+
+            inputs[i] = RAI_OrtValueFromTensors(batched_input_tensors, nbatches, error);
+            if (error->code != RAI_OK) {
+                ort->ReleaseStatus(status);
+                return 1;
+            }
 
 // TODO: use this to check input dim, shapes
 #if 0
@@ -511,101 +498,106 @@ int RAI_ModelRunORT(RAI_ModelRunCtx **mctxs, RAI_Error *error)
 
     OrtReleaseTypeInfo(typeinfo);
 #endif
-    }
-
-    for (size_t i = 0; i < n_output_nodes; i++) {
-      char *output_name;
-      status = ort->SessionGetOutputName(session, i, allocator, &output_name);
-      if (status != NULL) {
-        goto error;
-      }
-
-      output_names[i] = output_name;
-      outputs[i] = NULL;
-    }
-
-    // ORT_API_STATUS(OrtRun, _Inout_ OrtSession* sess,
-    //                _In_ OrtRunOptions* run_options,
-    //                _In_ const char* const* input_names, _In_ const OrtValue* const* input, size_t input_len,
-    //                _In_ const char* const* output_names, size_t output_names_len, _Out_ OrtValue** output);
-    OrtRunOptions *run_options = NULL;
-    status = ort->Run(session, run_options, input_names, (const OrtValue *const *)inputs,
-                     n_input_nodes, output_names, n_output_nodes, outputs);
-
-    if (status) {
-      goto error;
-    }
-
-    for (size_t i = 0; i < n_output_nodes; i++) {
-      if (nbatches > 1) {
-        OrtTensorTypeAndShapeInfo* info;
-        status = ort->GetTensorTypeAndShape(outputs[i], &info);
-        if (status != NULL) goto error;
-
-        size_t ndims;
-        status = ort->GetDimensionsCount(info, &ndims);
-        if (status != NULL) goto error;
-
-        int64_t dims[ndims];
-        status = ort->GetDimensions(info, dims, ndims);
-        if (status != NULL) goto error;
-
-        if (dims[0] != total_batch_size) {
-          RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");
-          ort->ReleaseStatus(status);
-          return 1;
         }
 
-        for (size_t b=0; b<nbatches; b++) {
-          RAI_Tensor* output_tensor = RAI_TensorCreateFromOrtValue(outputs[i], batch_offsets[b], batch_sizes[b], error);
-          if (error->code != RAI_OK) {
-            ort->ReleaseStatus(status);
-            return 1;
-          }
-          if (output_tensor) {
-            mctxs[b]->outputs[i].tensor = RAI_TensorGetShallowCopy(output_tensor);
-            RAI_TensorFree(output_tensor);
-          }
-          else {
-            printf("ERR: non-tensor output from ONNX models, ignoring (currently unsupported)");
-          }
-        }
-      }
-      else {
-        RAI_Tensor* output_tensor = RAI_TensorCreateFromOrtValue(outputs[i], 0, -1, error);
-        if (error->code != RAI_OK) {
-          ort->ReleaseStatus(status);
-          return 1;
-        }
-        if (output_tensor) {
-          mctxs[0]->outputs[i].tensor = RAI_TensorGetShallowCopy(output_tensor);
-          RAI_TensorFree(output_tensor);
-        }
-        else {
-          printf("ERR: non-tensor output from ONNX models, ignoring (currently unsupported)");
-        }
-      }
+        for (size_t i = 0; i < n_output_nodes; i++) {
+            char *output_name;
+            status = ort->SessionGetOutputName(session, i, allocator, &output_name);
+            if (status != NULL) {
+                goto error;
+            }
 
-      ort->ReleaseValue(outputs[i]);
+            output_names[i] = output_name;
+            outputs[i] = NULL;
+        }
+
+        // ORT_API_STATUS(OrtRun, _Inout_ OrtSession* sess,
+        //                _In_ OrtRunOptions* run_options,
+        //                _In_ const char* const* input_names, _In_ const OrtValue* const* input,
+        //                size_t input_len, _In_ const char* const* output_names, size_t
+        //                output_names_len, _Out_ OrtValue** output);
+        OrtRunOptions *run_options = NULL;
+        status = ort->Run(session, run_options, input_names, (const OrtValue *const *)inputs,
+                          n_input_nodes, output_names, n_output_nodes, outputs);
+
+        if (status) {
+            goto error;
+        }
+
+        for (size_t i = 0; i < n_output_nodes; i++) {
+            if (nbatches > 1) {
+                OrtTensorTypeAndShapeInfo *info;
+                status = ort->GetTensorTypeAndShape(outputs[i], &info);
+                if (status != NULL)
+                    goto error;
+
+                size_t ndims;
+                status = ort->GetDimensionsCount(info, &ndims);
+                if (status != NULL)
+                    goto error;
+
+                int64_t dims[ndims];
+                status = ort->GetDimensions(info, dims, ndims);
+                if (status != NULL)
+                    goto error;
+
+                if (dims[0] != total_batch_size) {
+                    RAI_SetError(error, RAI_EMODELRUN,
+                                 "ERR Model did not generate the expected batch size");
+                    ort->ReleaseStatus(status);
+                    return 1;
+                }
+
+                for (size_t b = 0; b < nbatches; b++) {
+                    RAI_Tensor *output_tensor = RAI_TensorCreateFromOrtValue(
+                        outputs[i], batch_offsets[b], batch_sizes[b], error);
+                    if (error->code != RAI_OK) {
+                        ort->ReleaseStatus(status);
+                        return 1;
+                    }
+                    if (output_tensor) {
+                        mctxs[b]->outputs[i].tensor = RAI_TensorGetShallowCopy(output_tensor);
+                        RAI_TensorFree(output_tensor);
+                    } else {
+                        printf("ERR: non-tensor output from ONNX models, ignoring (currently "
+                               "unsupported)");
+                    }
+                }
+            } else {
+                RAI_Tensor *output_tensor = RAI_TensorCreateFromOrtValue(outputs[i], 0, -1, error);
+                if (error->code != RAI_OK) {
+                    ort->ReleaseStatus(status);
+                    return 1;
+                }
+                if (output_tensor) {
+                    mctxs[0]->outputs[i].tensor = RAI_TensorGetShallowCopy(output_tensor);
+                    RAI_TensorFree(output_tensor);
+                } else {
+                    printf("ERR: non-tensor output from ONNX models, ignoring (currently "
+                           "unsupported)");
+                }
+            }
+
+            ort->ReleaseValue(outputs[i]);
+        }
+
+        for (size_t i = 0; i < n_input_nodes; i++) {
+            ort->ReleaseValue(inputs[i]);
+        }
+
+        return 0;
     }
-
-    for (size_t i = 0; i < n_input_nodes; i++) {
-      ort->ReleaseValue(inputs[i]);
-    }
-
-    return 0;
-  }
 
 error:
-  RAI_SetError(error, RAI_EMODELRUN, ort->GetErrorMessage(status));
-  ort->ReleaseStatus(status);
-  return 1;
+    RAI_SetError(error, RAI_EMODELRUN, ort->GetErrorMessage(status));
+    ort->ReleaseStatus(status);
+    return 1;
 }
 
 int RAI_ModelSerializeORT(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error) {
-  *buffer = RedisModule_Calloc(model->datalen, sizeof(char));
-  memcpy(*buffer, model->data, model->datalen);
-  *len = model->datalen;
+    *buffer = RedisModule_Calloc(model->datalen, sizeof(char));
+    memcpy(*buffer, model->data, model->datalen);
+    *len = model->datalen;
 
-  return 0;
+    return 0;
 }

--- a/src/backends/onnxruntime.h
+++ b/src/backends/onnxruntime.h
@@ -8,9 +8,8 @@
 
 int RAI_InitBackendORT(int (*get_api_fn)(const char *, void *));
 
-RAI_Model *RAI_ModelCreateORT(RAI_Backend backend,  const char* devicestr, RAI_ModelOpts opts,
-                              const char *modeldef, size_t modellen,
-                              RAI_Error *err);
+RAI_Model *RAI_ModelCreateORT(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
+                              const char *modeldef, size_t modellen, RAI_Error *err);
 
 void RAI_ModelFreeORT(RAI_Model *model, RAI_Error *error);
 

--- a/src/backends/tensorflow.c
+++ b/src/backends/tensorflow.c
@@ -7,591 +7,569 @@
 #include "tensorflow/c/c_api.h"
 
 int RAI_InitBackendTF(int (*get_api_fn)(const char *, void *)) {
-  get_api_fn("RedisModule_Alloc", ((void **)&RedisModule_Alloc));
-  get_api_fn("RedisModule_Calloc", ((void **)&RedisModule_Calloc));
-  get_api_fn("RedisModule_Free", ((void **)&RedisModule_Free));
-  get_api_fn("RedisModule_Realloc", ((void **)&RedisModule_Realloc));
-  get_api_fn("RedisModule_Strdup", ((void **)&RedisModule_Strdup));
+    get_api_fn("RedisModule_Alloc", ((void **)&RedisModule_Alloc));
+    get_api_fn("RedisModule_Calloc", ((void **)&RedisModule_Calloc));
+    get_api_fn("RedisModule_Free", ((void **)&RedisModule_Free));
+    get_api_fn("RedisModule_Realloc", ((void **)&RedisModule_Realloc));
+    get_api_fn("RedisModule_Strdup", ((void **)&RedisModule_Strdup));
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
 TF_DataType RAI_GetTFDataTypeFromDL(DLDataType dtype) {
 
-  if (dtype.code == kDLFloat) {
-    switch (dtype.bits) {
-      case 32:
-        return TF_FLOAT; break;
-      case 64:
-        return TF_DOUBLE; break;
-      default:
-        return 0;
+    if (dtype.code == kDLFloat) {
+        switch (dtype.bits) {
+        case 32:
+            return TF_FLOAT;
+            break;
+        case 64:
+            return TF_DOUBLE;
+            break;
+        default:
+            return 0;
+        }
+    } else if (dtype.code == kDLInt) {
+        switch (dtype.bits) {
+        case 8:
+            return TF_INT8;
+            break;
+        case 16:
+            return TF_INT16;
+            break;
+        case 32:
+            return TF_INT32;
+            break;
+        case 64:
+            return TF_INT64;
+            break;
+        default:
+            return 0;
+        }
+    } else if (dtype.code == kDLUInt) {
+        switch (dtype.bits) {
+        case 8:
+            return TF_UINT8;
+            break;
+        case 16:
+            return TF_UINT16;
+            break;
+        default:
+            return 0;
+        }
     }
-  }
-  else if (dtype.code == kDLInt) {
-    switch (dtype.bits) {
-      case 8:
-        return TF_INT8; break;
-      case 16:
-        return TF_INT16; break;
-      case 32:
-        return TF_INT32; break;
-      case 64:
-        return TF_INT64; break;
-      default:
-        return 0;
-    }
-  }
-  else if (dtype.code == kDLUInt) {
-    switch (dtype.bits) {
-      case 8:
-        return TF_UINT8; break;
-      case 16:
-        return TF_UINT16; break;
-      default:
-        return 0;
-    }
-  }
-  return 0;
+    return 0;
 }
 
 DLDataType RAI_GetDLDataTypeFromTF(TF_DataType dtype) {
-  switch (dtype) {
+    switch (dtype) {
     case TF_FLOAT:
-      return (DLDataType){ .code = kDLFloat, .bits = 32, .lanes = 1 };
+        return (DLDataType){.code = kDLFloat, .bits = 32, .lanes = 1};
     case TF_DOUBLE:
-      return (DLDataType){ .code = kDLFloat, .bits = 64, .lanes = 1 };
+        return (DLDataType){.code = kDLFloat, .bits = 64, .lanes = 1};
     case TF_INT8:
-      return (DLDataType){ .code = kDLInt, .bits = 8, .lanes = 1 };
+        return (DLDataType){.code = kDLInt, .bits = 8, .lanes = 1};
     case TF_INT16:
-      return (DLDataType){ .code = kDLInt, .bits = 16, .lanes = 1 };
+        return (DLDataType){.code = kDLInt, .bits = 16, .lanes = 1};
     case TF_INT32:
-      return (DLDataType){ .code = kDLInt, .bits = 32, .lanes = 1 };
+        return (DLDataType){.code = kDLInt, .bits = 32, .lanes = 1};
     case TF_INT64:
-      return (DLDataType){ .code = kDLInt, .bits = 64, .lanes = 1 };
+        return (DLDataType){.code = kDLInt, .bits = 64, .lanes = 1};
     case TF_UINT8:
-      return (DLDataType){ .code = kDLUInt, .bits = 8, .lanes = 1 };
+        return (DLDataType){.code = kDLUInt, .bits = 8, .lanes = 1};
     case TF_UINT16:
-      return (DLDataType){ .code = kDLUInt, .bits = 16, .lanes = 1 };
+        return (DLDataType){.code = kDLUInt, .bits = 16, .lanes = 1};
     default:
-      return (DLDataType){ .bits = 0 };
-  }
-  return (DLDataType){ .bits = 0 };
+        return (DLDataType){.bits = 0};
+    }
+    return (DLDataType){.bits = 0};
 }
 
-RAI_Tensor* RAI_TensorCreateFromTFTensor(TF_Tensor *tensor, size_t batch_offset, long long batch_size) {
-  RAI_Tensor* ret = RedisModule_Calloc(1, sizeof(*ret));
+RAI_Tensor *RAI_TensorCreateFromTFTensor(TF_Tensor *tensor, size_t batch_offset,
+                                         long long batch_size) {
+    RAI_Tensor *ret = RedisModule_Calloc(1, sizeof(*ret));
 
-  DLContext ctx = (DLContext){
-      .device_type = kDLCPU,
-      .device_id = 0
-  };
+    DLContext ctx = (DLContext){.device_type = kDLCPU, .device_id = 0};
 
-  const size_t ndims = TF_NumDims(tensor);
+    const size_t ndims = TF_NumDims(tensor);
 
-  int64_t total_batch_size = TF_Dim(tensor, 0);
-  total_batch_size = total_batch_size > 0 ? total_batch_size : 1;
+    int64_t total_batch_size = TF_Dim(tensor, 0);
+    total_batch_size = total_batch_size > 0 ? total_batch_size : 1;
 
-  int64_t* shape = RedisModule_Calloc(ndims, sizeof(*shape));
-  int64_t* strides = RedisModule_Calloc(ndims, sizeof(*strides));
-  for (int64_t i = 0 ; i < ndims ; ++i) {
-    shape[i] = TF_Dim(tensor, i);
-    strides[i] = 1;
-  }
-  if (batch_size != -1) {
-    shape[0] = batch_size;
-  }
-  else {
-    batch_size = total_batch_size;
-  }
-  for (int64_t i = ndims-2 ; i >= 0 ; --i) {
-    strides[i] *= strides[i+1] * shape[i+1];
-  }
+    int64_t *shape = RedisModule_Calloc(ndims, sizeof(*shape));
+    int64_t *strides = RedisModule_Calloc(ndims, sizeof(*strides));
+    for (int64_t i = 0; i < ndims; ++i) {
+        shape[i] = TF_Dim(tensor, i);
+        strides[i] = 1;
+    }
+    if (batch_size != -1) {
+        shape[0] = batch_size;
+    } else {
+        batch_size = total_batch_size;
+    }
+    for (int64_t i = ndims - 2; i >= 0; --i) {
+        strides[i] *= strides[i + 1] * shape[i + 1];
+    }
 
-  const size_t sample_bytesize = TF_TensorByteSize(tensor) / total_batch_size;
+    const size_t sample_bytesize = TF_TensorByteSize(tensor) / total_batch_size;
 
-  // FIXME: In TF, RunSession allocates memory for output tensors
-  // This means that we either memcpy the tensor data and let
-  // Redis be responsible for the memory, or we reuse the TF
-  // allocated memory, which might not be optimal down the road
-  // Note: on YOLO this has no impact on perf
+    // FIXME: In TF, RunSession allocates memory for output tensors
+    // This means that we either memcpy the tensor data and let
+    // Redis be responsible for the memory, or we reuse the TF
+    // allocated memory, which might not be optimal down the road
+    // Note: on YOLO this has no impact on perf
 #ifdef RAI_COPY_RUN_OUTPUT
-  const size_t len = sample_bytesize * batch_size;
-  char* data = RedisModule_Calloc(len, sizeof(*data));
-  memcpy(data, TF_TensorData(tensor) + sample_bytesize * batch_offset, len);
+    const size_t len = sample_bytesize * batch_size;
+    char *data = RedisModule_Calloc(len, sizeof(*data));
+    memcpy(data, TF_TensorData(tensor) + sample_bytesize * batch_offset, len);
 #endif
 
-  // TODO: use manager_ctx to ensure TF tensor doesn't get deallocated
-  // This applies to outputs
+    // TODO: use manager_ctx to ensure TF tensor doesn't get deallocated
+    // This applies to outputs
 
-  ret->tensor = (DLManagedTensor){
-    .dl_tensor = (DLTensor){
-      .ctx = ctx,
+    ret->tensor = (DLManagedTensor){
+        .dl_tensor = (DLTensor){.ctx = ctx,
 #ifdef RAI_COPY_RUN_OUTPUT
-      .data = data,
+                                .data = data,
 #else
-      .data = TF_TensorData(tensor),
+                                .data = TF_TensorData(tensor),
 #endif
-      .ndim = ndims,
-      .dtype = RAI_GetDLDataTypeFromTF(TF_TensorType(tensor)),
-      .shape = shape,
-      .strides = strides,
-      .byte_offset = 0
-    },
-    .manager_ctx = NULL,
-    .deleter = NULL
-  };
+                                .ndim = ndims,
+                                .dtype = RAI_GetDLDataTypeFromTF(TF_TensorType(tensor)),
+                                .shape = shape,
+                                .strides = strides,
+                                .byte_offset = 0},
+        .manager_ctx = NULL,
+        .deleter = NULL};
 
-  ret->refCount = 1;
-  return ret;
+    ret->refCount = 1;
+    return ret;
 }
 
-void RAI_TFDeallocator(void* data, size_t len, void* arg) {
-  // printf("DEALLOCATOR CALLED\n");
-  // do nothing, memory is managed by Redis
+void RAI_TFDeallocator(void *data, size_t len, void *arg) {
+    // printf("DEALLOCATOR CALLED\n");
+    // do nothing, memory is managed by Redis
 }
 
-TF_Tensor* RAI_TFTensorFromTensor(RAI_Tensor* t){
+TF_Tensor *RAI_TFTensorFromTensor(RAI_Tensor *t) {
 #ifdef RAI_COPY_RUN_INPUT
-  TF_Tensor* out = TF_AllocateTensor(
-      RAI_GetTFDataTypeFromDL(t->tensor.dl_tensor.dtype),
-      t->tensor.dl_tensor.shape,
-      t->tensor.dl_tensor.ndim,
-      RAI_TensorByteSize(t));
-  memcpy(TF_TensorData(out), t->tensor.dl_tensor.data, TF_TensorByteSize(out));
-  return out;
+    TF_Tensor *out = TF_AllocateTensor(RAI_GetTFDataTypeFromDL(t->tensor.dl_tensor.dtype),
+                                       t->tensor.dl_tensor.shape, t->tensor.dl_tensor.ndim,
+                                       RAI_TensorByteSize(t));
+    memcpy(TF_TensorData(out), t->tensor.dl_tensor.data, TF_TensorByteSize(out));
+    return out;
 #else
-  return TF_NewTensor(
-      RAI_GetTFDataTypeFromDL(t->tensor.dl_tensor.dtype),
-      t->tensor.dl_tensor.shape,
-      t->tensor.dl_tensor.ndim,
-      t->tensor.dl_tensor.data,
-      RAI_TensorByteSize(t),
-      &RAI_TFDeallocator,
-      NULL);
+    return TF_NewTensor(RAI_GetTFDataTypeFromDL(t->tensor.dl_tensor.dtype),
+                        t->tensor.dl_tensor.shape, t->tensor.dl_tensor.ndim,
+                        t->tensor.dl_tensor.data, RAI_TensorByteSize(t), &RAI_TFDeallocator, NULL);
 #endif /* RAI_COPY_RUN_INPUT */
 }
 
-TF_Tensor* RAI_TFTensorFromTensors(RAI_Tensor** ts, size_t count){
+TF_Tensor *RAI_TFTensorFromTensors(RAI_Tensor **ts, size_t count) {
 
-  if (count == 0) {
-    return NULL;
-  }
-
-  size_t batch_size = 0;
-  size_t batch_byte_size = 0;
-
-  for (size_t i=0; i<count; i++) {
-    batch_size += ts[i]->tensor.dl_tensor.shape[0];
-    batch_byte_size += RAI_TensorByteSize(ts[i]);
-  }
-
-  RAI_Tensor* t0 = ts[0];
-
-  const int ndim = t0->tensor.dl_tensor.ndim;
-  int64_t batched_shape[ndim];
-
-  for (size_t i=0; i<ndim; i++) {
-    batched_shape[i] = t0->tensor.dl_tensor.shape[i];
-  }
-
-  batched_shape[0] = batch_size;
-
-  TF_Tensor* out = NULL;
-
-  if (count > 1) {
-    out = TF_AllocateTensor(
-        RAI_GetTFDataTypeFromDL(t0->tensor.dl_tensor.dtype),
-        batched_shape,
-        t0->tensor.dl_tensor.ndim,
-        batch_byte_size);
-
-    size_t offset = 0;
-    for (size_t i=0; i<count; i++) {
-      size_t tbytesize = RAI_TensorByteSize(ts[i]);
-      memcpy(TF_TensorData(out) + offset, ts[i]->tensor.dl_tensor.data, tbytesize);
-      offset += tbytesize;
+    if (count == 0) {
+        return NULL;
     }
-  }
-  else {
-   out = TF_NewTensor(
-       RAI_GetTFDataTypeFromDL(t0->tensor.dl_tensor.dtype),
-       t0->tensor.dl_tensor.shape,
-       t0->tensor.dl_tensor.ndim,
-       t0->tensor.dl_tensor.data,
-       RAI_TensorByteSize(t0),
-       &RAI_TFDeallocator,
-       NULL);
-  }
 
-  return out;
+    size_t batch_size = 0;
+    size_t batch_byte_size = 0;
+
+    for (size_t i = 0; i < count; i++) {
+        batch_size += ts[i]->tensor.dl_tensor.shape[0];
+        batch_byte_size += RAI_TensorByteSize(ts[i]);
+    }
+
+    RAI_Tensor *t0 = ts[0];
+
+    const int ndim = t0->tensor.dl_tensor.ndim;
+    int64_t batched_shape[ndim];
+
+    for (size_t i = 0; i < ndim; i++) {
+        batched_shape[i] = t0->tensor.dl_tensor.shape[i];
+    }
+
+    batched_shape[0] = batch_size;
+
+    TF_Tensor *out = NULL;
+
+    if (count > 1) {
+        out = TF_AllocateTensor(RAI_GetTFDataTypeFromDL(t0->tensor.dl_tensor.dtype), batched_shape,
+                                t0->tensor.dl_tensor.ndim, batch_byte_size);
+
+        size_t offset = 0;
+        for (size_t i = 0; i < count; i++) {
+            size_t tbytesize = RAI_TensorByteSize(ts[i]);
+            memcpy(TF_TensorData(out) + offset, ts[i]->tensor.dl_tensor.data, tbytesize);
+            offset += tbytesize;
+        }
+    } else {
+        out = TF_NewTensor(RAI_GetTFDataTypeFromDL(t0->tensor.dl_tensor.dtype),
+                           t0->tensor.dl_tensor.shape, t0->tensor.dl_tensor.ndim,
+                           t0->tensor.dl_tensor.data, RAI_TensorByteSize(t0), &RAI_TFDeallocator,
+                           NULL);
+    }
+
+    return out;
 }
 
-
-RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char* devicestr, RAI_ModelOpts opts,
-                             size_t ninputs, const char **inputs,
-                             size_t noutputs, const char **outputs,
-                             const char *modeldef, size_t modellen,
+RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
+                             size_t ninputs, const char **inputs, size_t noutputs,
+                             const char **outputs, const char *modeldef, size_t modellen,
                              RAI_Error *error) {
-  TF_Graph* model = TF_NewGraph();
+    TF_Graph *model = TF_NewGraph();
 
-  RAI_Device device;
-  int64_t deviceid;
+    RAI_Device device;
+    int64_t deviceid;
 
-  if (!parseDeviceStr(devicestr, &device, &deviceid)) {
-    RAI_SetError(error, RAI_EMODELIMPORT, "ERR unsupported device");
-  }
-
-  TF_ImportGraphDefOptions* options = TF_NewImportGraphDefOptions();
-
-  TF_Buffer *tfbuffer = TF_NewBuffer();
-  tfbuffer->length = modellen;
-  tfbuffer->data = modeldef;
-
-  TF_Status *status = TF_NewStatus();
-
-  TF_GraphImportGraphDef(model, tfbuffer, options, status);
-
-  if (TF_GetCode(status) != TF_OK) {
-    char* errorMessage = RedisModule_Strdup(TF_Message(status));
-    RAI_SetError(error, RAI_EMODELIMPORT, errorMessage );
-    RedisModule_Free(errorMessage);
-    return NULL;
-  }
-
-  for (size_t i=0; i<ninputs; ++i) {
-    TF_Operation* oper = TF_GraphOperationByName(model, inputs[i]);
-    if (oper == NULL) {
-      size_t len = strlen(inputs[i]);
-      char* msg = RedisModule_Calloc(60 + len, sizeof(*msg));
-      sprintf(msg, "ERR Input node named \"%s\" not found in TF graph.", inputs[i]);
-      RAI_SetError(error, RAI_EMODELIMPORT, msg);
-      return NULL;
+    if (!parseDeviceStr(devicestr, &device, &deviceid)) {
+        RAI_SetError(error, RAI_EMODELIMPORT, "ERR unsupported device");
     }
-  }
 
-  for (size_t i=0; i<noutputs; ++i) {
-    TF_Operation* oper = TF_GraphOperationByName(model, outputs[i]);
-    if (oper == NULL) {
-      size_t len = strlen(outputs[i]);
-      char* msg = RedisModule_Calloc(60 + len, sizeof(*msg));
-      sprintf(msg, "ERR Output node named \"%s\" not found in TF graph", outputs[i]);
-      RAI_SetError(error, RAI_EMODELIMPORT, msg);
-      return NULL;
+    TF_ImportGraphDefOptions *options = TF_NewImportGraphDefOptions();
+
+    TF_Buffer *tfbuffer = TF_NewBuffer();
+    tfbuffer->length = modellen;
+    tfbuffer->data = modeldef;
+
+    TF_Status *status = TF_NewStatus();
+
+    TF_GraphImportGraphDef(model, tfbuffer, options, status);
+
+    if (TF_GetCode(status) != TF_OK) {
+        char *errorMessage = RedisModule_Strdup(TF_Message(status));
+        RAI_SetError(error, RAI_EMODELIMPORT, errorMessage);
+        RedisModule_Free(errorMessage);
+        return NULL;
     }
-  }
 
-  TF_DeleteImportGraphDefOptions(options);
-  TF_DeleteBuffer(tfbuffer);
-  TF_DeleteStatus(status);
+    for (size_t i = 0; i < ninputs; ++i) {
+        TF_Operation *oper = TF_GraphOperationByName(model, inputs[i]);
+        if (oper == NULL) {
+            size_t len = strlen(inputs[i]);
+            char *msg = RedisModule_Calloc(60 + len, sizeof(*msg));
+            sprintf(msg, "ERR Input node named \"%s\" not found in TF graph.", inputs[i]);
+            RAI_SetError(error, RAI_EMODELIMPORT, msg);
+            return NULL;
+        }
+    }
 
-  TF_Status *optionsStatus = TF_NewStatus();
+    for (size_t i = 0; i < noutputs; ++i) {
+        TF_Operation *oper = TF_GraphOperationByName(model, outputs[i]);
+        if (oper == NULL) {
+            size_t len = strlen(outputs[i]);
+            char *msg = RedisModule_Calloc(60 + len, sizeof(*msg));
+            sprintf(msg, "ERR Output node named \"%s\" not found in TF graph", outputs[i]);
+            RAI_SetError(error, RAI_EMODELIMPORT, msg);
+            return NULL;
+        }
+    }
 
-  TF_SessionOptions *sessionOptions = TF_NewSessionOptions();
+    TF_DeleteImportGraphDefOptions(options);
+    TF_DeleteBuffer(tfbuffer);
+    TF_DeleteStatus(status);
 
-  // For setting config options in session from the C API see:
-  // https://github.com/tensorflow/tensorflow/issues/13853
-  // import tensorflow as tf
-  // config = tf.ConfigProto(device_count = {'GPU': 0})
-  // serialized = config.SerializeToString()
-  // result = list(map(hex, serialized))
-  // print(result)
+    TF_Status *optionsStatus = TF_NewStatus();
 
-  if (device == RAI_DEVICE_CPU) {
-    // Set number of GPU to 0 with
-    // config.device_count = {'GPU': 0}
-    uint8_t config[] = {0x0a, 0x07, 0x0a, 0x03, 0x47, 0x50, 0x55, 0x10, 0x00};
-    TF_SetConfig(sessionOptions, (void *)config, sizeof(config), optionsStatus);
+    TF_SessionOptions *sessionOptions = TF_NewSessionOptions();
+
+    // For setting config options in session from the C API see:
+    // https://github.com/tensorflow/tensorflow/issues/13853
+    // import tensorflow as tf
+    // config = tf.ConfigProto(device_count = {'GPU': 0})
+    // serialized = config.SerializeToString()
+    // result = list(map(hex, serialized))
+    // print(result)
+
+    if (device == RAI_DEVICE_CPU) {
+        // Set number of GPU to 0 with
+        // config.device_count = {'GPU': 0}
+        uint8_t config[] = {0x0a, 0x07, 0x0a, 0x03, 0x47, 0x50, 0x55, 0x10, 0x00};
+        TF_SetConfig(sessionOptions, (void *)config, sizeof(config), optionsStatus);
+
+        if (TF_GetCode(optionsStatus) != TF_OK) {
+            RAI_SetError(error, RAI_EMODELCONFIGURE, RedisModule_Strdup(TF_Message(optionsStatus)));
+            // TODO: free memory
+            return NULL;
+        }
+
+        if (opts.backends_intra_op_parallelism > 0) {
+            uint8_t proto[] = {0x10, (uint8_t)opts.backends_intra_op_parallelism};
+            TF_SetConfig(sessionOptions, proto, sizeof(proto), optionsStatus);
+            if (TF_GetCode(optionsStatus) != TF_OK) {
+                RAI_SetError(error, RAI_EMODELCONFIGURE,
+                             RedisModule_Strdup(TF_Message(optionsStatus)));
+                // TODO: free memory
+                return NULL;
+            }
+        }
+
+        if (opts.backends_inter_op_parallelism > 0) {
+            uint8_t proto1[] = {0x28, (uint8_t)opts.backends_inter_op_parallelism};
+            TF_SetConfig(sessionOptions, proto1, sizeof(proto1), optionsStatus);
+            if (TF_GetCode(optionsStatus) != TF_OK) {
+                RAI_SetError(error, RAI_EMODELCONFIGURE,
+                             RedisModule_Strdup(TF_Message(optionsStatus)));
+                // TODO: free memory
+                return NULL;
+            }
+        }
+    } else if (device == RAI_DEVICE_GPU) {
+        if (deviceid == -1) {
+            // Set
+            // config.gpu_options.allow_growth = True
+            uint8_t config[4] = {0x32, 0x02, 0x20, 0x01};
+            TF_SetConfig(sessionOptions, (void *)config, 4, optionsStatus);
+        } else {
+            // Set
+            // config.gpu_options.allow_growth = True
+            // config.gpu_options.visible_device_list = '<deviceid>'
+            uint8_t config[7] = {0x32, 0x05, 0x20, 0x01, 0x2a, 0x01, 0x30};
+            config[6] += (uint8_t)deviceid;
+            TF_SetConfig(sessionOptions, (void *)config, 7, optionsStatus);
+        }
+    }
 
     if (TF_GetCode(optionsStatus) != TF_OK) {
-      RAI_SetError(error, RAI_EMODELCONFIGURE,
-                   RedisModule_Strdup(TF_Message(optionsStatus)));
-      // TODO: free memory
-      return NULL;
-    }
-
-    if (opts.backends_intra_op_parallelism > 0) {
-      uint8_t proto[] = {0x10, (uint8_t)opts.backends_intra_op_parallelism};
-      TF_SetConfig(sessionOptions, proto, sizeof(proto), optionsStatus);
-      if (TF_GetCode(optionsStatus) != TF_OK) {
-        RAI_SetError(error, RAI_EMODELCONFIGURE,
-                     RedisModule_Strdup(TF_Message(optionsStatus)));
+        RAI_SetError(error, RAI_EMODELCONFIGURE, RedisModule_Strdup(TF_Message(optionsStatus)));
         // TODO: free memory
         return NULL;
-      }
     }
+    TF_DeleteStatus(optionsStatus);
 
-    if (opts.backends_inter_op_parallelism > 0) {
-      uint8_t proto1[] = {0x28, (uint8_t)opts.backends_inter_op_parallelism};
-      TF_SetConfig(sessionOptions, proto1, sizeof(proto1), optionsStatus);
-      if (TF_GetCode(optionsStatus) != TF_OK) {
-        RAI_SetError(error, RAI_EMODELCONFIGURE,
-                     RedisModule_Strdup(TF_Message(optionsStatus)));
-        // TODO: free memory
+    TF_Status *sessionStatus = TF_NewStatus();
+    TF_Session *session = TF_NewSession(model, sessionOptions, sessionStatus);
+
+    TF_Status *deviceListStatus = TF_NewStatus();
+    TF_DeviceList *deviceList = TF_SessionListDevices(session, deviceListStatus);
+    const int num_devices = TF_DeviceListCount(deviceList);
+    int foundNoGPU = 1;
+    for (int i = 0; i < num_devices; ++i) {
+        const char *device_type = TF_DeviceListType(deviceList, i, deviceListStatus);
+        int cmp = strcmp(device_type, "GPU");
+        if (cmp == 0) {
+            foundNoGPU = 0;
+            break;
+        }
+    }
+    if (foundNoGPU == 1 && device == RAI_DEVICE_GPU) {
+        RAI_SetError(error, RAI_EMODELCREATE, "ERR GPU requested but TF couldn't find CUDA");
+        TF_DeleteDeviceList(deviceList);
+        TF_DeleteStatus(deviceListStatus);
+        // TODO: free other memory allocations
         return NULL;
-      }
     }
-  } else if (device == RAI_DEVICE_GPU) {
-    if (deviceid == -1) {
-      // Set
-      // config.gpu_options.allow_growth = True
-      uint8_t config[4] = {0x32, 0x02, 0x20, 0x01};
-      TF_SetConfig(sessionOptions, (void *)config, 4, optionsStatus);
-    }
-    else {
-      // Set
-      // config.gpu_options.allow_growth = True
-      // config.gpu_options.visible_device_list = '<deviceid>'
-      uint8_t config[7] = {0x32, 0x05, 0x20, 0x01, 0x2a, 0x01, 0x30};
-      config[6] += (uint8_t)deviceid;
-      TF_SetConfig(sessionOptions, (void *)config, 7, optionsStatus);
-    }
-  }
-
-  if (TF_GetCode(optionsStatus) != TF_OK) {
-    RAI_SetError(error, RAI_EMODELCONFIGURE, RedisModule_Strdup(TF_Message(optionsStatus)));
-    // TODO: free memory
-    return NULL;
-  }
-  TF_DeleteStatus(optionsStatus);
-
-  TF_Status *sessionStatus = TF_NewStatus();
-  TF_Session *session = TF_NewSession(model, sessionOptions, sessionStatus);
-
-  TF_Status *deviceListStatus = TF_NewStatus();
-  TF_DeviceList *deviceList = TF_SessionListDevices(session, deviceListStatus);
-  const int num_devices = TF_DeviceListCount(deviceList);
-  int foundNoGPU = 1;
-  for (int i = 0; i < num_devices; ++i) {
-    const char* device_type = TF_DeviceListType(deviceList, i, deviceListStatus);
-    int cmp = strcmp(device_type, "GPU");
-    if (cmp == 0) {
-      foundNoGPU = 0;
-      break;
-    }
-  }
-  if (foundNoGPU == 1 && device == RAI_DEVICE_GPU) {
-    RAI_SetError(error, RAI_EMODELCREATE, "ERR GPU requested but TF couldn't find CUDA");
     TF_DeleteDeviceList(deviceList);
     TF_DeleteStatus(deviceListStatus);
-    // TODO: free other memory allocations
-    return NULL;
-  }
-  TF_DeleteDeviceList(deviceList);
-  TF_DeleteStatus(deviceListStatus);
 
+    if (TF_GetCode(sessionStatus) != TF_OK) {
+        RAI_SetError(error, RAI_EMODELCREATE, RedisModule_Strdup(TF_Message(status)));
+        // TODO: free memory
+        return NULL;
+    }
 
-  if (TF_GetCode(sessionStatus) != TF_OK) {
-    RAI_SetError(error, RAI_EMODELCREATE, RedisModule_Strdup(TF_Message(status)));
-    // TODO: free memory
-    return NULL;
-  }
+    TF_DeleteSessionOptions(sessionOptions);
+    TF_DeleteStatus(sessionStatus);
 
-  TF_DeleteSessionOptions(sessionOptions);
-  TF_DeleteStatus(sessionStatus);
+    char **inputs_ = array_new(char *, ninputs);
+    for (long long i = 0; i < ninputs; i++) {
+        inputs_ = array_append(inputs_, RedisModule_Strdup(inputs[i]));
+    }
 
-  char **inputs_ = array_new(char*, ninputs);
-  for (long long i=0; i<ninputs; i++) {
-    inputs_ = array_append(inputs_, RedisModule_Strdup(inputs[i]));
-  }
+    char **outputs_ = array_new(char *, noutputs);
+    for (long long i = 0; i < noutputs; i++) {
+        outputs_ = array_append(outputs_, RedisModule_Strdup(outputs[i]));
+    }
 
-  char **outputs_ = array_new(char*, noutputs);
-  for (long long i=0; i<noutputs; i++) {
-    outputs_ = array_append(outputs_, RedisModule_Strdup(outputs[i]));
-  }
+    char *buffer = RedisModule_Calloc(modellen, sizeof(*buffer));
+    memcpy(buffer, modeldef, modellen);
 
-  char* buffer = RedisModule_Calloc(modellen, sizeof(*buffer));
-  memcpy(buffer, modeldef, modellen);
+    RAI_Model *ret = RedisModule_Calloc(1, sizeof(*ret));
+    ret->model = model;
+    ret->session = session;
+    ret->backend = backend;
+    ret->devicestr = RedisModule_Strdup(devicestr);
+    ret->inputs = inputs_;
+    ret->outputs = outputs_;
+    ret->opts = opts;
+    ret->refCount = 1;
+    ret->data = buffer;
+    ret->datalen = modellen;
 
-  RAI_Model* ret = RedisModule_Calloc(1, sizeof(*ret));
-  ret->model = model;
-  ret->session = session;
-  ret->backend = backend;
-  ret->devicestr = RedisModule_Strdup(devicestr);
-  ret->inputs = inputs_;
-  ret->outputs = outputs_;
-  ret->opts = opts;
-  ret->refCount = 1;
-  ret->data = buffer;
-  ret->datalen = modellen;
- 
-  return ret;
+    return ret;
 }
 
-void RAI_ModelFreeTF(RAI_Model* model, RAI_Error* error) {
-  TF_Status *status = TF_NewStatus();
-  TF_CloseSession(model->session, status);
+void RAI_ModelFreeTF(RAI_Model *model, RAI_Error *error) {
+    TF_Status *status = TF_NewStatus();
+    TF_CloseSession(model->session, status);
 
-  if (TF_GetCode(status) != TF_OK) {
-    RAI_SetError(error, RAI_EMODELFREE, RedisModule_Strdup(TF_Message(status)));
-    return;
-  }
-
-  TF_DeleteSession(model->session, status);
-  model->session = NULL;
-
-  if (TF_GetCode(status) != TF_OK) {
-    RAI_SetError(error, RAI_EMODELFREE, RedisModule_Strdup(TF_Message(status)));
-    return;
-  }
-
-  TF_DeleteGraph(model->model);
-  model->model = NULL;
-
-  RedisModule_Free(model->devicestr);
-
-  if (model->inputs) {
-    size_t ninputs = array_len(model->inputs);
-    for (size_t i=0; i<ninputs; i++) {
-      RedisModule_Free(model->inputs[i]);
+    if (TF_GetCode(status) != TF_OK) {
+        RAI_SetError(error, RAI_EMODELFREE, RedisModule_Strdup(TF_Message(status)));
+        return;
     }
-    array_free(model->inputs);
-  }
 
-  if (model->outputs) {
-    size_t noutputs = array_len(model->outputs);
-    for (size_t i=0; i<noutputs; i++) {
-      RedisModule_Free(model->outputs[i]);
+    TF_DeleteSession(model->session, status);
+    model->session = NULL;
+
+    if (TF_GetCode(status) != TF_OK) {
+        RAI_SetError(error, RAI_EMODELFREE, RedisModule_Strdup(TF_Message(status)));
+        return;
     }
-    array_free(model->outputs);
-  }
 
-  if (model->data) {
-    RedisModule_Free(model->data);
-  }
+    TF_DeleteGraph(model->model);
+    model->model = NULL;
 
-  TF_DeleteStatus(status);
-}
+    RedisModule_Free(model->devicestr);
 
-int RAI_ModelRunTF(RAI_ModelRunCtx** mctxs, RAI_Error *error) {
-  TF_Status *status = TF_NewStatus();
-
-  const size_t nbatches = array_len(mctxs);
-  if (nbatches == 0) {
-    RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
-    return 1;
-  }
-  
-  const size_t ninputs = array_len(mctxs[0]->inputs);
-  const size_t noutputs = array_len(mctxs[0]->outputs);
-  TF_Tensor* inputTensorsValues[ninputs];
-  TF_Output inputs[ninputs];
-  TF_Tensor* outputTensorsValues[noutputs];
-  TF_Output outputs[noutputs];
-
-  size_t batch_sizes[nbatches];
-  size_t batch_offsets[nbatches];
-  size_t total_batch_size = 0;
-  if (ninputs > 0) {
-    for (size_t b=0; b<nbatches; ++b) {
-      batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
-      total_batch_size += batch_sizes[b];
+    if (model->inputs) {
+        size_t ninputs = array_len(model->inputs);
+        for (size_t i = 0; i < ninputs; i++) {
+            RedisModule_Free(model->inputs[i]);
+        }
+        array_free(model->inputs);
     }
-    batch_offsets[0] = 0;
-    for (size_t b=1; b<nbatches; ++b) {
-      batch_offsets[b] = batch_offsets[b-1] + batch_sizes[b-1];
+
+    if (model->outputs) {
+        size_t noutputs = array_len(model->outputs);
+        for (size_t i = 0; i < noutputs; i++) {
+            RedisModule_Free(model->outputs[i]);
+        }
+        array_free(model->outputs);
     }
-  }
 
-  for (size_t i=0; i<ninputs; ++i) {
-    RAI_Tensor* batched_input_tensors[nbatches];
-
-    for (size_t b=0; b<nbatches; ++b) {
-      batched_input_tensors[b] = mctxs[b]->inputs[i].tensor;
+    if (model->data) {
+        RedisModule_Free(model->data);
     }
-    inputTensorsValues[i] = RAI_TFTensorFromTensors(batched_input_tensors, nbatches);
-    TF_Output port;
-    port.oper = TF_GraphOperationByName(mctxs[0]->model->model, mctxs[0]->inputs[i].name);
-    port.index = 0;
-    if(port.oper == NULL){
-      return 1;
-    }
-    inputs[i] = port;
-  }
 
-  for (size_t i=0 ; i<noutputs; ++i) {
-    TF_Output port;
-    port.oper = TF_GraphOperationByName(mctxs[0]->model->model, mctxs[0]->outputs[i].name);
-    port.index = 0;
-    if(port.oper == NULL){
-      return 1;
-    }
-    outputs[i] = port;
-  }
-
-  TF_SessionRun(mctxs[0]->model->session, NULL /* run_options */,
-                inputs, inputTensorsValues, ninputs,
-                outputs, outputTensorsValues, noutputs,
-                NULL /* target_opers */, 0 /* ntargets */,
-                NULL /* run_Metadata */,
-                status);
-
-  for(size_t i = 0 ; i < ninputs ; ++i) {
-    TF_DeleteTensor(inputTensorsValues[i]);
-  }
-
-  if (TF_GetCode(status) != TF_OK) {
-    char* errorMessage = RedisModule_Strdup(TF_Message(status));
-    RAI_SetError(error, RAI_EMODELRUN, errorMessage);
     TF_DeleteStatus(status);
-    RedisModule_Free(errorMessage);
-    return 1;
-  }
+}
 
-  for(size_t i=0; i<noutputs; ++i) {
-    if (nbatches > 1) {
-      if (TF_NumDims(outputTensorsValues[i]) == 0) {
-        continue;
-      }
-      if (TF_Dim(outputTensorsValues[i], 0) != total_batch_size) {
-        TF_DeleteTensor(outputTensorsValues[i]);
-        TF_DeleteStatus(status);
-        RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");
+int RAI_ModelRunTF(RAI_ModelRunCtx **mctxs, RAI_Error *error) {
+    TF_Status *status = TF_NewStatus();
+
+    const size_t nbatches = array_len(mctxs);
+    if (nbatches == 0) {
+        RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
         return 1;
-      }
-
-      for (size_t b=0; b<nbatches; b++) {
-        mctxs[b]->outputs[i].tensor = RAI_TensorCreateFromTFTensor(outputTensorsValues[i], batch_offsets[b], batch_sizes[b]);
-      }
     }
-    else {
-      mctxs[0]->outputs[i].tensor = RAI_TensorCreateFromTFTensor(outputTensorsValues[i], 0, -1);
+
+    const size_t ninputs = array_len(mctxs[0]->inputs);
+    const size_t noutputs = array_len(mctxs[0]->outputs);
+    TF_Tensor *inputTensorsValues[ninputs];
+    TF_Output inputs[ninputs];
+    TF_Tensor *outputTensorsValues[noutputs];
+    TF_Output outputs[noutputs];
+
+    size_t batch_sizes[nbatches];
+    size_t batch_offsets[nbatches];
+    size_t total_batch_size = 0;
+    if (ninputs > 0) {
+        for (size_t b = 0; b < nbatches; ++b) {
+            batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
+            total_batch_size += batch_sizes[b];
+        }
+        batch_offsets[0] = 0;
+        for (size_t b = 1; b < nbatches; ++b) {
+            batch_offsets[b] = batch_offsets[b - 1] + batch_sizes[b - 1];
+        }
     }
-    TF_DeleteTensor(outputTensorsValues[i]);
-  }
 
-  TF_DeleteStatus(status);
+    for (size_t i = 0; i < ninputs; ++i) {
+        RAI_Tensor *batched_input_tensors[nbatches];
 
-  return 0;
+        for (size_t b = 0; b < nbatches; ++b) {
+            batched_input_tensors[b] = mctxs[b]->inputs[i].tensor;
+        }
+        inputTensorsValues[i] = RAI_TFTensorFromTensors(batched_input_tensors, nbatches);
+        TF_Output port;
+        port.oper = TF_GraphOperationByName(mctxs[0]->model->model, mctxs[0]->inputs[i].name);
+        port.index = 0;
+        if (port.oper == NULL) {
+            return 1;
+        }
+        inputs[i] = port;
+    }
+
+    for (size_t i = 0; i < noutputs; ++i) {
+        TF_Output port;
+        port.oper = TF_GraphOperationByName(mctxs[0]->model->model, mctxs[0]->outputs[i].name);
+        port.index = 0;
+        if (port.oper == NULL) {
+            return 1;
+        }
+        outputs[i] = port;
+    }
+
+    TF_SessionRun(mctxs[0]->model->session, NULL /* run_options */, inputs, inputTensorsValues,
+                  ninputs, outputs, outputTensorsValues, noutputs, NULL /* target_opers */,
+                  0 /* ntargets */, NULL /* run_Metadata */, status);
+
+    for (size_t i = 0; i < ninputs; ++i) {
+        TF_DeleteTensor(inputTensorsValues[i]);
+    }
+
+    if (TF_GetCode(status) != TF_OK) {
+        char *errorMessage = RedisModule_Strdup(TF_Message(status));
+        RAI_SetError(error, RAI_EMODELRUN, errorMessage);
+        TF_DeleteStatus(status);
+        RedisModule_Free(errorMessage);
+        return 1;
+    }
+
+    for (size_t i = 0; i < noutputs; ++i) {
+        if (nbatches > 1) {
+            if (TF_NumDims(outputTensorsValues[i]) == 0) {
+                continue;
+            }
+            if (TF_Dim(outputTensorsValues[i], 0) != total_batch_size) {
+                TF_DeleteTensor(outputTensorsValues[i]);
+                TF_DeleteStatus(status);
+                RAI_SetError(error, RAI_EMODELRUN,
+                             "ERR Model did not generate the expected batch size");
+                return 1;
+            }
+
+            for (size_t b = 0; b < nbatches; b++) {
+                mctxs[b]->outputs[i].tensor = RAI_TensorCreateFromTFTensor(
+                    outputTensorsValues[i], batch_offsets[b], batch_sizes[b]);
+            }
+        } else {
+            mctxs[0]->outputs[i].tensor =
+                RAI_TensorCreateFromTFTensor(outputTensorsValues[i], 0, -1);
+        }
+        TF_DeleteTensor(outputTensorsValues[i]);
+    }
+
+    TF_DeleteStatus(status);
+
+    return 0;
 }
 
 int RAI_ModelSerializeTF(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error) {
 
-  if (model->data) {
-    *buffer = RedisModule_Calloc(model->datalen, sizeof(char));
-    memcpy(*buffer, model->data, model->datalen);
-    *len = model->datalen;
-  }
-  else {
-    TF_Buffer *tf_buffer = TF_NewBuffer();
-    TF_Status *status = TF_NewStatus();
+    if (model->data) {
+        *buffer = RedisModule_Calloc(model->datalen, sizeof(char));
+        memcpy(*buffer, model->data, model->datalen);
+        *len = model->datalen;
+    } else {
+        TF_Buffer *tf_buffer = TF_NewBuffer();
+        TF_Status *status = TF_NewStatus();
 
-    TF_GraphToGraphDef(model->model, tf_buffer, status);
+        TF_GraphToGraphDef(model->model, tf_buffer, status);
 
-    if (TF_GetCode(status) != TF_OK) {
-      RAI_SetError(error, RAI_EMODELSERIALIZE, "ERR Error serializing TF model");
-      TF_DeleteBuffer(tf_buffer);
-      TF_DeleteStatus(status);
-      return 1;
+        if (TF_GetCode(status) != TF_OK) {
+            RAI_SetError(error, RAI_EMODELSERIALIZE, "ERR Error serializing TF model");
+            TF_DeleteBuffer(tf_buffer);
+            TF_DeleteStatus(status);
+            return 1;
+        }
+
+        *buffer = RedisModule_Alloc(tf_buffer->length);
+        memcpy(*buffer, tf_buffer->data, tf_buffer->length);
+        *len = tf_buffer->length;
+
+        TF_DeleteBuffer(tf_buffer);
+        TF_DeleteStatus(status);
     }
 
-    *buffer = RedisModule_Alloc(tf_buffer->length);
-    memcpy(*buffer, tf_buffer->data, tf_buffer->length);
-    *len = tf_buffer->length;
-
-    TF_DeleteBuffer(tf_buffer);
-    TF_DeleteStatus(status);
-  }
-
-  return 0;
+    return 0;
 }

--- a/src/backends/tensorflow.h
+++ b/src/backends/tensorflow.h
@@ -8,10 +8,9 @@
 
 int RAI_InitBackendTF(int (*get_api_fn)(const char *, void *));
 
-RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char* devicestr, RAI_ModelOpts opts,
-                             size_t ninputs, const char **inputs,
-                             size_t noutputs, const char **outputs,
-                             const char *modeldef, size_t modellen,
+RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
+                             size_t ninputs, const char **inputs, size_t noutputs,
+                             const char **outputs, const char *modeldef, size_t modellen,
                              RAI_Error *error);
 
 void RAI_ModelFreeTF(RAI_Model *model, RAI_Error *error);

--- a/src/backends/tflite.c
+++ b/src/backends/tflite.c
@@ -5,173 +5,173 @@
 #include "libtflite_c/tflite_c.h"
 
 int RAI_InitBackendTFLite(int (*get_api_fn)(const char *, void *)) {
-  get_api_fn("RedisModule_Alloc", ((void **)&RedisModule_Alloc));
-  get_api_fn("RedisModule_Calloc", ((void **)&RedisModule_Calloc));
-  get_api_fn("RedisModule_Free", ((void **)&RedisModule_Free));
-  get_api_fn("RedisModule_Realloc", ((void **)&RedisModule_Realloc));
-  get_api_fn("RedisModule_Strdup", ((void **)&RedisModule_Strdup));
+    get_api_fn("RedisModule_Alloc", ((void **)&RedisModule_Alloc));
+    get_api_fn("RedisModule_Calloc", ((void **)&RedisModule_Calloc));
+    get_api_fn("RedisModule_Free", ((void **)&RedisModule_Free));
+    get_api_fn("RedisModule_Realloc", ((void **)&RedisModule_Realloc));
+    get_api_fn("RedisModule_Strdup", ((void **)&RedisModule_Strdup));
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
-RAI_Model *RAI_ModelCreateTFLite(RAI_Backend backend, const char* devicestr, RAI_ModelOpts opts,
-                                 const char *modeldef, size_t modellen,
-                                 RAI_Error *error) {
-  DLDeviceType dl_device;
-  
-  RAI_Device device;
-  int64_t deviceid;
-  if (!parseDeviceStr(devicestr, &device, &deviceid)) {
-    RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR Unsupported device");
-    return NULL;
-  }
+RAI_Model *RAI_ModelCreateTFLite(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
+                                 const char *modeldef, size_t modellen, RAI_Error *error) {
+    DLDeviceType dl_device;
 
-  switch (device) {
+    RAI_Device device;
+    int64_t deviceid;
+    if (!parseDeviceStr(devicestr, &device, &deviceid)) {
+        RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR Unsupported device");
+        return NULL;
+    }
+
+    switch (device) {
     case RAI_DEVICE_CPU:
-      dl_device = kDLCPU;
-      break;
+        dl_device = kDLCPU;
+        break;
     case RAI_DEVICE_GPU:
-      dl_device = kDLGPU;
-      break;
+        dl_device = kDLGPU;
+        break;
     default:
-      RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR Error configuring model: unsupported device");
-      return NULL;
-  }
+        RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR Error configuring model: unsupported device");
+        return NULL;
+    }
 
-  char* error_descr = NULL;
-  void* model = tfliteLoadModel(modeldef, modellen, dl_device, deviceid, &error_descr, RedisModule_Alloc);
+    char *error_descr = NULL;
+    void *model =
+        tfliteLoadModel(modeldef, modellen, dl_device, deviceid, &error_descr, RedisModule_Alloc);
 
-  if (model == NULL) {
-    RAI_SetError(error, RAI_EMODELCREATE, error_descr);
-    RedisModule_Free(error_descr);
-    return NULL;
-  }
+    if (model == NULL) {
+        RAI_SetError(error, RAI_EMODELCREATE, error_descr);
+        RedisModule_Free(error_descr);
+        return NULL;
+    }
 
-  char* buffer = RedisModule_Calloc(modellen, sizeof(*buffer));
-  memcpy(buffer, modeldef, modellen);
+    char *buffer = RedisModule_Calloc(modellen, sizeof(*buffer));
+    memcpy(buffer, modeldef, modellen);
 
-  RAI_Model* ret = RedisModule_Calloc(1, sizeof(*ret));
-  ret->model = model;
-  ret->session = NULL;
-  ret->backend = backend;
-  ret->devicestr = RedisModule_Strdup(devicestr);
-  ret->inputs = NULL;
-  ret->outputs = NULL;
-  ret->refCount = 1;
-  ret->opts = opts;
-  ret->data = buffer;
-  ret->datalen = modellen;
+    RAI_Model *ret = RedisModule_Calloc(1, sizeof(*ret));
+    ret->model = model;
+    ret->session = NULL;
+    ret->backend = backend;
+    ret->devicestr = RedisModule_Strdup(devicestr);
+    ret->inputs = NULL;
+    ret->outputs = NULL;
+    ret->refCount = 1;
+    ret->opts = opts;
+    ret->data = buffer;
+    ret->datalen = modellen;
 
-  return ret;
+    return ret;
 }
 
-void RAI_ModelFreeTFLite(RAI_Model* model, RAI_Error *error) {
-  RedisModule_Free(model->data);
-  RedisModule_Free(model->devicestr);
-  tfliteDeallocContext(model->model);
+void RAI_ModelFreeTFLite(RAI_Model *model, RAI_Error *error) {
+    RedisModule_Free(model->data);
+    RedisModule_Free(model->devicestr);
+    tfliteDeallocContext(model->model);
 
-  model->model = NULL;
+    model->model = NULL;
 }
 
-int RAI_ModelRunTFLite(RAI_ModelRunCtx** mctxs, RAI_Error *error) {
+int RAI_ModelRunTFLite(RAI_ModelRunCtx **mctxs, RAI_Error *error) {
 
-  const size_t nbatches = array_len(mctxs);
-  if (nbatches == 0) {
-    RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
-    return 1;
-  }
-
-  const size_t ninputs = array_len(mctxs[0]->inputs);
-  const size_t noutputs = array_len(mctxs[0]->outputs);
-
-  RAI_Tensor* inputs[ninputs];
-
-  DLManagedTensor* inputs_dl[ninputs];
-  DLManagedTensor* outputs_dl[noutputs];
-
-  size_t batch_sizes[nbatches];
-  size_t batch_offsets[nbatches];
-  size_t total_batch_size = 0;
-
-  if (nbatches > 1) {
-    if (array_len(mctxs[0]->inputs) > 0) {
-      for (size_t b=0; b<nbatches; ++b) {
-        batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
-        total_batch_size += batch_sizes[b];
-      }
-      batch_offsets[0] = 0;
-      for (size_t b=1; b<nbatches; ++b) {
-        batch_offsets[b] = batch_offsets[b-1] + batch_sizes[b-1];
-      }
+    const size_t nbatches = array_len(mctxs);
+    if (nbatches == 0) {
+        RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
+        return 1;
     }
- 
-    for (size_t i=0 ; i<ninputs; ++i) {
-      RAI_Tensor* batch[nbatches];
 
-      for (size_t b=0; b<nbatches; b++) {
-        batch[b] = mctxs[b]->inputs[i].tensor;
-      }
+    const size_t ninputs = array_len(mctxs[0]->inputs);
+    const size_t noutputs = array_len(mctxs[0]->outputs);
 
-      inputs[i] = RAI_TensorCreateByConcatenatingTensors(batch, nbatches);
-      inputs_dl[i] = &inputs[i]->tensor;
-    }
-  }
-  else {
-    for (size_t i=0 ; i<ninputs; ++i) {
-      inputs[i] = RAI_TensorGetShallowCopy(mctxs[0]->inputs[i].tensor);
-      inputs_dl[i] = &inputs[i]->tensor;
-    }
-  }
+    RAI_Tensor *inputs[ninputs];
 
-  for (size_t i=0 ; i<noutputs; ++i) {
-    outputs_dl[i] = NULL;
-  }
+    DLManagedTensor *inputs_dl[ninputs];
+    DLManagedTensor *outputs_dl[noutputs];
 
-  char* error_descr = NULL;
-  tfliteRunModel(mctxs[0]->model->model,
-                 ninputs, inputs_dl, noutputs, outputs_dl,
-                 &error_descr, RedisModule_Alloc);
+    size_t batch_sizes[nbatches];
+    size_t batch_offsets[nbatches];
+    size_t total_batch_size = 0;
 
-  if (error_descr != NULL) {
-    RAI_SetError(error, RAI_EMODELRUN, error_descr);
-    RedisModule_Free(error_descr);
-    return 1;
-  }
-
-  for(size_t i=0 ; i<noutputs; ++i) {
-    if (outputs_dl[i] == NULL) {
-      RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected number of outputs");
-      return 1;
-    }
-    RAI_Tensor* output_tensor = RAI_TensorCreateFromDLTensor(outputs_dl[i]);
-    if (nbatches > 1 && RAI_TensorDim(output_tensor, 0) != total_batch_size) {
-      RAI_TensorFree(output_tensor);
-      RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");
-      return 1;
-    }
     if (nbatches > 1) {
-      for (size_t b=0; b<nbatches; b++) {
-        mctxs[b]->outputs[i].tensor = RAI_TensorCreateBySlicingTensor(output_tensor, batch_offsets[b], batch_sizes[b]);
-      }
-    }
-    else {
-      mctxs[0]->outputs[i].tensor = RAI_TensorGetShallowCopy(output_tensor);
-    }
-    RAI_TensorFree(output_tensor);
-    RedisModule_Free(outputs_dl[i]);
-  }
+        if (array_len(mctxs[0]->inputs) > 0) {
+            for (size_t b = 0; b < nbatches; ++b) {
+                batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
+                total_batch_size += batch_sizes[b];
+            }
+            batch_offsets[0] = 0;
+            for (size_t b = 1; b < nbatches; ++b) {
+                batch_offsets[b] = batch_offsets[b - 1] + batch_sizes[b - 1];
+            }
+        }
 
-  for (size_t i=0 ; i<ninputs; ++i) {
-    RAI_TensorFree(inputs[i]);
-  }
+        for (size_t i = 0; i < ninputs; ++i) {
+            RAI_Tensor *batch[nbatches];
 
-  return 0;
+            for (size_t b = 0; b < nbatches; b++) {
+                batch[b] = mctxs[b]->inputs[i].tensor;
+            }
+
+            inputs[i] = RAI_TensorCreateByConcatenatingTensors(batch, nbatches);
+            inputs_dl[i] = &inputs[i]->tensor;
+        }
+    } else {
+        for (size_t i = 0; i < ninputs; ++i) {
+            inputs[i] = RAI_TensorGetShallowCopy(mctxs[0]->inputs[i].tensor);
+            inputs_dl[i] = &inputs[i]->tensor;
+        }
+    }
+
+    for (size_t i = 0; i < noutputs; ++i) {
+        outputs_dl[i] = NULL;
+    }
+
+    char *error_descr = NULL;
+    tfliteRunModel(mctxs[0]->model->model, ninputs, inputs_dl, noutputs, outputs_dl, &error_descr,
+                   RedisModule_Alloc);
+
+    if (error_descr != NULL) {
+        RAI_SetError(error, RAI_EMODELRUN, error_descr);
+        RedisModule_Free(error_descr);
+        return 1;
+    }
+
+    for (size_t i = 0; i < noutputs; ++i) {
+        if (outputs_dl[i] == NULL) {
+            RAI_SetError(error, RAI_EMODELRUN,
+                         "ERR Model did not generate the expected number of outputs");
+            return 1;
+        }
+        RAI_Tensor *output_tensor = RAI_TensorCreateFromDLTensor(outputs_dl[i]);
+        if (nbatches > 1 && RAI_TensorDim(output_tensor, 0) != total_batch_size) {
+            RAI_TensorFree(output_tensor);
+            RAI_SetError(error, RAI_EMODELRUN,
+                         "ERR Model did not generate the expected batch size");
+            return 1;
+        }
+        if (nbatches > 1) {
+            for (size_t b = 0; b < nbatches; b++) {
+                mctxs[b]->outputs[i].tensor = RAI_TensorCreateBySlicingTensor(
+                    output_tensor, batch_offsets[b], batch_sizes[b]);
+            }
+        } else {
+            mctxs[0]->outputs[i].tensor = RAI_TensorGetShallowCopy(output_tensor);
+        }
+        RAI_TensorFree(output_tensor);
+        RedisModule_Free(outputs_dl[i]);
+    }
+
+    for (size_t i = 0; i < ninputs; ++i) {
+        RAI_TensorFree(inputs[i]);
+    }
+
+    return 0;
 }
 
 int RAI_ModelSerializeTFLite(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error) {
-  *buffer = RedisModule_Calloc(model->datalen, sizeof(char));
-  memcpy(*buffer, model->data, model->datalen);
-  *len = model->datalen;
+    *buffer = RedisModule_Calloc(model->datalen, sizeof(char));
+    memcpy(*buffer, model->data, model->datalen);
+    *len = model->datalen;
 
-  return 0;
+    return 0;
 }

--- a/src/backends/tflite.h
+++ b/src/backends/tflite.h
@@ -8,9 +8,8 @@
 
 int RAI_InitBackendTFLite(int (*get_api_fn)(const char *, void *));
 
-RAI_Model *RAI_ModelCreateTFLite(RAI_Backend backend, const char* devicestr, RAI_ModelOpts opts,
-                                 const char *modeldef, size_t modellen,
-                                 RAI_Error *err);
+RAI_Model *RAI_ModelCreateTFLite(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
+                                 const char *modeldef, size_t modellen, RAI_Error *err);
 
 void RAI_ModelFreeTFLite(RAI_Model *model, RAI_Error *error);
 

--- a/src/backends/torch.c
+++ b/src/backends/torch.c
@@ -5,290 +5,287 @@
 #include "libtorch_c/torch_c.h"
 
 int RAI_InitBackendTorch(int (*get_api_fn)(const char *, void *)) {
-  get_api_fn("RedisModule_Alloc", ((void **)&RedisModule_Alloc));
-  get_api_fn("RedisModule_Calloc", ((void **)&RedisModule_Calloc));
-  get_api_fn("RedisModule_Free", ((void **)&RedisModule_Free));
-  get_api_fn("RedisModule_Realloc", ((void **)&RedisModule_Realloc));
-  get_api_fn("RedisModule_Strdup", ((void **)&RedisModule_Strdup));
+    get_api_fn("RedisModule_Alloc", ((void **)&RedisModule_Alloc));
+    get_api_fn("RedisModule_Calloc", ((void **)&RedisModule_Calloc));
+    get_api_fn("RedisModule_Free", ((void **)&RedisModule_Free));
+    get_api_fn("RedisModule_Realloc", ((void **)&RedisModule_Realloc));
+    get_api_fn("RedisModule_Strdup", ((void **)&RedisModule_Strdup));
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
-RAI_Model *RAI_ModelCreateTorch(RAI_Backend backend, const char* devicestr, RAI_ModelOpts opts,
-                                const char *modeldef, size_t modellen,
-                                RAI_Error *error) {
-  DLDeviceType dl_device;
-  
-  RAI_Device device = RAI_DEVICE_CPU;
-  int64_t deviceid = 0;
+RAI_Model *RAI_ModelCreateTorch(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
+                                const char *modeldef, size_t modellen, RAI_Error *error) {
+    DLDeviceType dl_device;
 
-  if (!parseDeviceStr(devicestr, &device, &deviceid)) {
-    RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR unsupported device");
-    return NULL;
-  }
+    RAI_Device device = RAI_DEVICE_CPU;
+    int64_t deviceid = 0;
 
-  switch (device) {
+    if (!parseDeviceStr(devicestr, &device, &deviceid)) {
+        RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR unsupported device");
+        return NULL;
+    }
+
+    switch (device) {
     case RAI_DEVICE_CPU:
-      dl_device = kDLCPU;
-      break;
+        dl_device = kDLCPU;
+        break;
     case RAI_DEVICE_GPU:
-      dl_device = kDLGPU;
-      break;
+        dl_device = kDLGPU;
+        break;
     default:
-      RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR Error configuring model: unsupported device");
-      return NULL;
-  }
+        RAI_SetError(error, RAI_EMODELCONFIGURE, "ERR Error configuring model: unsupported device");
+        return NULL;
+    }
 
-  char* error_descr = NULL;
-  if (opts.backends_inter_op_parallelism > 0) {
-      torchSetInterOpThreads(opts.backends_inter_op_parallelism, &error_descr, RedisModule_Alloc);
-  }
+    char *error_descr = NULL;
+    if (opts.backends_inter_op_parallelism > 0) {
+        torchSetInterOpThreads(opts.backends_inter_op_parallelism, &error_descr, RedisModule_Alloc);
+    }
 
-  if (error_descr != NULL) {
-    RAI_SetError(error, RAI_EMODELCREATE, error_descr);
-    RedisModule_Free(error_descr);
-    return NULL;
-  }
+    if (error_descr != NULL) {
+        RAI_SetError(error, RAI_EMODELCREATE, error_descr);
+        RedisModule_Free(error_descr);
+        return NULL;
+    }
 
+    if (opts.backends_intra_op_parallelism > 0) {
+        torchSetIntraOpThreads(opts.backends_intra_op_parallelism, &error_descr, RedisModule_Alloc);
+    }
+    if (error_descr != NULL) {
+        RAI_SetError(error, RAI_EMODELCREATE, error_descr);
+        RedisModule_Free(error_descr);
+        return NULL;
+    }
 
-  if (opts.backends_intra_op_parallelism > 0) {
-    torchSetIntraOpThreads(opts.backends_intra_op_parallelism, &error_descr, RedisModule_Alloc);
-  }
-  if (error_descr != NULL) {
-    RAI_SetError(error, RAI_EMODELCREATE, error_descr);
-    RedisModule_Free(error_descr);
-    return NULL;
-  }
+    void *model =
+        torchLoadModel(modeldef, modellen, dl_device, deviceid, &error_descr, RedisModule_Alloc);
 
-  void* model = torchLoadModel(modeldef, modellen, dl_device, deviceid, &error_descr, RedisModule_Alloc);
+    if (model == NULL) {
+        RAI_SetError(error, RAI_EMODELCREATE, error_descr);
+        RedisModule_Free(error_descr);
+        return NULL;
+    }
 
-  if (model == NULL) {
-    RAI_SetError(error, RAI_EMODELCREATE, error_descr);
-    RedisModule_Free(error_descr);
-    return NULL;
-  }
+    char *buffer = RedisModule_Calloc(modellen, sizeof(*buffer));
+    memcpy(buffer, modeldef, modellen);
 
-  char* buffer = RedisModule_Calloc(modellen, sizeof(*buffer));
-  memcpy(buffer, modeldef, modellen);
+    RAI_Model *ret = RedisModule_Calloc(1, sizeof(*ret));
+    ret->model = model;
+    ret->session = NULL;
+    ret->backend = backend;
+    ret->devicestr = RedisModule_Strdup(devicestr);
+    ret->inputs = NULL;
+    ret->outputs = NULL;
+    ret->opts = opts;
+    ret->refCount = 1;
+    ret->data = buffer;
+    ret->datalen = modellen;
 
-  RAI_Model* ret = RedisModule_Calloc(1, sizeof(*ret));
-  ret->model = model;
-  ret->session = NULL;
-  ret->backend = backend;
-  ret->devicestr = RedisModule_Strdup(devicestr);
-  ret->inputs = NULL;
-  ret->outputs = NULL;
-  ret->opts = opts;
-  ret->refCount = 1;
-  ret->data = buffer;
-  ret->datalen = modellen;
- 
-  return ret;
+    return ret;
 }
 
-void RAI_ModelFreeTorch(RAI_Model* model, RAI_Error *error) {
-  if(model->devicestr){
-    RedisModule_Free(model->devicestr);
-  }
-  if (model->data) {
-    RedisModule_Free(model->data);
-  }
-  torchDeallocContext(model->model);
+void RAI_ModelFreeTorch(RAI_Model *model, RAI_Error *error) {
+    if (model->devicestr) {
+        RedisModule_Free(model->devicestr);
+    }
+    if (model->data) {
+        RedisModule_Free(model->data);
+    }
+    torchDeallocContext(model->model);
 }
 
-int RAI_ModelRunTorch(RAI_ModelRunCtx** mctxs, RAI_Error *error) {
-  const size_t nbatches = array_len(mctxs);
-  if (nbatches == 0) {
-    RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
-    return 1;
-  }
-
-  const size_t ninputs = array_len(mctxs[0]->inputs);
-  const size_t noutputs = array_len(mctxs[0]->outputs);
-
-  RAI_Tensor* inputs[ninputs];
-
-  DLManagedTensor* inputs_dl[ninputs];
-  DLManagedTensor* outputs_dl[noutputs];
-
-  size_t batch_sizes[nbatches];
-  size_t batch_offsets[nbatches];
-  size_t total_batch_size = 0;
-
-  if (nbatches > 1) {
-    if (array_len(mctxs[0]->inputs) > 0) {
-      for (size_t b=0; b<nbatches; ++b) {
-        batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
-        total_batch_size += batch_sizes[b];
-      }
-      batch_offsets[0] = 0;
-      for (size_t b=1; b<nbatches; ++b) {
-        batch_offsets[b] = batch_offsets[b-1] + batch_sizes[b-1];
-      }
-    }
-
-    for (size_t i=0 ; i<ninputs; ++i) {
-      RAI_Tensor* batch[nbatches];
-
-      for (size_t b=0; b<nbatches; b++) {
-        batch[b] = mctxs[b]->inputs[i].tensor;
-      }
-
-      inputs[i] = RAI_TensorCreateByConcatenatingTensors(batch, nbatches);
-      inputs_dl[i] = &inputs[i]->tensor;
-    }
-  }
-  else {
-    for (size_t i=0 ; i<ninputs; ++i) {
-      inputs[i] = RAI_TensorGetShallowCopy(mctxs[0]->inputs[i].tensor);
-      inputs_dl[i] = &inputs[i]->tensor;
-    }
-  }
-
-  for (size_t i=0 ; i<noutputs; ++i) {
-    outputs_dl[i] = NULL;
-  }
-
-  char* error_descr = NULL;
-  torchRunModel(mctxs[0]->model->model,
-                ninputs, inputs_dl, noutputs, outputs_dl,
-                &error_descr, RedisModule_Alloc);
-
-  if (error_descr != NULL) {
-    RAI_SetError(error, RAI_EMODELRUN, error_descr);
-    RedisModule_Free(error_descr);
-    return 1;
-  }
-
-  for(size_t i=0 ; i<noutputs; ++i) {
-    if (outputs_dl[i] == NULL) {
-      RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected number of outputs");
-      return 1;
-    }
-    RAI_Tensor* output_tensor = RAI_TensorCreateFromDLTensor(outputs_dl[i]);
-    if (nbatches > 1) {
-      if (outputs_dl[i]->dl_tensor.shape[0] != total_batch_size) {
-        RAI_SetError(error, RAI_EMODELRUN, "ERR Model did not generate the expected batch size");
+int RAI_ModelRunTorch(RAI_ModelRunCtx **mctxs, RAI_Error *error) {
+    const size_t nbatches = array_len(mctxs);
+    if (nbatches == 0) {
+        RAI_SetError(error, RAI_EMODELRUN, "ERR No batches to run");
         return 1;
-      }
-      for (size_t b=0; b<nbatches; b++) {
-        mctxs[b]->outputs[i].tensor = RAI_TensorCreateBySlicingTensor(output_tensor, batch_offsets[b], batch_sizes[b]);
-      }
     }
-    else {
-      mctxs[0]->outputs[i].tensor = RAI_TensorGetShallowCopy(output_tensor);
+
+    const size_t ninputs = array_len(mctxs[0]->inputs);
+    const size_t noutputs = array_len(mctxs[0]->outputs);
+
+    RAI_Tensor *inputs[ninputs];
+
+    DLManagedTensor *inputs_dl[ninputs];
+    DLManagedTensor *outputs_dl[noutputs];
+
+    size_t batch_sizes[nbatches];
+    size_t batch_offsets[nbatches];
+    size_t total_batch_size = 0;
+
+    if (nbatches > 1) {
+        if (array_len(mctxs[0]->inputs) > 0) {
+            for (size_t b = 0; b < nbatches; ++b) {
+                batch_sizes[b] = RAI_TensorDim(mctxs[b]->inputs[0].tensor, 0);
+                total_batch_size += batch_sizes[b];
+            }
+            batch_offsets[0] = 0;
+            for (size_t b = 1; b < nbatches; ++b) {
+                batch_offsets[b] = batch_offsets[b - 1] + batch_sizes[b - 1];
+            }
+        }
+
+        for (size_t i = 0; i < ninputs; ++i) {
+            RAI_Tensor *batch[nbatches];
+
+            for (size_t b = 0; b < nbatches; b++) {
+                batch[b] = mctxs[b]->inputs[i].tensor;
+            }
+
+            inputs[i] = RAI_TensorCreateByConcatenatingTensors(batch, nbatches);
+            inputs_dl[i] = &inputs[i]->tensor;
+        }
+    } else {
+        for (size_t i = 0; i < ninputs; ++i) {
+            inputs[i] = RAI_TensorGetShallowCopy(mctxs[0]->inputs[i].tensor);
+            inputs_dl[i] = &inputs[i]->tensor;
+        }
     }
-    RAI_TensorFree(output_tensor);
-  }
 
-  for (size_t i=0 ; i<ninputs; ++i) {
-    RAI_TensorFree(inputs[i]);
-  }
+    for (size_t i = 0; i < noutputs; ++i) {
+        outputs_dl[i] = NULL;
+    }
 
-  return 0;
+    char *error_descr = NULL;
+    torchRunModel(mctxs[0]->model->model, ninputs, inputs_dl, noutputs, outputs_dl, &error_descr,
+                  RedisModule_Alloc);
+
+    if (error_descr != NULL) {
+        RAI_SetError(error, RAI_EMODELRUN, error_descr);
+        RedisModule_Free(error_descr);
+        return 1;
+    }
+
+    for (size_t i = 0; i < noutputs; ++i) {
+        if (outputs_dl[i] == NULL) {
+            RAI_SetError(error, RAI_EMODELRUN,
+                         "ERR Model did not generate the expected number of outputs");
+            return 1;
+        }
+        RAI_Tensor *output_tensor = RAI_TensorCreateFromDLTensor(outputs_dl[i]);
+        if (nbatches > 1) {
+            if (outputs_dl[i]->dl_tensor.shape[0] != total_batch_size) {
+                RAI_SetError(error, RAI_EMODELRUN,
+                             "ERR Model did not generate the expected batch size");
+                return 1;
+            }
+            for (size_t b = 0; b < nbatches; b++) {
+                mctxs[b]->outputs[i].tensor = RAI_TensorCreateBySlicingTensor(
+                    output_tensor, batch_offsets[b], batch_sizes[b]);
+            }
+        } else {
+            mctxs[0]->outputs[i].tensor = RAI_TensorGetShallowCopy(output_tensor);
+        }
+        RAI_TensorFree(output_tensor);
+    }
+
+    for (size_t i = 0; i < ninputs; ++i) {
+        RAI_TensorFree(inputs[i]);
+    }
+
+    return 0;
 }
 
 int RAI_ModelSerializeTorch(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error) {
 
-  if (model->data) {
-    *buffer = RedisModule_Calloc(model->datalen, sizeof(char));
-    memcpy(*buffer, model->data, model->datalen);
-    *len = model->datalen;
-  }
-  else {
-    char* error_descr = NULL;
-    torchSerializeModel(model->model, buffer, len, &error_descr, RedisModule_Alloc);
+    if (model->data) {
+        *buffer = RedisModule_Calloc(model->datalen, sizeof(char));
+        memcpy(*buffer, model->data, model->datalen);
+        *len = model->datalen;
+    } else {
+        char *error_descr = NULL;
+        torchSerializeModel(model->model, buffer, len, &error_descr, RedisModule_Alloc);
 
-    if (*buffer == NULL) {
-      RAI_SetError(error, RAI_EMODELSERIALIZE, error_descr);
-      RedisModule_Free(error_descr);
-      return 1;
+        if (*buffer == NULL) {
+            RAI_SetError(error, RAI_EMODELSERIALIZE, error_descr);
+            RedisModule_Free(error_descr);
+            return 1;
+        }
     }
-  }
 
-  return 0;
+    return 0;
 }
 
-RAI_Script *RAI_ScriptCreateTorch(const char* devicestr, const char *scriptdef, RAI_Error *error) {
-  DLDeviceType dl_device;
-  
-  RAI_Device device;
-  int64_t deviceid;
+RAI_Script *RAI_ScriptCreateTorch(const char *devicestr, const char *scriptdef, RAI_Error *error) {
+    DLDeviceType dl_device;
 
-  if (!parseDeviceStr(devicestr, &device, &deviceid)) {
-    RAI_SetError(error, RAI_ESCRIPTCONFIGURE, "ERR unsupported device");
-  }
+    RAI_Device device;
+    int64_t deviceid;
 
+    if (!parseDeviceStr(devicestr, &device, &deviceid)) {
+        RAI_SetError(error, RAI_ESCRIPTCONFIGURE, "ERR unsupported device");
+    }
 
-  switch (device) {
+    switch (device) {
     case RAI_DEVICE_CPU:
-      dl_device = kDLCPU;
-      break;
+        dl_device = kDLCPU;
+        break;
     case RAI_DEVICE_GPU:
-      dl_device = kDLGPU;
-      break;
+        dl_device = kDLGPU;
+        break;
     default:
-      RAI_SetError(error, RAI_ESCRIPTCONFIGURE, "ERR Error configuring script: unsupported device");
-      break;
-  }
+        RAI_SetError(error, RAI_ESCRIPTCONFIGURE,
+                     "ERR Error configuring script: unsupported device");
+        break;
+    }
 
-  char* error_descr = NULL;
-  void* script = torchCompileScript(scriptdef, dl_device, deviceid, &error_descr, RedisModule_Alloc);
+    char *error_descr = NULL;
+    void *script =
+        torchCompileScript(scriptdef, dl_device, deviceid, &error_descr, RedisModule_Alloc);
 
-  if (script == NULL) {
-    RAI_SetError(error, RAI_ESCRIPTCREATE, error_descr);
-    RedisModule_Free(error_descr);
-    return NULL;
-  }
+    if (script == NULL) {
+        RAI_SetError(error, RAI_ESCRIPTCREATE, error_descr);
+        RedisModule_Free(error_descr);
+        return NULL;
+    }
 
-  RAI_Script* ret = RedisModule_Calloc(1, sizeof(*ret));
-  ret->script = script;
-  ret->scriptdef = RedisModule_Strdup(scriptdef);
-  ret->devicestr = RedisModule_Strdup(devicestr);
-  ret->refCount = 1;
-  
-  return ret;
+    RAI_Script *ret = RedisModule_Calloc(1, sizeof(*ret));
+    ret->script = script;
+    ret->scriptdef = RedisModule_Strdup(scriptdef);
+    ret->devicestr = RedisModule_Strdup(devicestr);
+    ret->refCount = 1;
+
+    return ret;
 }
 
-void RAI_ScriptFreeTorch(RAI_Script* script, RAI_Error* error) {
+void RAI_ScriptFreeTorch(RAI_Script *script, RAI_Error *error) {
 
-  torchDeallocContext(script->script);
-  RedisModule_Free(script->scriptdef);
-  RedisModule_Free(script->devicestr);
-  RedisModule_Free(script);
+    torchDeallocContext(script->script);
+    RedisModule_Free(script->scriptdef);
+    RedisModule_Free(script->devicestr);
+    RedisModule_Free(script);
 }
 
-int RAI_ScriptRunTorch(RAI_ScriptRunCtx* sctx, RAI_Error* error) {
+int RAI_ScriptRunTorch(RAI_ScriptRunCtx *sctx, RAI_Error *error) {
 
-  long nInputs = array_len(sctx->inputs);
-  long nOutputs = array_len(sctx->outputs);
+    long nInputs = array_len(sctx->inputs);
+    long nOutputs = array_len(sctx->outputs);
 
-  DLManagedTensor* inputs[nInputs];
-  DLManagedTensor* outputs[nOutputs];
+    DLManagedTensor *inputs[nInputs];
+    DLManagedTensor *outputs[nOutputs];
 
-  for (size_t i=0; i<nInputs; i++) {
-    inputs[i] = &sctx->inputs[i].tensor->tensor;
-  }
+    for (size_t i = 0; i < nInputs; i++) {
+        inputs[i] = &sctx->inputs[i].tensor->tensor;
+    }
 
-  for (size_t i=0; i<nOutputs; i++) {
-    outputs[i] = &sctx->outputs[i].tensor->tensor;
-  }
+    for (size_t i = 0; i < nOutputs; i++) {
+        outputs[i] = &sctx->outputs[i].tensor->tensor;
+    }
 
-  char* error_descr = NULL;
-  torchRunScript(sctx->script->script, sctx->fnname,
-                 sctx->variadic,
-                 nInputs, inputs, nOutputs, outputs,
-                 &error_descr, RedisModule_Alloc);
+    char *error_descr = NULL;
+    torchRunScript(sctx->script->script, sctx->fnname, sctx->variadic, nInputs, inputs, nOutputs,
+                   outputs, &error_descr, RedisModule_Alloc);
 
-  if (error_descr) {
-    RAI_SetError(error, RAI_ESCRIPTRUN, error_descr);
-    RedisModule_Free(error_descr);
-    return 1;
-  }
+    if (error_descr) {
+        RAI_SetError(error, RAI_ESCRIPTRUN, error_descr);
+        RedisModule_Free(error_descr);
+        return 1;
+    }
 
-  for (size_t i=0; i<nOutputs; i++) {
-    sctx->outputs[i].tensor = RAI_TensorCreateFromDLTensor(outputs[i]);
-  }
+    for (size_t i = 0; i < nOutputs; i++) {
+        sctx->outputs[i].tensor = RAI_TensorCreateFromDLTensor(outputs[i]);
+    }
 
-  return 0;
+    return 0;
 }

--- a/src/backends/torch.h
+++ b/src/backends/torch.h
@@ -9,9 +9,8 @@
 
 int RAI_InitBackendTorch(int (*get_api_fn)(const char *, void *));
 
-RAI_Model *RAI_ModelCreateTorch(RAI_Backend backend, const char* devicestr, RAI_ModelOpts opts,
-                                const char *modeldef, size_t modellen,
-                                RAI_Error *err);
+RAI_Model *RAI_ModelCreateTorch(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
+                                const char *modeldef, size_t modellen, RAI_Error *err);
 
 void RAI_ModelFreeTorch(RAI_Model *model, RAI_Error *error);
 
@@ -19,8 +18,7 @@ int RAI_ModelRunTorch(RAI_ModelRunCtx **mctxs, RAI_Error *error);
 
 int RAI_ModelSerializeTorch(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error);
 
-RAI_Script *RAI_ScriptCreateTorch(const char* devicestr, const char *scriptdef,
-                                  RAI_Error *error);
+RAI_Script *RAI_ScriptCreateTorch(const char *devicestr, const char *scriptdef, RAI_Error *error);
 
 void RAI_ScriptFreeTorch(RAI_Script *script, RAI_Error *error);
 

--- a/src/backends/util.c
+++ b/src/backends/util.c
@@ -1,23 +1,21 @@
 #include "backends/util.h"
 
-int parseDeviceStr(const char* devicestr, RAI_Device* device,
-                   int64_t* deviceid) {
-  // if (strcasecmp(devicestr, "CPU") == 0) {
-  if (strncasecmp(devicestr, "CPU", 3) == 0) {
-    *device = RAI_DEVICE_CPU;
-    *deviceid = -1;
-  } else if (strcasecmp(devicestr, "GPU") == 0) {
-    *device = RAI_DEVICE_GPU;
-    *deviceid = -1;
-  } else if (strncasecmp(devicestr, "GPU:", 4) == 0) {
-    *device = RAI_DEVICE_GPU;
-    long long id;
-    sscanf(devicestr, "GPU:%lld", &id);
-    *deviceid = id;
-  } else {
-    return 0;
-  }
+int parseDeviceStr(const char *devicestr, RAI_Device *device, int64_t *deviceid) {
+    // if (strcasecmp(devicestr, "CPU") == 0) {
+    if (strncasecmp(devicestr, "CPU", 3) == 0) {
+        *device = RAI_DEVICE_CPU;
+        *deviceid = -1;
+    } else if (strcasecmp(devicestr, "GPU") == 0) {
+        *device = RAI_DEVICE_GPU;
+        *deviceid = -1;
+    } else if (strncasecmp(devicestr, "GPU:", 4) == 0) {
+        *device = RAI_DEVICE_GPU;
+        long long id;
+        sscanf(devicestr, "GPU:%lld", &id);
+        *deviceid = id;
+    } else {
+        return 0;
+    }
 
-  return 1;
+    return 1;
 }
-

--- a/src/backends/util.h
+++ b/src/backends/util.h
@@ -7,7 +7,6 @@
 
 #include "config.h"
 
-int parseDeviceStr(const char* devicestr, RAI_Device* device,
-                   int64_t* deviceid);
+int parseDeviceStr(const char *devicestr, RAI_Device *device, int64_t *deviceid);
 
 #endif /* SRC_BACKENDS_UTIL_H_ */

--- a/src/background_workers.c
+++ b/src/background_workers.c
@@ -21,502 +21,506 @@
 #include "util/arr_rm_alloc.h"
 #include "util/dict.h"
 #include "util/queue.h"
+#include <ctype.h>
+#include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <ctype.h>
 
 int freeRunQueueInfo(RunQueueInfo *info) {
-  int result = REDISMODULE_OK;
-  if (info->run_queue) {
-    RedisModule_Free(info->run_queue);
-  }
-  RedisModule_Free(info->devicestr);
-  if (info->threads) {
-    /* Wait for workers to exit */
-    for (int i = 0; i < perqueueThreadPoolSize; i++) {
-      const int rtn = pthread_join(info->threads[i], NULL);
-      if (rtn != 0) {
-        result = REDISMODULE_ERR;
-      }
+    int result = REDISMODULE_OK;
+    if (info->run_queue) {
+        RedisModule_Free(info->run_queue);
     }
-    /* Now free pool structure */
-    RedisModule_Free(info->threads);
-  }
-  RedisModule_Free(info);
-  return result;
+    RedisModule_Free(info->devicestr);
+    if (info->threads) {
+        /* Wait for workers to exit */
+        for (int i = 0; i < perqueueThreadPoolSize; i++) {
+            const int rtn = pthread_join(info->threads[i], NULL);
+            if (rtn != 0) {
+                result = REDISMODULE_ERR;
+            }
+        }
+        /* Now free pool structure */
+        RedisModule_Free(info->threads);
+    }
+    RedisModule_Free(info);
+    return result;
 }
 
 void *RedisAI_Run_ThreadMain(void *arg);
 
-char* strToUpper(const char* input) {
-  char* output = RedisModule_Strdup(input);
-  size_t output_len = strlen(output);
-  for (long long i=0; i<output_len; i++) {
-    output[i] = toupper(output[i]);
-  }
-  return output;
+char *strToUpper(const char *input) {
+    char *output = RedisModule_Strdup(input);
+    size_t output_len = strlen(output);
+    for (long long i = 0; i < output_len; i++) {
+        output[i] = toupper(output[i]);
+    }
+    return output;
 }
 
 /* Ensure that the the run queue for the device exists.
  * If not, create it. */
 int ensureRunQueue(const char *devicestr, RunQueueInfo **run_queue_info) {
-  int result = REDISMODULE_ERR;
-  if (run_queues == NULL) {
-    return result;
-  }
-
-  char *devicestr_ = strToUpper(devicestr);
-
-  AI_dictEntry *entry = AI_dictFind(run_queues, devicestr_);
-  if (entry) {
-    *run_queue_info = AI_dictGetVal(entry);
-    result = REDISMODULE_OK;
-  } else {
-    *run_queue_info = RedisModule_Alloc(sizeof(RunQueueInfo));
-    (*run_queue_info)->run_queue = queueCreate();
-    (*run_queue_info)->devicestr = RedisModule_Strdup(devicestr_);
-    pthread_cond_init(&(*run_queue_info)->queue_condition_var, NULL);
-    pthread_mutex_init(&(*run_queue_info)->run_queue_mutex, NULL);
-    (*run_queue_info)->threads = (pthread_t *)RedisModule_Alloc(
-        sizeof(pthread_t) * perqueueThreadPoolSize);
-    /* create threads */
-    for (int i = 0; i < perqueueThreadPoolSize; i++) {
-      if (pthread_create(&((*run_queue_info)->threads[i]), NULL,
-                         RedisAI_Run_ThreadMain, *run_queue_info) != 0) {
-        freeRunQueueInfo(*run_queue_info);
-        return REDISMODULE_ERR;
-      }
+    int result = REDISMODULE_ERR;
+    if (run_queues == NULL) {
+        return result;
     }
-    AI_dictAdd(run_queues, (void *)devicestr_, (void *)*run_queue_info);
-    result = REDISMODULE_OK;
-  }
 
-  RedisModule_Free(devicestr_);
+    char *devicestr_ = strToUpper(devicestr);
 
-  return result;
+    AI_dictEntry *entry = AI_dictFind(run_queues, devicestr_);
+    if (entry) {
+        *run_queue_info = AI_dictGetVal(entry);
+        result = REDISMODULE_OK;
+    } else {
+        *run_queue_info = RedisModule_Alloc(sizeof(RunQueueInfo));
+        (*run_queue_info)->run_queue = queueCreate();
+        (*run_queue_info)->devicestr = RedisModule_Strdup(devicestr_);
+        pthread_cond_init(&(*run_queue_info)->queue_condition_var, NULL);
+        pthread_mutex_init(&(*run_queue_info)->run_queue_mutex, NULL);
+        (*run_queue_info)->threads =
+            (pthread_t *)RedisModule_Alloc(sizeof(pthread_t) * perqueueThreadPoolSize);
+        /* create threads */
+        for (int i = 0; i < perqueueThreadPoolSize; i++) {
+            if (pthread_create(&((*run_queue_info)->threads[i]), NULL, RedisAI_Run_ThreadMain,
+                               *run_queue_info) != 0) {
+                freeRunQueueInfo(*run_queue_info);
+                return REDISMODULE_ERR;
+            }
+        }
+        AI_dictAdd(run_queues, (void *)devicestr_, (void *)*run_queue_info);
+        result = REDISMODULE_OK;
+    }
+
+    RedisModule_Free(devicestr_);
+
+    return result;
 }
 
 void *RedisAI_Run_ThreadMain(void *arg) {
-  RunQueueInfo *run_queue_info = (RunQueueInfo *)arg;
-  pthread_t self = pthread_self();
-  RAI_PTHREAD_SETNAME("redisai_bthread");
-  pthread_mutex_lock(&run_queue_info->run_queue_mutex);
+    RunQueueInfo *run_queue_info = (RunQueueInfo *)arg;
+    pthread_t self = pthread_self();
+    RAI_PTHREAD_SETNAME("redisai_bthread");
+    pthread_mutex_lock(&run_queue_info->run_queue_mutex);
 
-  queueItem **evicted_items = array_new(queueItem *, 1);
-  RedisAI_RunInfo **batch_rinfo = array_new(RedisAI_RunInfo *, 1);
+    queueItem **evicted_items = array_new(queueItem *, 1);
+    RedisAI_RunInfo **batch_rinfo = array_new(RedisAI_RunInfo *, 1);
 
-  while (true) {
+    while (true) {
 
-    // In case a DAG Op can express a MINBATCHSIZE > 0 with a MINBATCHTIMEOUT
-    // in milliseconds, we will use a timedwait of one millisecond to evaluate
-    // whether the run needs to trigger in case nothing else happens on the
-    // queue.
-    // Possible optimization: opt for a longer timeout if there's no minbatchtimeout
-    // involved.
-    struct timeval now;
-    gettimeofday(&now,NULL);
+        // In case a DAG Op can express a MINBATCHSIZE > 0 with a MINBATCHTIMEOUT
+        // in milliseconds, we will use a timedwait of one millisecond to evaluate
+        // whether the run needs to trigger in case nothing else happens on the
+        // queue.
+        // Possible optimization: opt for a longer timeout if there's no
+        // minbatchtimeout involved.
+        struct timeval now;
+        gettimeofday(&now, NULL);
 
-    struct timespec absTimeout;
-    absTimeout.tv_sec = now.tv_sec;
-    absTimeout.tv_nsec = (now.tv_usec + 1000) * 1000; // 1 millisecond
+        struct timespec absTimeout;
+        absTimeout.tv_sec = now.tv_sec;
+        absTimeout.tv_nsec = (now.tv_usec + 1000) * 1000; // 1 millisecond
 
-    int rc = pthread_cond_timedwait(&run_queue_info->queue_condition_var,
-                                    &run_queue_info->run_queue_mutex,
-                                    &absTimeout);
+        int rc = pthread_cond_timedwait(&run_queue_info->queue_condition_var,
+                                        &run_queue_info->run_queue_mutex, &absTimeout);
 
-    // This is the length of the queue for this particular device
-    // (see run_queue_info->devicestr).
-    // There might be more than one thread operating on the same
-    // queue, according to the THREADS_PER_QUEUE config variable.
-    long long run_queue_len = queueLength(run_queue_info->run_queue);
+        // This is the length of the queue for this particular device
+        // (see run_queue_info->devicestr).
+        // There might be more than one thread operating on the same
+        // queue, according to the THREADS_PER_QUEUE config variable.
+        long long run_queue_len = queueLength(run_queue_info->run_queue);
 
-    while (run_queue_len > 0) {
-      // We first peek the front of the queue
-      queueItem *item = queueFront(run_queue_info->run_queue);
+        while (run_queue_len > 0) {
+            // We first peek the front of the queue
+            queueItem *item = queueFront(run_queue_info->run_queue);
 
-      // We define a few variables to inform about the next action to take
-      // based on the status of the entries on the queue
-      // Do we need to unblock the client (or clients in case of batching)?
-      int do_unblock = 0;
-      // Do we need to run the entry (or the entries in case of batching)?
-      int do_run = 0;
-      // Is the entry not ready to run due to inputs not being available yet,
-      // so that we need to put the entry back on the queue?
-      int do_retry = 0;
-      // Were all ops in entry executed for the device, so that we can just
-      // remove the entry from the queue and be done with it?
-      int device_complete = 0;
+            // We define a few variables to inform about the next action to take
+            // based on the status of the entries on the queue
+            // Do we need to unblock the client (or clients in case of batching)?
+            int do_unblock = 0;
+            // Do we need to run the entry (or the entries in case of batching)?
+            int do_run = 0;
+            // Is the entry not ready to run due to inputs not being available yet,
+            // so that we need to put the entry back on the queue?
+            int do_retry = 0;
+            // Were all ops in entry executed for the device, so that we can just
+            // remove the entry from the queue and be done with it?
+            int device_complete = 0;
 
-      while (item) {
-        RedisAI_RunInfo *rinfo = (RedisAI_RunInfo *)item->value;
+            while (item) {
+                RedisAI_RunInfo *rinfo = (RedisAI_RunInfo *)item->value;
 
-        // We keep a list of additional items that are evicted from the queue
-        // to find opporunities for batching
-        array_clear(evicted_items);
-        array_clear(batch_rinfo);
+                // We keep a list of additional items that are evicted from the queue
+                // to find opporunities for batching
+                array_clear(evicted_items);
+                array_clear(batch_rinfo);
 
-        if (rinfo->timeout > 0) {
-          int timedOut = __atomic_load_n(rinfo->timedOut, __ATOMIC_RELAXED);
+                if (rinfo->timeout > 0) {
+                    int timedOut = __atomic_load_n(rinfo->timedOut, __ATOMIC_RELAXED);
 
-          if (timedOut == 0) {
-            struct timeval now, sub;
-            gettimeofday(&now, NULL); 
-            timersub(&now, &rinfo->queuingTime, &sub);
-            size_t time_msec = sub.tv_sec * 1000 + sub.tv_usec / 1000;
+                    if (timedOut == 0) {
+                        struct timeval now, sub;
+                        gettimeofday(&now, NULL);
+                        timersub(&now, &rinfo->queuingTime, &sub);
+                        size_t time_msec = sub.tv_sec * 1000 + sub.tv_usec / 1000;
 
-            if (time_msec > rinfo->timeout) {
-              timedOut = 1;
-              __atomic_store_n(rinfo->timedOut, timedOut, __ATOMIC_RELAXED);
+                        if (time_msec > rinfo->timeout) {
+                            timedOut = 1;
+                            __atomic_store_n(rinfo->timedOut, timedOut, __ATOMIC_RELAXED);
+                        }
+                    }
+
+                    if (timedOut == 1) {
+                        queueEvict(run_queue_info->run_queue, item);
+
+                        int dagRefCount =
+                            __atomic_sub_fetch(rinfo->dagRefCount, 1, __ATOMIC_RELAXED);
+                        if (dagRefCount == 0 && rinfo->client) {
+                            RedisModule_UnblockClient(rinfo->client, rinfo);
+                        }
+
+                        queueItem *evicted_item = item;
+                        item = item->next;
+                        RedisModule_Free(evicted_item);
+
+                        continue;
+                    }
+                }
+
+                // Since we might be looking through the queue for candidates, we need
+                // to reinitialize our findings every time we consider a new item for
+                // running
+                do_unblock = 0;
+                do_run = 0;
+                do_retry = 0;
+                device_complete = 0;
+
+                // We add the current item to the list of evicted items. If it's the
+                // first time around this will be the queue front.
+                evicted_items = array_append(evicted_items, item);
+                batch_rinfo = array_append(batch_rinfo, rinfo);
+
+                // Get the currentOp from the DAG at the top of the queue
+                // The currentOp is the first op without a result that needs to run
+                // on the device for the queue
+                // Also collect info on:
+                // - whether the currentOp is ready (all its inputs
+                //   are present in the context)
+                // - whether the currentOp is batchable (that is, it is a model and
+                //   it was set with batchsize > 0)
+                RAI_DagOp *currentOp = RedisAI_DagCurrentOp(rinfo);
+
+                // Have all ops that need to run on the device been executed
+                int deviceComplete = RedisAI_DagDeviceComplete(rinfo);
+                // Have all ops in the DAG been executed
+                int dagComplete = RedisAI_DagComplete(rinfo);
+
+                // If all ops in the DAG, then we decide we will unblock (one thread
+                // will actually unblock in practice, according to the reference count)
+                if (dagComplete) {
+                    device_complete = 1;
+                    do_unblock = 1;
+                    break;
+                }
+
+                // If we made it to here, we won't unblock (unless there's an error
+                // during the run, see below)
+                do_unblock = 0;
+
+                // If all ops on the device have a result, then we don't schedule to run
+                // and we won't place the entry back on the queue
+                if (deviceComplete) {
+                    do_run = 0;
+                    do_retry = 0;
+                    device_complete = 1;
+                    break;
+                }
+
+                // Is the currentOp ready to run (all its inputs are present in the
+                // context) Is the currentOp batchable (that is, it is a modelrun and it
+                // was set with batchsize > 0)
+                int currentOpReady, currentOpBatchable;
+                RedisAI_DagCurrentOpInfo(rinfo, &currentOpReady, &currentOpBatchable);
+
+                // If any of the inputs of the current op is not in the context, it
+                // means that some parent ops did not execute. In this case we don't
+                // schedule to run, but we will place the entry back on the queue
+                if (currentOpReady == 0) {
+                    do_run = 0;
+                    do_retry = 1;
+                    break;
+                }
+
+                // If we made it this far, we will run the currentOp
+                do_run = 1;
+
+                // If the current op is not batchable (that is, if it's not a modelrun
+                // or if it's a modelrun but batchsize was set to 0), we stop looking
+                // further
+                if (currentOpBatchable == 0) {
+                    break;
+                }
+
+                // If we are here, then we scheduled to run and we currently have an
+                // operation that can be batched.
+
+                // Since the current op can be batched, then we collect info on
+                // batching, namely
+                // - batchsize
+                // - minbatchsize
+                // - minbatchtimeout
+                // - actual size of the input along the batch (0-th) dimension
+                size_t batchsize, minbatchsize, minbatchtimeout, inbatchsize;
+                RedisAI_DagOpBatchInfo(rinfo, currentOp, &batchsize, &minbatchsize,
+                                       &minbatchtimeout, &inbatchsize);
+
+                // Get the size of the batch so far, that is, the size of the first
+                // input tensor in the 0-th dimension
+                size_t current_batchsize = inbatchsize;
+
+                // If the size is zero or if it already exceeds the desired batch size
+                // then stop searching
+                if (current_batchsize == 0 || current_batchsize >= batchsize) {
+                    break;
+                }
+
+                // Get the next item in the queue
+                queueItem *next_item = item->next;
+
+                // While we don't reach the end of the queue
+                while (next_item != NULL) {
+                    // Get the next run info
+                    RedisAI_RunInfo *next_rinfo = (RedisAI_RunInfo *)next_item->value;
+
+                    // If the next item is batchable, that is, if it is a model, if it
+                    // is a call to the same model, and if the size of the inputs except
+                    // the 0-th dimension match, then go on, otherwise continue to the
+                    // next item in the queue
+                    RAI_DagOp *nextOp = RedisAI_DagCurrentOp(next_rinfo);
+
+                    int nextOpReady, nextOpBatchable;
+                    RedisAI_DagCurrentOpInfo(next_rinfo, &nextOpReady, &nextOpBatchable);
+
+                    if (nextOpReady == 0 || nextOpBatchable == 0) {
+                        next_item = queueNext(next_item);
+                        continue;
+                    }
+
+                    int batched = 0;
+                    size_t next_batchsize = 0;
+                    RedisAI_DagOpBatchingMatch(rinfo, currentOp, next_rinfo, nextOp, &batched,
+                                               &next_batchsize);
+
+                    if (batched == 0) {
+                        next_item = queueNext(next_item);
+                        continue;
+                    }
+
+                    // If the new batch size would exceed the prescribed batch
+                    // size, then quit searching.
+                    // Here we could consider searching further down the queue.
+                    if (current_batchsize + next_batchsize > batchsize) {
+                        break;
+                    }
+
+                    // If all previous checks pass, then keep track of the item
+                    // in the list of evicted items
+                    evicted_items = array_append(evicted_items, next_item);
+                    batch_rinfo = array_append(batch_rinfo, next_rinfo);
+
+                    // Update the batchsize and go to the next item to see if
+                    // there's anything else to batch
+                    current_batchsize += next_batchsize;
+                    next_item = queueNext(next_item);
+                }
+
+                // If minbatchsize hasn't been set, or if the current batch
+                // size exceeds the minimum batch size already, then we're done.
+                // Otherwise, if minbatchsize was set and the size wasn't reached,
+                // loop until there's something new on the queue
+                if (minbatchsize == 0 || current_batchsize >= minbatchsize) {
+                    break;
+                }
+
+                // If minbatchsize has been set and we are not past it, we check
+                // if the timeout for min batch has expired, in which case we proceed
+                // anyway
+                if (minbatchsize > 0 && minbatchtimeout > 0) {
+                    struct timeval now, sub;
+                    gettimeofday(&now, NULL);
+
+                    timersub(&now, &rinfo->queuingTime, &sub);
+                    size_t time_msec = sub.tv_sec * 1000 + sub.tv_usec / 1000;
+
+                    if (time_msec > minbatchtimeout) {
+                        break;
+                    }
+                }
+
+                item = item->next;
             }
-          }
 
-          if (timedOut == 1) {
-            queueEvict(run_queue_info->run_queue, item);
-
-            int dagRefCount = __atomic_sub_fetch(rinfo->dagRefCount, 1, __ATOMIC_RELAXED);
-            if (dagRefCount == 0 && rinfo->client) {
-              RedisModule_UnblockClient(rinfo->client, rinfo);
+            // If there was nothing on the queue, free up the arrays and unlock
+            // so we can wait for more items to land on the queue
+            if (item == NULL) {
+                break;
             }
 
-            queueItem *evicted_item = item;
-            item = item->next;
-            RedisModule_Free(evicted_item);
-
-            continue;
-          }
-        }
-
-        // Since we might be looking through the queue for candidates, we need
-        // to reinitialize our findings every time we consider a new item for
-        // running
-        do_unblock = 0;
-        do_run = 0;
-        do_retry = 0;
-        device_complete = 0;
- 
-        // We add the current item to the list of evicted items. If it's the
-        // first time around this will be the queue front.
-        evicted_items = array_append(evicted_items, item);
-        batch_rinfo = array_append(batch_rinfo, rinfo);
-
-        // Get the currentOp from the DAG at the top of the queue
-        // The currentOp is the first op without a result that needs to run
-        // on the device for the queue
-        // Also collect info on:
-        // - whether the currentOp is ready (all its inputs
-        //   are present in the context)
-        // - whether the currentOp is batchable (that is, it is a model and
-        //   it was set with batchsize > 0)
-        RAI_DagOp* currentOp = RedisAI_DagCurrentOp(rinfo);
-
-        // Have all ops that need to run on the device been executed
-        int deviceComplete = RedisAI_DagDeviceComplete(rinfo);
-        // Have all ops in the DAG been executed
-        int dagComplete = RedisAI_DagComplete(rinfo);
-
-        // If all ops in the DAG, then we decide we will unblock (one thread
-        // will actually unblock in practice, according to the reference count)
-        if (dagComplete) {
-          device_complete = 1;
-          do_unblock = 1;
-          break;
-        }
-
-        // If we made it to here, we won't unblock (unless there's an error during
-        // the run, see below)
-        do_unblock = 0;
-
-        // If all ops on the device have a result, then we don't schedule to run
-        // and we won't place the entry back on the queue
-        if (deviceComplete) {
-          do_run = 0;
-          do_retry = 0;
-          device_complete = 1;
-          break;
-        }
-
-        // Is the currentOp ready to run (all its inputs are present in the
-        // context) Is the currentOp batchable (that is, it is a modelrun and it
-        // was set with batchsize > 0)
-        int currentOpReady, currentOpBatchable;
-        RedisAI_DagCurrentOpInfo(rinfo, &currentOpReady, &currentOpBatchable);
-
-        // If any of the inputs of the current op is not in the context, it means
-        // that some parent ops did not execute. In this case we don't schedule
-        // to run, but we will place the entry back on the queue
-        if (currentOpReady == 0) {
-          do_run = 0;
-          do_retry = 1;
-          break;
-        }
-
-        // If we made it this far, we will run the currentOp
-        do_run = 1;
-
-        // If the current op is not batchable (that is, if it's not a modelrun or
-        // if it's a modelrun but batchsize was set to 0), we stop looking further
-        if (currentOpBatchable == 0) {
-          break;
-        }
-
-        // If we are here, then we scheduled to run and we currently have an
-        // operation that can be batched.
-
-        // Since the current op can be batched, then we collect info on batching, namely
-        // - batchsize
-        // - minbatchsize
-        // - minbatchtimeout
-        // - actual size of the input along the batch (0-th) dimension
-        size_t batchsize, minbatchsize, minbatchtimeout, inbatchsize;
-        RedisAI_DagOpBatchInfo(rinfo, currentOp, &batchsize, &minbatchsize,
-                               &minbatchtimeout, &inbatchsize);
-
-        // Get the size of the batch so far, that is, the size of the first input
-        // tensor in the 0-th dimension
-        size_t current_batchsize = inbatchsize;
-
-        // If the size is zero or if it already exceeds the desired batch size
-        // then stop searching
-        if (current_batchsize == 0 || current_batchsize >= batchsize) {
-          break;
-        }
-
-        // Get the next item in the queue
-        queueItem *next_item = item->next;
-
-        // While we don't reach the end of the queue
-        while (next_item != NULL) {
-          // Get the next run info
-          RedisAI_RunInfo *next_rinfo = (RedisAI_RunInfo *)next_item->value;
-
-          // If the next item is batchable, that is, if it is a model, if it
-          // is a call to the same model, and if the size of the inputs except
-          // the 0-th dimension match, then go on, otherwise continue to the
-          // next item in the queue
-          RAI_DagOp* nextOp = RedisAI_DagCurrentOp(next_rinfo);
-
-          int nextOpReady, nextOpBatchable;
-          RedisAI_DagCurrentOpInfo(next_rinfo, &nextOpReady, &nextOpBatchable);
-
-          if (nextOpReady ==0 || nextOpBatchable == 0) {
-            next_item = queueNext(next_item);
-            continue;
-          }
-
-          int batched = 0;
-          size_t next_batchsize = 0;
-          RedisAI_DagOpBatchingMatch(rinfo, currentOp, 
-                                     next_rinfo, nextOp,
-                                     &batched, &next_batchsize);
-
-          if (batched == 0) {
-            next_item = queueNext(next_item);
-            continue;
-          }
- 
-          // If the new batch size would exceed the prescribed batch
-          // size, then quit searching.
-          // Here we could consider searching further down the queue.
-          if (current_batchsize + next_batchsize > batchsize) {
-            break;
-          }
-
-          // If all previous checks pass, then keep track of the item
-          // in the list of evicted items
-          evicted_items = array_append(evicted_items, next_item);
-          batch_rinfo = array_append(batch_rinfo, next_rinfo);
-
-          // Update the batchsize and go to the next item to see if
-          // there's anything else to batch
-          current_batchsize += next_batchsize;
-          next_item = queueNext(next_item);
-        }
-
-        // If minbatchsize hasn't been set, or if the current batch
-        // size exceeds the minimum batch size already, then we're done.
-        // Otherwise, if minbatchsize was set and the size wasn't reached,
-        // loop until there's something new on the queue
-        if (minbatchsize == 0 || current_batchsize >= minbatchsize) {
-          break;
-        }
-
-        // If minbatchsize has been set and we are not past it, we check
-        // if the timeout for min batch has expired, in which case we proceed
-        // anyway
-        if (minbatchsize > 0 && minbatchtimeout > 0) {
-          struct timeval now, sub;
-          gettimeofday(&now, NULL); 
-
-          timersub(&now, &rinfo->queuingTime, &sub);
-          size_t time_msec = sub.tv_sec * 1000 + sub.tv_usec / 1000;
-
-          if (time_msec > minbatchtimeout) {
-            break;
-          }
-        }
-
-        item = item->next;
-      }
-
-      // If there was nothing on the queue, free up the arrays and unlock
-      // so we can wait for more items to land on the queue
-      if (item == NULL) {
-        break;
-      }
-
-      // We're ready to process the items in the evicted list, so actually
-      // evict them from the queue
-      for (long long i = 0; i < array_len(evicted_items); i++) {
-        queueEvict(run_queue_info->run_queue, evicted_items[i]);
-      }
-
-      // For better readability, we create a variable that says if the current
-      // run will actually be batched or not
-      int batched_run = array_len(batch_rinfo) > 1;
-
-      // Variable holding the fact that running triggered an error.
-      int run_error = 0;
-      // Run the computation step (batched or not)
-      if (do_run == 1) {
-        // We're done with the queue here, items have been evicted so we can
-        // safely unlock the queue mutex, to allow other threads to operate
-        // on the same queue. The evicted items at this point are only visible
-        // to this worker.
-        pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
-
-        // For simplicity, we call into different functions whether the run
-        // is batched or not
-        if (batched_run == 1) {
-          RedisAI_BatchedDagRunSessionStep(batch_rinfo, run_queue_info->devicestr);
-        }
-        else {
-          RedisAI_DagRunSessionStep(batch_rinfo[0], run_queue_info->devicestr);
-        }
-
-        // Lock the queue again: we're done operating on evicted items only, we need
-        // to update the queue with the new information after run
-        pthread_mutex_lock(&run_queue_info->run_queue_mutex);
-
-        // Run is over, now iterate over the run info structs in the batch
-        // and see if any error was generated
-        int dagError = 0;
-        for (long long i=0; i<array_len(batch_rinfo); i++) {
-          RedisAI_RunInfo *rinfo = batch_rinfo[i];
-          // We lock on the DAG because error could be set from
-          // other threads operating on the same DAG (TODO: use atomic)
-          dagError = __atomic_load_n(rinfo->dagError, __ATOMIC_RELAXED);
-
-          // We record that there was an error for later on
-          run_error = dagError;
-
-          // If there was an error and the reference count for the dag
-          // has gone to zero and the client is still around, we unblock
-          if (dagError) {
-            int dagRefCount = __atomic_sub_fetch(rinfo->dagRefCount, 1, __ATOMIC_RELAXED);
-
-            if (dagRefCount == 0 && rinfo->client) {
-              RedisModule_UnblockClient(rinfo->client, rinfo);
+            // We're ready to process the items in the evicted list, so actually
+            // evict them from the queue
+            for (long long i = 0; i < array_len(evicted_items); i++) {
+                queueEvict(run_queue_info->run_queue, evicted_items[i]);
             }
-          }
-          else {
-            rinfo->dagDeviceCompleteOpCount += 1;
-            __atomic_add_fetch(rinfo->dagCompleteOpCount, 1, __ATOMIC_RELAXED);
-          }
+
+            // For better readability, we create a variable that says if the current
+            // run will actually be batched or not
+            int batched_run = array_len(batch_rinfo) > 1;
+
+            // Variable holding the fact that running triggered an error.
+            int run_error = 0;
+            // Run the computation step (batched or not)
+            if (do_run == 1) {
+                // We're done with the queue here, items have been evicted so we can
+                // safely unlock the queue mutex, to allow other threads to operate
+                // on the same queue. The evicted items at this point are only visible
+                // to this worker.
+                pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
+
+                // For simplicity, we call into different functions whether the run
+                // is batched or not
+                if (batched_run == 1) {
+                    RedisAI_BatchedDagRunSessionStep(batch_rinfo, run_queue_info->devicestr);
+                } else {
+                    RedisAI_DagRunSessionStep(batch_rinfo[0], run_queue_info->devicestr);
+                }
+
+                // Lock the queue again: we're done operating on evicted items only, we
+                // need to update the queue with the new information after run
+                pthread_mutex_lock(&run_queue_info->run_queue_mutex);
+
+                // Run is over, now iterate over the run info structs in the batch
+                // and see if any error was generated
+                int dagError = 0;
+                for (long long i = 0; i < array_len(batch_rinfo); i++) {
+                    RedisAI_RunInfo *rinfo = batch_rinfo[i];
+                    // We lock on the DAG because error could be set from
+                    // other threads operating on the same DAG (TODO: use atomic)
+                    dagError = __atomic_load_n(rinfo->dagError, __ATOMIC_RELAXED);
+
+                    // We record that there was an error for later on
+                    run_error = dagError;
+
+                    // If there was an error and the reference count for the dag
+                    // has gone to zero and the client is still around, we unblock
+                    if (dagError) {
+                        int dagRefCount =
+                            __atomic_sub_fetch(rinfo->dagRefCount, 1, __ATOMIC_RELAXED);
+
+                        if (dagRefCount == 0 && rinfo->client) {
+                            RedisModule_UnblockClient(rinfo->client, rinfo);
+                        }
+                    } else {
+                        rinfo->dagDeviceCompleteOpCount += 1;
+                        __atomic_add_fetch(rinfo->dagCompleteOpCount, 1, __ATOMIC_RELAXED);
+                    }
+                }
+            }
+
+            // We initialize variables where we'll store the fact hat, after the
+            // current run, all ops for the device or all ops in the dag could be
+            // complete. This way we can avoid placing the op back on the queue if
+            // there's nothing left to do.
+            int device_complete_after_run = RedisAI_DagDeviceComplete(batch_rinfo[0]);
+            int dag_complete_after_run = RedisAI_DagComplete(batch_rinfo[0]);
+
+            int dagRefCount = -1;
+
+            if (device_complete == 1 || device_complete_after_run == 1) {
+                RedisAI_RunInfo *evicted_rinfo = (RedisAI_RunInfo *)(evicted_items[0]->value);
+                // We decrease and get the reference count for the DAG
+                dagRefCount = __atomic_sub_fetch(evicted_rinfo->dagRefCount, 1, __ATOMIC_RELAXED);
+            }
+
+            // If the DAG was complete, then it's time to unblock the client
+            if (do_unblock == 1 || dag_complete_after_run == 1) {
+                RedisAI_RunInfo *evicted_rinfo = (RedisAI_RunInfo *)(evicted_items[0]->value);
+
+                // If the reference count for the DAG is zero and the client is still
+                // around, then we actually unblock the client
+                if (dagRefCount == 0 && evicted_rinfo->client) {
+                    RedisModule_UnblockClient(evicted_rinfo->client, evicted_rinfo);
+                }
+            }
+
+            // If there was no progress on the DAG, meaning the inputs to the
+            // current operation were not ready (they depend on other workers on other
+            // queues completing their job), then we put the entry back on the queue
+            if (do_retry == 1) {
+                RedisAI_RunInfo *evicted_rinfo = (RedisAI_RunInfo *)(evicted_items[0]->value);
+
+                if (queueLength(run_queue_info->run_queue) > 0) {
+                    // Pop the next item in the queue
+                    queueItem *next_item = queuePop(run_queue_info->run_queue);
+                    RedisAI_RunInfo *next_rinfo = (RedisAI_RunInfo *)next_item->value;
+                    // Push the DAG to the front of the queue, and then the item we just
+                    // popped in front of it, so that it becomes the first item in the
+                    // queue. The rationale is, since the DAG needs to wait for other
+                    // workers, we are giving way to the next item and we'll get back to
+                    // the DAG when that is done
+                    queuePushFront(run_queue_info->run_queue, evicted_rinfo);
+                    queuePushFront(run_queue_info->run_queue, next_rinfo);
+                }
+                // If there's nothing else in the queue
+                else {
+                    // We push the DAG back at the front
+                    queuePushFront(run_queue_info->run_queue, evicted_rinfo);
+                    // Since there's nothing else on the queue we just break out and give
+                    // other workers a chance to produce the inputs needed for this DAG
+                    // step
+                    break;
+                }
+            }
+
+            // If the op was ran successfully and without any error, then put the
+            // entry back on the queue unless all ops for the device have been
+            // executed
+            if (do_run == 1 && run_error == 0) {
+                // Here we iterate backwards to keep the first evicted on top
+                // A side effect of this is that we are potentially changing priority in
+                // the queue We could solve this using a priority queue, TODO for later
+                for (long long i = array_len(evicted_items) - 1; i >= 0; i--) {
+                    // Get the current evicted run info
+                    RedisAI_RunInfo *evicted_rinfo = (RedisAI_RunInfo *)(evicted_items[i]->value);
+                    // If the DAG for the top-most item is complete for the device, then
+                    // we don't push it back on the queue
+                    if (i == 0 && device_complete_after_run == 1) {
+                        continue;
+                    }
+                    queuePushFront(run_queue_info->run_queue, evicted_rinfo);
+                }
+            }
+
+            // TODO now we can figure out of the device is complete or the dag is
+            // complete if (dag_complete_op_count == evicted_rinfo[0]->dagOpCount) ->
+            // ublock, free if (dag_device_complete_op_count ==
+            // evicted_rinfo[0]->dagDeviceOpCount) -> device complete
+
+            // If there's nothing else to do for the DAG in the current worker or if
+            // an error occurred in any worker, we just move on
+            if (device_complete == 1 || device_complete_after_run == 1 || do_unblock == 1 ||
+                run_error == 1) {
+                for (long long i = 0; i < array_len(evicted_items); i++) {
+                    RedisModule_Free(evicted_items[i]);
+                }
+            }
+
+            run_queue_len = queueLength(run_queue_info->run_queue);
         }
-      }
-
-      // We initialize variables where we'll store the fact hat, after the current
-      // run, all ops for the device or all ops in the dag could be complete. This
-      // way we can avoid placing the op back on the queue if there's nothing left
-      // to do.
-      int device_complete_after_run = RedisAI_DagDeviceComplete(batch_rinfo[0]);
-      int dag_complete_after_run = RedisAI_DagComplete(batch_rinfo[0]);
- 
-      int dagRefCount = -1;
-
-      if (device_complete == 1 || device_complete_after_run == 1) {
-        RedisAI_RunInfo *evicted_rinfo = (RedisAI_RunInfo *)(evicted_items[0]->value);
-        // We decrease and get the reference count for the DAG
-        dagRefCount = __atomic_sub_fetch(evicted_rinfo->dagRefCount, 1, __ATOMIC_RELAXED);
-      }
-
-      // If the DAG was complete, then it's time to unblock the client
-      if (do_unblock == 1 || dag_complete_after_run == 1) {
-        RedisAI_RunInfo *evicted_rinfo = (RedisAI_RunInfo *)(evicted_items[0]->value);
-
-        // If the reference count for the DAG is zero and the client is still around,
-        // then we actually unblock the client
-        if (dagRefCount == 0 && evicted_rinfo->client) {
-          RedisModule_UnblockClient(evicted_rinfo->client, evicted_rinfo);
-        }
-      }
-
-      // If there was no progress on the DAG, meaning the inputs to the
-      // current operation were not ready (they depend on other workers on other
-      // queues completing their job), then we put the entry back on the queue
-      if (do_retry == 1) {
-        RedisAI_RunInfo *evicted_rinfo = (RedisAI_RunInfo *)(evicted_items[0]->value);
-
-        if (queueLength(run_queue_info->run_queue) > 0) {
-          // Pop the next item in the queue
-          queueItem *next_item = queuePop(run_queue_info->run_queue);
-          RedisAI_RunInfo *next_rinfo = (RedisAI_RunInfo *)next_item->value;
-          // Push the DAG to the front of the queue, and then the item we just
-          // popped in front of it, so that it becomes the first item in the queue.
-          // The rationale is, since the DAG needs to wait for other workers, we are
-          // giving way to the next item and we'll get back to the DAG when that is done
-          queuePushFront(run_queue_info->run_queue, evicted_rinfo);
-          queuePushFront(run_queue_info->run_queue, next_rinfo);
-        }
-        // If there's nothing else in the queue
-        else {
-          // We push the DAG back at the front
-          queuePushFront(run_queue_info->run_queue, evicted_rinfo);
-          // Since there's nothing else on the queue we just break out and give other
-          // workers a chance to produce the inputs needed for this DAG step
-          break;
-        }
-      }
-
-      // If the op was ran successfully and without any error, then put the entry back
-      // on the queue unless all ops for the device have been executed
-      if (do_run == 1 && run_error == 0) {
-        // Here we iterate backwards to keep the first evicted on top
-        // A side effect of this is that we are potentially changing priority in the queue
-        // We could solve this using a priority queue, TODO for later
-        for (long long i = array_len(evicted_items) - 1; i >= 0; i--) {
-          // Get the current evicted run info
-          RedisAI_RunInfo *evicted_rinfo = (RedisAI_RunInfo *)(evicted_items[i]->value);
-          // If the DAG for the top-most item is complete for the device, then
-          // we don't push it back on the queue
-          if (i ==0 && device_complete_after_run == 1) {
-            continue;
-          }
-          queuePushFront(run_queue_info->run_queue, evicted_rinfo);
-        }
-      }
-
-      // TODO now we can figure out of the device is complete or the dag is complete
-      // if (dag_complete_op_count == evicted_rinfo[0]->dagOpCount) -> ublock, free
-      // if (dag_device_complete_op_count == evicted_rinfo[0]->dagDeviceOpCount) -> device complete
-
-      // If there's nothing else to do for the DAG in the current worker or if an error
-      // occurred in any worker, we just move on
-      if (device_complete == 1 || device_complete_after_run == 1 || do_unblock == 1 || run_error == 1) {
-        for (long long i=0; i<array_len(evicted_items); i++) {
-          RedisModule_Free(evicted_items[i]);
-        }
-      }
-
-
-      run_queue_len = queueLength(run_queue_info->run_queue);
     }
-  }
 
-  array_free(evicted_items);
-  array_free(batch_rinfo);
+    array_free(evicted_items);
+    array_free(batch_rinfo);
 }

--- a/src/background_workers.h
+++ b/src/background_workers.h
@@ -36,28 +36,28 @@
 #define RAI_PTHREAD_SETNAME(name) pthread_setname_np(pthread_self(), name)
 #else
 #if (defined __NetBSD__ || defined __FreeBSD__ || defined __OpenBSD__)
-    #include <pthread_np.h>
-    #define RAI_PTHREAD_SETNAME(name) pthread_set_name_np(pthread_self(), name)
-    #else
-        #if (defined __APPLE__ && defined(MAC_OS_X_VERSION_10_7))
-        int pthread_setname_np(const char *name);
-        #include <pthread.h>
-        #define RAI_PTHREAD_SETNAME(name) pthread_setname_np(name)
-        #else
-        #define RAI_PTHREAD_SETNAME(name)
-        #endif
-    #endif
+#include <pthread_np.h>
+#define RAI_PTHREAD_SETNAME(name) pthread_set_name_np(pthread_self(), name)
+#else
+#if (defined __APPLE__ && defined(MAC_OS_X_VERSION_10_7))
+int pthread_setname_np(const char *name);
+#include <pthread.h>
+#define RAI_PTHREAD_SETNAME(name) pthread_setname_np(name)
+#else
+#define RAI_PTHREAD_SETNAME(name)
+#endif
+#endif
 #endif
 
 AI_dict *run_queues;
 long long perqueueThreadPoolSize;
 
 typedef struct RunQueueInfo {
-  pthread_mutex_t run_queue_mutex;
-  pthread_cond_t queue_condition_var;
-  queue *run_queue;
-  pthread_t *threads;
-  char* devicestr;
+    pthread_mutex_t run_queue_mutex;
+    pthread_cond_t queue_condition_var;
+    queue *run_queue;
+    pthread_t *threads;
+    char *devicestr;
 } RunQueueInfo;
 
 int freeRunQueueInfo(RunQueueInfo *info);

--- a/src/config.c
+++ b/src/config.c
@@ -15,20 +15,17 @@
 #include "util/dict.h"
 #include "util/queue.h"
 
-long long backends_intra_op_parallelism;  //  number of threads used within an
-//  individual op for parallelism.
-long long
-    backends_inter_op_parallelism;  //  number of threads used for parallelism
-                                    //  between independent operations.
-long long model_chunk_size;  // size of chunks used to break up model payloads.
+long long backends_intra_op_parallelism; //  number of threads used within an
+                                         //  individual op for parallelism.
+long long backends_inter_op_parallelism; //  number of threads used for parallelism
+                                         //  between independent operations.
+long long model_chunk_size;              // size of chunks used to break up model payloads.
 
 /**
  *
  * @return number of threads used within an individual op for parallelism.
  */
-long long getBackendsInterOpParallelism() {
-  return backends_inter_op_parallelism;
-}
+long long getBackendsInterOpParallelism() { return backends_inter_op_parallelism; }
 
 /**
  * Set number of threads used for parallelism between independent operations, by
@@ -38,21 +35,19 @@ long long getBackendsInterOpParallelism() {
  * @return 0 on success, or 1  if failed
  */
 int setBackendsInterOpParallelism(long long num_threads) {
-  int result = 1;
-  if (num_threads >= 0) {
-    backends_inter_op_parallelism = num_threads;
-    result = 0;
-  }
-  return result;
+    int result = 1;
+    if (num_threads >= 0) {
+        backends_inter_op_parallelism = num_threads;
+        result = 0;
+    }
+    return result;
 }
 
 /**
  *
  * @return
  */
-long long getBackendsIntraOpParallelism() {
-  return backends_intra_op_parallelism;
-}
+long long getBackendsIntraOpParallelism() { return backends_intra_op_parallelism; }
 
 /**
  * Set number of threads used within an individual op for parallelism, by
@@ -62,21 +57,19 @@ long long getBackendsIntraOpParallelism() {
  * @return 0 on success, or 1  if failed
  */
 int setBackendsIntraOpParallelism(long long num_threads) {
-  int result = 1;
-  if (num_threads >= 0) {
-    backends_intra_op_parallelism = num_threads;
-    result = 0;
-  }
-  return result;
+    int result = 1;
+    if (num_threads >= 0) {
+        backends_intra_op_parallelism = num_threads;
+        result = 0;
+    }
+    return result;
 }
 
 /**
  * @return size of chunks (in bytes) in which models are split for
  * set, get, serialization and replication.
  */
-long long getModelChunkSize() {
-  return model_chunk_size;
-}
+long long getModelChunkSize() { return model_chunk_size; }
 
 /**
  * Set size of chunks (in bytes) in which models are split for set,
@@ -86,12 +79,12 @@ long long getModelChunkSize() {
  * @return 0 on success, or 1  if failed
  */
 int setModelChunkSize(long long size) {
-  int result = 1;
-  if (size > 0) {
-    model_chunk_size = size;
-    result = 0;
-  }
-  return result;
+    int result = 1;
+    if (size > 0) {
+        model_chunk_size = size;
+        result = 0;
+    }
+    return result;
 }
 
 /**
@@ -103,31 +96,31 @@ int setModelChunkSize(long long size) {
  * @param argc Redis command number of arguments
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if the DAGRUN failed
  */
-int RedisAI_Config_LoadBackend(RedisModuleCtx *ctx, RedisModuleString **argv,
-                               int argc) {
-  if (argc < 3) return RedisModule_WrongArity(ctx);
+int RedisAI_Config_LoadBackend(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 3)
+        return RedisModule_WrongArity(ctx);
 
-  const char *backend = RedisModule_StringPtrLen(argv[1], NULL);
-  const char *path = RedisModule_StringPtrLen(argv[2], NULL);
+    const char *backend = RedisModule_StringPtrLen(argv[1], NULL);
+    const char *path = RedisModule_StringPtrLen(argv[2], NULL);
 
-  int result = REDISMODULE_ERR;
-  if (!strcasecmp(backend, "TF")) {
-    result = RAI_LoadBackend(ctx, RAI_BACKEND_TENSORFLOW, path);
-  } else if (!strcasecmp(backend, "TFLITE")) {
-    result = RAI_LoadBackend(ctx, RAI_BACKEND_TFLITE, path);
-  } else if (!strcasecmp(backend, "TORCH")) {
-    result = RAI_LoadBackend(ctx, RAI_BACKEND_TORCH, path);
-  } else if (!strcasecmp(backend, "ONNX")) {
-    result = RAI_LoadBackend(ctx, RAI_BACKEND_ONNXRUNTIME, path);
-  } else {
-    return RedisModule_ReplyWithError(ctx, "ERR unsupported backend");
-  }
+    int result = REDISMODULE_ERR;
+    if (!strcasecmp(backend, "TF")) {
+        result = RAI_LoadBackend(ctx, RAI_BACKEND_TENSORFLOW, path);
+    } else if (!strcasecmp(backend, "TFLITE")) {
+        result = RAI_LoadBackend(ctx, RAI_BACKEND_TFLITE, path);
+    } else if (!strcasecmp(backend, "TORCH")) {
+        result = RAI_LoadBackend(ctx, RAI_BACKEND_TORCH, path);
+    } else if (!strcasecmp(backend, "ONNX")) {
+        result = RAI_LoadBackend(ctx, RAI_BACKEND_ONNXRUNTIME, path);
+    } else {
+        return RedisModule_ReplyWithError(ctx, "ERR unsupported backend");
+    }
 
-  if (result == REDISMODULE_OK) {
-    return RedisModule_ReplyWithSimpleString(ctx, "OK");
-  }
+    if (result == REDISMODULE_OK) {
+        return RedisModule_ReplyWithSimpleString(ctx, "OK");
+    }
 
-  return RedisModule_ReplyWithError(ctx, "ERR error loading backend");
+    return RedisModule_ReplyWithError(ctx, "ERR error loading backend");
 }
 
 /**
@@ -139,12 +132,12 @@ int RedisAI_Config_LoadBackend(RedisModuleCtx *ctx, RedisModuleString **argv,
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if the DAGRUN failed
  */
 int RedisAI_Config_BackendsPath(RedisModuleCtx *ctx, const char *path) {
-  if (RAI_BackendsPath != NULL) {
-    RedisModule_Free(RAI_BackendsPath);
-  }
-  RAI_BackendsPath = RedisModule_Strdup(path);
+    if (RAI_BackendsPath != NULL) {
+        RedisModule_Free(RAI_BackendsPath);
+    }
+    RAI_BackendsPath = RedisModule_Strdup(path);
 
-  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 
 /**
@@ -155,15 +148,14 @@ int RedisAI_Config_BackendsPath(RedisModuleCtx *ctx, const char *path) {
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
  */
 int RedisAI_Config_QueueThreads(RedisModuleString *num_threads_string) {
-  int result =
-      RedisModule_StringToLongLong(num_threads_string, &perqueueThreadPoolSize);
-  // make sure the number of threads is a positive integer
-  // if not set the value to the default
-  if (result == REDISMODULE_OK && perqueueThreadPoolSize < 1) {
-    perqueueThreadPoolSize = REDISAI_DEFAULT_THREADS_PER_QUEUE;
-    result = REDISMODULE_ERR;
-  }
-  return result;
+    int result = RedisModule_StringToLongLong(num_threads_string, &perqueueThreadPoolSize);
+    // make sure the number of threads is a positive integer
+    // if not set the value to the default
+    if (result == REDISMODULE_OK && perqueueThreadPoolSize < 1) {
+        perqueueThreadPoolSize = REDISAI_DEFAULT_THREADS_PER_QUEUE;
+        result = REDISMODULE_ERR;
+    }
+    return result;
 }
 
 /**
@@ -173,14 +165,13 @@ int RedisAI_Config_QueueThreads(RedisModuleString *num_threads_string) {
  * @param num_threads_string string containing thread number
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
  */
-int RedisAI_Config_InterOperationParallelism(
-    RedisModuleString *num_threads_string) {
-  long long temp;
-  int result = RedisModule_StringToLongLong(num_threads_string, &temp);
-  if (result == REDISMODULE_OK) {
-    result = setBackendsInterOpParallelism(temp);
-  }
-  return result;
+int RedisAI_Config_InterOperationParallelism(RedisModuleString *num_threads_string) {
+    long long temp;
+    int result = RedisModule_StringToLongLong(num_threads_string, &temp);
+    if (result == REDISMODULE_OK) {
+        result = setBackendsInterOpParallelism(temp);
+    }
+    return result;
 }
 
 /**
@@ -190,14 +181,13 @@ int RedisAI_Config_InterOperationParallelism(
  * @param num_threads_string string containing thread number
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
  */
-int RedisAI_Config_IntraOperationParallelism(
-    RedisModuleString *num_threads_string) {
-  long long temp;
-  int result = RedisModule_StringToLongLong(num_threads_string, &temp);
-  if (result == REDISMODULE_OK) {
-    result = setBackendsIntraOpParallelism(temp);
-  }
-  return result;
+int RedisAI_Config_IntraOperationParallelism(RedisModuleString *num_threads_string) {
+    long long temp;
+    int result = RedisModule_StringToLongLong(num_threads_string, &temp);
+    if (result == REDISMODULE_OK) {
+        result = setBackendsIntraOpParallelism(temp);
+    }
+    return result;
 }
 
 /**
@@ -208,16 +198,16 @@ int RedisAI_Config_IntraOperationParallelism(
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
  */
 int RedisAI_Config_ModelChunkSize(RedisModuleString *chunk_size_string) {
-  long long temp;
-  int result = RedisModule_StringToLongLong(chunk_size_string, &temp);
-  // make sure chunk size is a positive integer
-  // if not set the value to the default
-  if (result == REDISMODULE_OK && temp < 1) {
-    temp = REDISAI_DEFAULT_MODEL_CHUNK_SIZE;
-    result = REDISMODULE_ERR;
-  }
-  result = setModelChunkSize(temp);
-  return result;
+    long long temp;
+    int result = RedisModule_StringToLongLong(chunk_size_string, &temp);
+    // make sure chunk size is a positive integer
+    // if not set the value to the default
+    if (result == REDISMODULE_OK && temp < 1) {
+        temp = REDISAI_DEFAULT_MODEL_CHUNK_SIZE;
+        result = REDISMODULE_ERR;
+    }
+    result = setModelChunkSize(temp);
+    return result;
 }
 
 /**
@@ -227,54 +217,49 @@ int RedisAI_Config_ModelChunkSize(RedisModuleString *chunk_size_string) {
  * @param val
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
  */
-int RAI_configParamParse(RedisModuleCtx *ctx, const char *key,
-                         const char *val, RedisModuleString *rsval) {
-  int ret = REDISMODULE_OK;
-  if (strcasecmp((key), "TF") == 0) {
-    ret = RAI_LoadBackend(ctx, RAI_BACKEND_TENSORFLOW, (val));
-  } else if (strcasecmp((key), "TFLITE") == 0) {
-    ret = RAI_LoadBackend(ctx, RAI_BACKEND_TFLITE, (val));
-  } else if (strcasecmp((key), "TORCH") == 0) {
-    ret = RAI_LoadBackend(ctx, RAI_BACKEND_TORCH, (val));
-  } else if (strcasecmp((key), "ONNX") == 0) {
-    ret = RAI_LoadBackend(ctx, RAI_BACKEND_ONNXRUNTIME, (val));
-  }
-  // enable configuring the main thread to create a fixed number of worker
-  // threads up front per device. by default we'll use 1
-  else if (strcasecmp((key), "THREADS_PER_QUEUE") == 0) {
-    ret = RedisAI_Config_QueueThreads(rsval);
-    if (ret == REDISMODULE_OK) {
-      RedisModule_Log(ctx, "notice", "%s: %s",
-                      REDISAI_INFOMSG_THREADS_PER_QUEUE,
-                      (val));
+int RAI_configParamParse(RedisModuleCtx *ctx, const char *key, const char *val,
+                         RedisModuleString *rsval) {
+    int ret = REDISMODULE_OK;
+    if (strcasecmp((key), "TF") == 0) {
+        ret = RAI_LoadBackend(ctx, RAI_BACKEND_TENSORFLOW, (val));
+    } else if (strcasecmp((key), "TFLITE") == 0) {
+        ret = RAI_LoadBackend(ctx, RAI_BACKEND_TFLITE, (val));
+    } else if (strcasecmp((key), "TORCH") == 0) {
+        ret = RAI_LoadBackend(ctx, RAI_BACKEND_TORCH, (val));
+    } else if (strcasecmp((key), "ONNX") == 0) {
+        ret = RAI_LoadBackend(ctx, RAI_BACKEND_ONNXRUNTIME, (val));
     }
-  } else if (strcasecmp((key), "INTRA_OP_PARALLELISM") == 0) {
-    ret = RedisAI_Config_IntraOperationParallelism(rsval);
-    if (ret == REDISMODULE_OK) {
-      RedisModule_Log(ctx, "notice", "%s: %lld",
-                      REDISAI_INFOMSG_INTRA_OP_PARALLELISM,
-                      getBackendsIntraOpParallelism());
+    // enable configuring the main thread to create a fixed number of worker
+    // threads up front per device. by default we'll use 1
+    else if (strcasecmp((key), "THREADS_PER_QUEUE") == 0) {
+        ret = RedisAI_Config_QueueThreads(rsval);
+        if (ret == REDISMODULE_OK) {
+            RedisModule_Log(ctx, "notice", "%s: %s", REDISAI_INFOMSG_THREADS_PER_QUEUE, (val));
+        }
+    } else if (strcasecmp((key), "INTRA_OP_PARALLELISM") == 0) {
+        ret = RedisAI_Config_IntraOperationParallelism(rsval);
+        if (ret == REDISMODULE_OK) {
+            RedisModule_Log(ctx, "notice", "%s: %lld", REDISAI_INFOMSG_INTRA_OP_PARALLELISM,
+                            getBackendsIntraOpParallelism());
+        }
+    } else if (strcasecmp((key), "INTER_OP_PARALLELISM") == 0) {
+        ret = RedisAI_Config_InterOperationParallelism(rsval);
+        if (ret == REDISMODULE_OK) {
+            RedisModule_Log(ctx, "notice", "%s: %lld", REDISAI_INFOMSG_INTER_OP_PARALLELISM,
+                            getBackendsInterOpParallelism());
+        }
+    } else if (strcasecmp((key), "MODEL_CHUNK_SIZE") == 0) {
+        ret = RedisAI_Config_ModelChunkSize(rsval);
+        if (ret == REDISMODULE_OK) {
+            RedisModule_Log(ctx, "notice", "%s: %lld", REDISAI_INFOMSG_MODEL_CHUNK_SIZE,
+                            getModelChunkSize());
+        }
+    } else if (strcasecmp((key), "BACKENDSPATH") == 0) {
+        // already taken care of
+    } else {
+        ret = REDISMODULE_ERR;
     }
-  } else if (strcasecmp((key), "INTER_OP_PARALLELISM") == 0) {
-    ret = RedisAI_Config_InterOperationParallelism(rsval);
-    if (ret == REDISMODULE_OK) {
-      RedisModule_Log(ctx, "notice", "%s: %lld",
-                      REDISAI_INFOMSG_INTER_OP_PARALLELISM,
-                      getBackendsInterOpParallelism());
-    }
-  } else if (strcasecmp((key), "MODEL_CHUNK_SIZE") == 0) {
-    ret = RedisAI_Config_ModelChunkSize(rsval);
-    if (ret == REDISMODULE_OK) {
-      RedisModule_Log(ctx, "notice", "%s: %lld",
-                      REDISAI_INFOMSG_MODEL_CHUNK_SIZE,
-                      getModelChunkSize());
-    }
-  } else if (strcasecmp((key), "BACKENDSPATH") == 0) {
-    // already taken care of
-  } else {
-    ret = REDISMODULE_ERR;
-  }
-  return ret;
+    return ret;
 }
 
 /**
@@ -285,41 +270,39 @@ int RAI_configParamParse(RedisModuleCtx *ctx, const char *key,
  * @param argc Redis command number of arguments
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if the DAGRUN failed
  */
-int RAI_loadTimeConfig(RedisModuleCtx *ctx,
-                       RedisModuleString *const *argv, int argc) {
-  if (argc > 0 && argc % 2 != 0) {
-    RedisModule_Log(ctx, "warning",
-                    "Even number of arguments provided to module. Please "
-                    "provide arguments as KEY VAL pairs");
-  }
-
-  // need BACKENDSPATH set up before loading specific backends
-  for (int i = 0; i < argc / 2; i++) {
-    const char *key = RedisModule_StringPtrLen(argv[2 * i], NULL);
-    const char *val = RedisModule_StringPtrLen(argv[2 * i + 1], NULL);
-
-    int ret = REDISMODULE_OK;
-    if (strcasecmp(key, "BACKENDSPATH") == 0) {
-      ret = RedisAI_Config_BackendsPath(ctx, val);
+int RAI_loadTimeConfig(RedisModuleCtx *ctx, RedisModuleString *const *argv, int argc) {
+    if (argc > 0 && argc % 2 != 0) {
+        RedisModule_Log(ctx, "warning",
+                        "Even number of arguments provided to module. Please "
+                        "provide arguments as KEY VAL pairs");
     }
-  }
 
-  for (int i = 0; i < argc / 2; i++) {
-    const char *key = RedisModule_StringPtrLen(argv[2 * i], NULL);
-    const char *val = RedisModule_StringPtrLen(argv[2 * i + 1], NULL);
-    int ret = RAI_configParamParse(ctx, key, val, argv[2 * i + 1]);
+    // need BACKENDSPATH set up before loading specific backends
+    for (int i = 0; i < argc / 2; i++) {
+        const char *key = RedisModule_StringPtrLen(argv[2 * i], NULL);
+        const char *val = RedisModule_StringPtrLen(argv[2 * i + 1], NULL);
 
-    if (ret == REDISMODULE_ERR) {
-      char *buffer =
-          RedisModule_Alloc((4 + strlen(REDISAI_ERRORMSG_PROCESSING_ARG) +
-                             strlen(key) + strlen(val)) *
-                            sizeof(*buffer));
-      sprintf(buffer, "%s: %s %s", REDISAI_ERRORMSG_PROCESSING_ARG, key, val);
-      RedisModule_Log(ctx, "warning", "%s", buffer);
-      RedisModule_Free(buffer);
-      return ret;
+        int ret = REDISMODULE_OK;
+        if (strcasecmp(key, "BACKENDSPATH") == 0) {
+            ret = RedisAI_Config_BackendsPath(ctx, val);
+        }
     }
-  }
 
-  return REDISMODULE_OK;
+    for (int i = 0; i < argc / 2; i++) {
+        const char *key = RedisModule_StringPtrLen(argv[2 * i], NULL);
+        const char *val = RedisModule_StringPtrLen(argv[2 * i + 1], NULL);
+        int ret = RAI_configParamParse(ctx, key, val, argv[2 * i + 1]);
+
+        if (ret == REDISMODULE_ERR) {
+            char *buffer = RedisModule_Alloc(
+                (4 + strlen(REDISAI_ERRORMSG_PROCESSING_ARG) + strlen(key) + strlen(val)) *
+                sizeof(*buffer));
+            sprintf(buffer, "%s: %s %s", REDISAI_ERRORMSG_PROCESSING_ARG, key, val);
+            RedisModule_Log(ctx, "warning", "%s", buffer);
+            RedisModule_Free(buffer);
+            return ret;
+        }
+    }
+
+    return REDISMODULE_OK;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -6,10 +6,10 @@
 typedef enum { RAI_MODEL, RAI_SCRIPT } RAI_RunType;
 
 typedef enum {
-  RAI_BACKEND_TENSORFLOW = 0,
-  RAI_BACKEND_TFLITE,
-  RAI_BACKEND_TORCH,
-  RAI_BACKEND_ONNXRUNTIME,
+    RAI_BACKEND_TENSORFLOW = 0,
+    RAI_BACKEND_TFLITE,
+    RAI_BACKEND_TORCH,
+    RAI_BACKEND_ONNXRUNTIME,
 } RAI_Backend;
 
 // NOTE: entry in queue hash is formed by
@@ -20,26 +20,19 @@ typedef enum { RAI_DEVICE_CPU = 0, RAI_DEVICE_GPU = 1 } RAI_Device;
 //#define RAI_COPY_RUN_INPUT
 #define RAI_COPY_RUN_OUTPUT
 #define RAI_PRINT_BACKEND_ERRORS
-#define REDISAI_DEFAULT_THREADS_PER_QUEUE 1
-#define REDISAI_DEFAULT_INTRA_OP_PARALLELISM 0
-#define REDISAI_DEFAULT_INTER_OP_PARALLELISM 0
-#define REDISAI_DEFAULT_MODEL_CHUNK_SIZE 535822336 // (511 * 1024 * 1024)
-#define REDISAI_ERRORMSG_PROCESSING_ARG "ERR error processing argument"
-#define REDISAI_ERRORMSG_THREADS_PER_QUEUE \
-  "ERR error setting THREADS_PER_QUEUE to"
-#define REDISAI_ERRORMSG_INTRA_OP_PARALLELISM \
-  "ERR error setting INTRA_OP_PARALLELISM to"
-#define REDISAI_ERRORMSG_INTER_OP_PARALLELISM \
-  "ERR error setting INTER_OP_PARALLELISM to"
+#define REDISAI_DEFAULT_THREADS_PER_QUEUE     1
+#define REDISAI_DEFAULT_INTRA_OP_PARALLELISM  0
+#define REDISAI_DEFAULT_INTER_OP_PARALLELISM  0
+#define REDISAI_DEFAULT_MODEL_CHUNK_SIZE      535822336 // (511 * 1024 * 1024)
+#define REDISAI_ERRORMSG_PROCESSING_ARG       "ERR error processing argument"
+#define REDISAI_ERRORMSG_THREADS_PER_QUEUE    "ERR error setting THREADS_PER_QUEUE to"
+#define REDISAI_ERRORMSG_INTRA_OP_PARALLELISM "ERR error setting INTRA_OP_PARALLELISM to"
+#define REDISAI_ERRORMSG_INTER_OP_PARALLELISM "ERR error setting INTER_OP_PARALLELISM to"
 
-#define REDISAI_INFOMSG_THREADS_PER_QUEUE \
-  "Setting THREADS_PER_QUEUE parameter to"
-#define REDISAI_INFOMSG_INTRA_OP_PARALLELISM \
-  "Setting INTRA_OP_PARALLELISM parameter to"
-#define REDISAI_INFOMSG_INTER_OP_PARALLELISM \
-  "Setting INTER_OP_PARALLELISM parameter to"
-#define REDISAI_INFOMSG_MODEL_CHUNK_SIZE \
-  "Setting MODEL_CHUNK_SIZE parameter to"
+#define REDISAI_INFOMSG_THREADS_PER_QUEUE    "Setting THREADS_PER_QUEUE parameter to"
+#define REDISAI_INFOMSG_INTRA_OP_PARALLELISM "Setting INTRA_OP_PARALLELISM parameter to"
+#define REDISAI_INFOMSG_INTER_OP_PARALLELISM "Setting INTER_OP_PARALLELISM parameter to"
+#define REDISAI_INFOMSG_MODEL_CHUNK_SIZE     "Setting MODEL_CHUNK_SIZE parameter to"
 
 /**
  * Get number of threads used for parallelism between independent operations, by
@@ -99,8 +92,7 @@ int setModelChunkSize(long long size);
  * @param argc Redis command number of arguments
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if the DAGRUN failed
  */
-int RedisAI_Config_LoadBackend(RedisModuleCtx *ctx, RedisModuleString **argv,
-                               int argc);
+int RedisAI_Config_LoadBackend(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 /**
  * Helper method for AI.CONFIG BACKENDSPATH
@@ -128,8 +120,7 @@ int RedisAI_Config_QueueThreads(RedisModuleString *num_threads_string);
  * @param num_threads_string string containing thread number
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
  */
-int RedisAI_Config_InterOperationParallelism(
-    RedisModuleString *num_threads_string);
+int RedisAI_Config_InterOperationParallelism(RedisModuleString *num_threads_string);
 
 /**
  * Set number of threads used within an individual op for parallelism, by
@@ -138,8 +129,7 @@ int RedisAI_Config_InterOperationParallelism(
  * @param num_threads_string string containing thread number
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
  */
-int RedisAI_Config_IntraOperationParallelism(
-    RedisModuleString *num_threads_string);
+int RedisAI_Config_IntraOperationParallelism(RedisModuleString *num_threads_string);
 
 /**
  * Set size of chunks in which model payloads are split for set,
@@ -148,8 +138,7 @@ int RedisAI_Config_IntraOperationParallelism(
  * @param chunk_size_string string containing chunk size (in bytes)
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
  */
-int RedisAI_Config_ModelChunkSize(
-    RedisModuleString *chunk_size_string);
+int RedisAI_Config_ModelChunkSize(RedisModuleString *chunk_size_string);
 
 /**
  *
@@ -158,8 +147,8 @@ int RedisAI_Config_ModelChunkSize(
  * @param val
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if failed
  */
-int RAI_configParamParse(RedisModuleCtx *ctx, const char *key,
-                         const char *val, RedisModuleString *rsval);
+int RAI_configParamParse(RedisModuleCtx *ctx, const char *key, const char *val,
+                         RedisModuleString *rsval);
 
 /**
  * Load time configuration parser
@@ -169,7 +158,6 @@ int RAI_configParamParse(RedisModuleCtx *ctx, const char *key,
  * @param argc Redis command number of arguments
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if the DAGRUN failed
  */
-int RAI_loadTimeConfig(RedisModuleCtx *ctx,
-                       RedisModuleString *const *argv, int argc);
+int RAI_loadTimeConfig(RedisModuleCtx *ctx, RedisModuleString *const *argv, int argc);
 
 #endif /* SRC_CONFIG_H_ */

--- a/src/dag.c
+++ b/src/dag.c
@@ -3,7 +3,7 @@
  *
  * Contains the helper methods for both parsing, running the command in the
  * background, and replying DAG structured commands.
- * 
+ *
  * The way we allow DAG operations to run on different devices in parallel
  * (when possible) is the following: instead of running the whole DAG in one
  * swoop, the DAG run info is created on one
@@ -20,7 +20,7 @@
  * next item. When all ops for a device have been executed, the DAG is not
  * placed back on the queue. When all ops in a DAG have been executed or an
  * error occurs, the client is unblocked.
- * 
+ *
  * See background_workers.c for the queue logic, everything else DAG is here.
  */
 
@@ -52,19 +52,18 @@
  * @return
  */
 void RedisAI_DagRunSession_TensorSet_Step(RedisAI_RunInfo *rinfo, RAI_DagOp *currentOp) {
-  RAI_Tensor *t = NULL;
-  const int parse_result = RAI_parseTensorSetArgs(
-      NULL, currentOp->argv, currentOp->argc, &t, 0, currentOp->err);
-  if (parse_result > 0) {
-    const char *key_string =
-        RedisModule_StringPtrLen(currentOp->outkeys[0], NULL);
-    RAI_ContextWriteLock(rinfo);
-    AI_dictReplace(rinfo->dagTensorsContext, (void*)key_string, t);
-    RAI_ContextUnlock(rinfo);
-    currentOp->result = REDISMODULE_OK;
-  } else {
-    currentOp->result = REDISMODULE_ERR;
-  }
+    RAI_Tensor *t = NULL;
+    const int parse_result =
+        RAI_parseTensorSetArgs(NULL, currentOp->argv, currentOp->argc, &t, 0, currentOp->err);
+    if (parse_result > 0) {
+        const char *key_string = RedisModule_StringPtrLen(currentOp->outkeys[0], NULL);
+        RAI_ContextWriteLock(rinfo);
+        AI_dictReplace(rinfo->dagTensorsContext, (void *)key_string, t);
+        RAI_ContextUnlock(rinfo);
+        currentOp->result = REDISMODULE_OK;
+    } else {
+        currentOp->result = REDISMODULE_ERR;
+    }
 }
 
 /**
@@ -76,18 +75,18 @@ void RedisAI_DagRunSession_TensorSet_Step(RedisAI_RunInfo *rinfo, RAI_DagOp *cur
  * @return
  */
 void RedisAI_DagRunSession_TensorGet_Step(RedisAI_RunInfo *rinfo, RAI_DagOp *currentOp) {
-  const char *key_string = RedisModule_StringPtrLen(currentOp->inkeys[0], NULL);
-  RAI_Tensor *t = NULL;
-  RAI_ContextReadLock(rinfo);
-  currentOp->result = RAI_getTensorFromLocalContext(
-      NULL, rinfo->dagTensorsContext, key_string, &t, currentOp->err);
-  RAI_ContextUnlock(rinfo);
-  if (currentOp->result == REDISMODULE_OK) {
-    RAI_Tensor *outTensor = NULL;
-    // TODO: check tensor copy return value
-    RAI_TensorDeepCopy(t, &outTensor);
-    currentOp->outTensors = array_append(currentOp->outTensors, outTensor);
-  }
+    const char *key_string = RedisModule_StringPtrLen(currentOp->inkeys[0], NULL);
+    RAI_Tensor *t = NULL;
+    RAI_ContextReadLock(rinfo);
+    currentOp->result = RAI_getTensorFromLocalContext(NULL, rinfo->dagTensorsContext, key_string,
+                                                      &t, currentOp->err);
+    RAI_ContextUnlock(rinfo);
+    if (currentOp->result == REDISMODULE_OK) {
+        RAI_Tensor *outTensor = NULL;
+        // TODO: check tensor copy return value
+        RAI_TensorDeepCopy(t, &outTensor);
+        currentOp->outTensors = array_append(currentOp->outTensors, outTensor);
+    }
 }
 
 /**
@@ -99,174 +98,177 @@ void RedisAI_DagRunSession_TensorGet_Step(RedisAI_RunInfo *rinfo, RAI_DagOp *cur
  * @return
  */
 void RedisAI_DagRunSession_ModelRun_Step(RedisAI_RunInfo *rinfo, RAI_DagOp *currentOp) {
-  uint n_inkeys = array_len(currentOp->inkeys);
-  uint n_outkeys = array_len(currentOp->outkeys);
+    uint n_inkeys = array_len(currentOp->inkeys);
+    uint n_outkeys = array_len(currentOp->outkeys);
 
-  RAI_ContextReadLock(rinfo);
+    RAI_ContextReadLock(rinfo);
 
-  RAI_Tensor* inputTensors[n_inkeys];
-  for (uint i=0; i<n_inkeys; i++) {
-    RAI_Tensor *inputTensor;
-    const int get_result = RAI_getTensorFromLocalContext(
-        NULL, rinfo->dagTensorsContext, RedisModule_StringPtrLen(currentOp->inkeys[i], NULL), &inputTensor, currentOp->err);
-    if (get_result == REDISMODULE_ERR) {
-      // We check for this outside the function
-      // this check cannot be covered by tests
-      currentOp->result = REDISMODULE_ERR;
-      RAI_ContextUnlock(rinfo);
-      return;
+    RAI_Tensor *inputTensors[n_inkeys];
+    for (uint i = 0; i < n_inkeys; i++) {
+        RAI_Tensor *inputTensor;
+        const int get_result = RAI_getTensorFromLocalContext(
+            NULL, rinfo->dagTensorsContext, RedisModule_StringPtrLen(currentOp->inkeys[i], NULL),
+            &inputTensor, currentOp->err);
+        if (get_result == REDISMODULE_ERR) {
+            // We check for this outside the function
+            // this check cannot be covered by tests
+            currentOp->result = REDISMODULE_ERR;
+            RAI_ContextUnlock(rinfo);
+            return;
+        }
+        inputTensors[i] = inputTensor;
     }
-    inputTensors[i] = inputTensor;
-  }
 
-  RAI_ContextUnlock(rinfo);
+    RAI_ContextUnlock(rinfo);
 
-  for (uint i=0; i<n_inkeys; i++) {
-    const char *opname = NULL;
-    if (currentOp->mctx->model->inputs) {
-      opname = currentOp->mctx->model->inputs[i];
+    for (uint i = 0; i < n_inkeys; i++) {
+        const char *opname = NULL;
+        if (currentOp->mctx->model->inputs) {
+            opname = currentOp->mctx->model->inputs[i];
+        }
+        RAI_ModelRunCtxAddInput(currentOp->mctx, opname, inputTensors[i]);
     }
-    RAI_ModelRunCtxAddInput(currentOp->mctx, opname, inputTensors[i]);
-  }
 
-  for (uint i=0; i<n_outkeys; i++) {
-    const char *opname = NULL;
-    if (currentOp->mctx->model->inputs) {
-      opname = currentOp->mctx->model->outputs[i];
+    for (uint i = 0; i < n_outkeys; i++) {
+        const char *opname = NULL;
+        if (currentOp->mctx->model->inputs) {
+            opname = currentOp->mctx->model->outputs[i];
+        }
+        RAI_ModelRunCtxAddOutput(currentOp->mctx, opname);
     }
-    RAI_ModelRunCtxAddOutput(currentOp->mctx, opname);
-  }
 
-  RAI_ModelRunCtx *mctxs[1];
-  mctxs[0] = currentOp->mctx;
-  const long long start = ustime();
-  int result = RAI_ModelRun(mctxs, 1, currentOp->err);
-  const long long end = ustime();
+    RAI_ModelRunCtx *mctxs[1];
+    mctxs[0] = currentOp->mctx;
+    const long long start = ustime();
+    int result = RAI_ModelRun(mctxs, 1, currentOp->err);
+    const long long end = ustime();
 
-  if (result == REDISMODULE_ERR) {
+    if (result == REDISMODULE_ERR) {
+        currentOp->result = result;
+        return;
+    }
+
+    RAI_ContextWriteLock(rinfo);
+
+    currentOp->duration_us = end - start;
+
+    const size_t noutputs = RAI_ModelRunCtxNumOutputs(currentOp->mctx);
+    for (size_t outputNumber = 0; outputNumber < noutputs; outputNumber++) {
+        RAI_Tensor *tensor = RAI_ModelRunCtxOutputTensor(currentOp->mctx, outputNumber);
+        const char *key_string = RedisModule_StringPtrLen(currentOp->outkeys[outputNumber], NULL);
+        tensor = tensor ? RAI_TensorGetShallowCopy(tensor) : NULL;
+        AI_dictReplace(rinfo->dagTensorsContext, (void *)key_string, tensor);
+    }
+
     currentOp->result = result;
+
+    RAI_ContextUnlock(rinfo);
+
     return;
-  }
-
-  RAI_ContextWriteLock(rinfo);
-
-  currentOp->duration_us = end - start;
-
-  const size_t noutputs = RAI_ModelRunCtxNumOutputs(currentOp->mctx);
-  for (size_t outputNumber = 0; outputNumber<noutputs; outputNumber++) {
-    RAI_Tensor *tensor = RAI_ModelRunCtxOutputTensor(currentOp->mctx, outputNumber);
-    const char *key_string = RedisModule_StringPtrLen(
-        currentOp->outkeys[outputNumber], NULL);
-    tensor = tensor ? RAI_TensorGetShallowCopy(tensor) : NULL;
-    AI_dictReplace(rinfo->dagTensorsContext, (void*)key_string, tensor);
-  }
-
-  currentOp->result = result;
-
-  RAI_ContextUnlock(rinfo);
-
-  return;
 }
 
 /**
  * Execution of a batched (MODELRUN) DAG step.
  * If an error occurs, it is recorded in all DagOp structs.
  *
- * @param batched_rinfo array of contexts in which RedisAI blocking commands operate.
+ * @param batched_rinfo array of contexts in which RedisAI blocking commands
+ * operate.
  * @param currentOps MODELRUN DagOps to be executed
  * @return
  */
-void RedisAI_BatchedDagRunSession_ModelRun_Step(RedisAI_RunInfo **batched_rinfo, RAI_DagOp **currentOps) {
+void RedisAI_BatchedDagRunSession_ModelRun_Step(RedisAI_RunInfo **batched_rinfo,
+                                                RAI_DagOp **currentOps) {
 
-  int n_rinfo = array_len(batched_rinfo);
+    int n_rinfo = array_len(batched_rinfo);
 
-  RAI_ModelRunCtx *mctxs[n_rinfo];
+    RAI_ModelRunCtx *mctxs[n_rinfo];
 
-  for (int i=0; i<n_rinfo; i++) {
-    RedisAI_RunInfo *rinfo = batched_rinfo[i];
-    RAI_DagOp *currentOp = currentOps[i];
+    for (int i = 0; i < n_rinfo; i++) {
+        RedisAI_RunInfo *rinfo = batched_rinfo[i];
+        RAI_DagOp *currentOp = currentOps[i];
 
-    uint n_inkeys = array_len(currentOp->inkeys);
-    uint n_outkeys = array_len(currentOp->outkeys);
+        uint n_inkeys = array_len(currentOp->inkeys);
+        uint n_outkeys = array_len(currentOp->outkeys);
 
-    RAI_ContextReadLock(rinfo);
+        RAI_ContextReadLock(rinfo);
 
-    RAI_Tensor* inputTensors[n_inkeys];
-    for (uint i=0; i<n_inkeys; i++) {
-      RAI_Tensor *inputTensor;
-      const int get_result = RAI_getTensorFromLocalContext(
-          NULL, rinfo->dagTensorsContext, RedisModule_StringPtrLen(currentOp->inkeys[i], NULL), &inputTensor, currentOp->err);
-      if (get_result == REDISMODULE_ERR) {
-        // We check for this outside the function
-        // this check cannot be covered by tests
-        currentOp->result = REDISMODULE_ERR;
+        RAI_Tensor *inputTensors[n_inkeys];
+        for (uint i = 0; i < n_inkeys; i++) {
+            RAI_Tensor *inputTensor;
+            const int get_result = RAI_getTensorFromLocalContext(
+                NULL, rinfo->dagTensorsContext,
+                RedisModule_StringPtrLen(currentOp->inkeys[i], NULL), &inputTensor, currentOp->err);
+            if (get_result == REDISMODULE_ERR) {
+                // We check for this outside the function
+                // this check cannot be covered by tests
+                currentOp->result = REDISMODULE_ERR;
+                RAI_ContextUnlock(rinfo);
+                return;
+            }
+            inputTensors[i] = inputTensor;
+        }
+
         RAI_ContextUnlock(rinfo);
-        return;
-      }
-      inputTensors[i] = inputTensor;
+
+        for (uint i = 0; i < n_inkeys; i++) {
+            const char *input_name = NULL;
+            if (currentOp->mctx->model->inputs) {
+                input_name = currentOp->mctx->model->inputs[i];
+            }
+            RAI_ModelRunCtxAddInput(currentOp->mctx, input_name, inputTensors[i]);
+        }
+
+        for (uint i = 0; i < n_outkeys; i++) {
+            const char *output_name = NULL;
+            if (currentOp->mctx->model->outputs) {
+                output_name = currentOp->mctx->model->outputs[i];
+            }
+            RAI_ModelRunCtxAddOutput(currentOp->mctx, output_name);
+        }
+
+        mctxs[i] = currentOp->mctx;
     }
 
-    RAI_ContextUnlock(rinfo);
+    RAI_Error err = {0};
+    const long long start = ustime();
+    int result = RAI_ModelRun(mctxs, n_rinfo, &err);
+    const long long end = ustime();
 
-    for (uint i=0; i<n_inkeys; i++) {
-      const char *input_name = NULL;
-      if (currentOp->mctx->model->inputs) {
-        input_name = currentOp->mctx->model->inputs[i];
-      }
-      RAI_ModelRunCtxAddInput(currentOp->mctx, input_name, inputTensors[i]);
+    long long duration = end - start;
+
+    for (int i = 0; i < n_rinfo; i++) {
+        RedisAI_RunInfo *rinfo = batched_rinfo[i];
+        RAI_DagOp *currentOp = currentOps[i];
+
+        if (result == REDISMODULE_ERR) {
+            currentOp->result = result;
+            RAI_SetError(currentOp->err, err.code, err.detail);
+            continue;
+        }
+
+        RAI_ContextWriteLock(rinfo);
+
+        currentOp->duration_us = duration;
+
+        const size_t noutputs = RAI_ModelRunCtxNumOutputs(currentOp->mctx);
+        for (size_t outputNumber = 0; outputNumber < noutputs; outputNumber++) {
+            RAI_Tensor *tensor = RAI_ModelRunCtxOutputTensor(currentOp->mctx, outputNumber);
+            const char *key_string =
+                RedisModule_StringPtrLen(currentOp->outkeys[outputNumber], NULL);
+            tensor = tensor ? RAI_TensorGetShallowCopy(tensor) : NULL;
+            AI_dictReplace(rinfo->dagTensorsContext, (void *)key_string, tensor);
+        }
+
+        currentOp->result = result;
+
+        RAI_ContextUnlock(rinfo);
     }
-
-    for (uint i=0; i<n_outkeys; i++) {
-      const char *output_name = NULL;
-      if (currentOp->mctx->model->outputs) {
-        output_name = currentOp->mctx->model->outputs[i];
-      }
-      RAI_ModelRunCtxAddOutput(currentOp->mctx, output_name);
-    }
-
-    mctxs[i] = currentOp->mctx;
-  }
-
-  RAI_Error err = {0};
-  const long long start = ustime();
-  int result = RAI_ModelRun(mctxs, n_rinfo, &err);
-  const long long end = ustime();
-
-  long long duration = end - start;
-
-  for (int i=0; i<n_rinfo; i++) {
-    RedisAI_RunInfo *rinfo = batched_rinfo[i];
-    RAI_DagOp *currentOp = currentOps[i];
 
     if (result == REDISMODULE_ERR) {
-      currentOp->result = result;
-      RAI_SetError(currentOp->err, err.code, err.detail);
-      continue;
+        RAI_ClearError(&err);
     }
 
-    RAI_ContextWriteLock(rinfo);
-
-    currentOp->duration_us = duration;
-
-    const size_t noutputs = RAI_ModelRunCtxNumOutputs(currentOp->mctx);
-    for (size_t outputNumber = 0; outputNumber<noutputs; outputNumber++) {
-      RAI_Tensor *tensor = RAI_ModelRunCtxOutputTensor(currentOp->mctx, outputNumber);
-      const char *key_string = RedisModule_StringPtrLen(
-          currentOp->outkeys[outputNumber], NULL);
-      tensor = tensor ? RAI_TensorGetShallowCopy(tensor) : NULL;
-      AI_dictReplace(rinfo->dagTensorsContext, (void*)key_string, tensor);
-    }
-
-    currentOp->result = result;
-
-    RAI_ContextUnlock(rinfo);
-  }
-
-  if (result == REDISMODULE_ERR) {
-    RAI_ClearError(&err);
-  }
-
-  return;
+    return;
 }
 
 /**
@@ -278,1022 +280,999 @@ void RedisAI_BatchedDagRunSession_ModelRun_Step(RedisAI_RunInfo **batched_rinfo,
  * @return
  */
 void RedisAI_DagRunSession_ScriptRun_Step(RedisAI_RunInfo *rinfo, RAI_DagOp *currentOp) {
-  uint n_inkeys = array_len(currentOp->inkeys);
-  uint n_outkeys = array_len(currentOp->outkeys);
+    uint n_inkeys = array_len(currentOp->inkeys);
+    uint n_outkeys = array_len(currentOp->outkeys);
 
-  RAI_ContextReadLock(rinfo);
+    RAI_ContextReadLock(rinfo);
 
-  RAI_Tensor* inputTensors[n_inkeys];
-  for (uint i=0; i<n_inkeys; i++) {
-    RAI_Tensor *inputTensor;
-    const int get_result = RAI_getTensorFromLocalContext(
-        NULL, rinfo->dagTensorsContext, RedisModule_StringPtrLen(currentOp->inkeys[i], NULL), &inputTensor, currentOp->err);
-    if (get_result == REDISMODULE_ERR) {
-      // We check for this outside the function
-      // this check cannot be covered by tests
-      currentOp->result = REDISMODULE_ERR;
-      RAI_ContextUnlock(rinfo);
-      return;
+    RAI_Tensor *inputTensors[n_inkeys];
+    for (uint i = 0; i < n_inkeys; i++) {
+        RAI_Tensor *inputTensor;
+        const int get_result = RAI_getTensorFromLocalContext(
+            NULL, rinfo->dagTensorsContext, RedisModule_StringPtrLen(currentOp->inkeys[i], NULL),
+            &inputTensor, currentOp->err);
+        if (get_result == REDISMODULE_ERR) {
+            // We check for this outside the function
+            // this check cannot be covered by tests
+            currentOp->result = REDISMODULE_ERR;
+            RAI_ContextUnlock(rinfo);
+            return;
+        }
+        inputTensors[i] = inputTensor;
     }
-    inputTensors[i] = inputTensor;
-  }
 
-  RAI_ContextUnlock(rinfo);
+    RAI_ContextUnlock(rinfo);
 
-  for (uint i=0; i<n_inkeys; i++) {
-    RAI_ScriptRunCtxAddInput(currentOp->sctx, inputTensors[i], currentOp->err);
-  }
+    for (uint i = 0; i < n_inkeys; i++) {
+        RAI_ScriptRunCtxAddInput(currentOp->sctx, inputTensors[i], currentOp->err);
+    }
 
-  for (uint i=0; i<n_outkeys; i++) {
-    RAI_ScriptRunCtxAddOutput(currentOp->sctx);
-  } 
+    for (uint i = 0; i < n_outkeys; i++) {
+        RAI_ScriptRunCtxAddOutput(currentOp->sctx);
+    }
 
-  const long long start = ustime();
-  int result = RAI_ScriptRun(currentOp->sctx, currentOp->err);
-  const long long end = ustime();
+    const long long start = ustime();
+    int result = RAI_ScriptRun(currentOp->sctx, currentOp->err);
+    const long long end = ustime();
 
-  RAI_ContextWriteLock(rinfo);
+    RAI_ContextWriteLock(rinfo);
 
-  const size_t noutputs = RAI_ScriptRunCtxNumOutputs(currentOp->sctx);
-  for (size_t outputNumber = 0; outputNumber < noutputs;
-     outputNumber++) {
-    RAI_Tensor *tensor =
-          RAI_ScriptRunCtxOutputTensor(currentOp->sctx, outputNumber);
-    const char *key_string = RedisModule_StringPtrLen(
-            currentOp->outkeys[outputNumber], NULL);
-    tensor = tensor ? RAI_TensorGetShallowCopy(tensor) : NULL;
-    AI_dictReplace(rinfo->dagTensorsContext, (void*)key_string, tensor);
-  }
+    const size_t noutputs = RAI_ScriptRunCtxNumOutputs(currentOp->sctx);
+    for (size_t outputNumber = 0; outputNumber < noutputs; outputNumber++) {
+        RAI_Tensor *tensor = RAI_ScriptRunCtxOutputTensor(currentOp->sctx, outputNumber);
+        const char *key_string = RedisModule_StringPtrLen(currentOp->outkeys[outputNumber], NULL);
+        tensor = tensor ? RAI_TensorGetShallowCopy(tensor) : NULL;
+        AI_dictReplace(rinfo->dagTensorsContext, (void *)key_string, tensor);
+    }
 
-  currentOp->result = result;
-  currentOp->duration_us = end - start;
+    currentOp->result = result;
+    currentOp->duration_us = end - start;
 
-  RAI_ContextUnlock(rinfo);
+    RAI_ContextUnlock(rinfo);
 
-  return;
+    return;
 }
 
 size_t RAI_DagOpBatchSize(RAI_DagOp *op, AI_dict *opTensorsContext) {
-  if (op->mctx == NULL) {
-    return -1;
-  }
+    if (op->mctx == NULL) {
+        return -1;
+    }
 
-  // size_t ninputs = RAI_ModelRunCtxNumInputs(op->mctx);
-  size_t ninputs = array_len(op->inkeys);
+    // size_t ninputs = RAI_ModelRunCtxNumInputs(op->mctx);
+    size_t ninputs = array_len(op->inkeys);
 
-  int batchsize = 0;
+    int batchsize = 0;
 
-  if (ninputs == 0) {
+    if (ninputs == 0) {
+        return batchsize;
+    }
+
+    for (size_t i = 0; i < ninputs; i++) {
+        RAI_Tensor *input;
+        RAI_getTensorFromLocalContext(
+            NULL, opTensorsContext, RedisModule_StringPtrLen(op->inkeys[i], NULL), &input, op->err);
+        // We are expecting input != NULL, because we only reach this function if
+        // all inputs are available in context for the current dagOp. We could be
+        // more defensive eventually.
+
+        if (i == 0) {
+            batchsize = RAI_TensorDim(input, 0);
+            continue;
+        }
+
+        if (batchsize != RAI_TensorDim(input, 0)) {
+            batchsize = 0;
+            break;
+        }
+    }
+
     return batchsize;
-  }
-
-  for (size_t i = 0; i < ninputs; i++) {
-    RAI_Tensor *input;
-    RAI_getTensorFromLocalContext(NULL, opTensorsContext, RedisModule_StringPtrLen(op->inkeys[i], NULL), &input, op->err);
-    // We are expecting input != NULL, because we only reach this function if all inputs
-    // are available in context for the current dagOp. We could be more defensive eventually.
- 
-    if (i == 0) {
-      batchsize = RAI_TensorDim(input, 0);
-      continue;
-    }
-
-    if (batchsize != RAI_TensorDim(input, 0)) {
-      batchsize = 0;
-      break;
-    }
-  }
-
-  return batchsize;
 }
 
-int RAI_DagOpBatchable(RAI_DagOp *op1, AI_dict *op1TensorsContext,
-                       RAI_DagOp *op2, AI_dict *op2TensorsContext) {
+int RAI_DagOpBatchable(RAI_DagOp *op1, AI_dict *op1TensorsContext, RAI_DagOp *op2,
+                       AI_dict *op2TensorsContext) {
 
-  if (op1->mctx == NULL || op2->mctx == NULL) {
-    return 0;
-  }
-
-  if (op1->mctx->model != op2->mctx->model) {
-    return 0;
-  }
-
-  const int ninputs1 = RAI_ModelRunCtxNumInputs(op1->mctx);
-  const int ninputs2 = RAI_ModelRunCtxNumInputs(op2->mctx);
-
-  if (ninputs1 != ninputs2) {
-    return 0;
-  }
-
-  for (int i = 0; i < ninputs1; i++) {
-    RAI_Tensor *input1;
-    RAI_getTensorFromLocalContext(NULL, op1TensorsContext, RedisModule_StringPtrLen(op1->inkeys[i], NULL), &input1, op1->err);
- 
-    RAI_Tensor *input2;
-    RAI_getTensorFromLocalContext(NULL, op2TensorsContext, RedisModule_StringPtrLen(op2->inkeys[i], NULL), &input2, op2->err);
-
-    if (input1 == NULL || input2 == NULL) {
-      return 0;
-    }
- 
-    int ndims1 = RAI_TensorNumDims(input1);
-    int ndims2 = RAI_TensorNumDims(input2);
-
-    if (ndims1 != ndims2) {
-      return 0;
-    }
-
-    if (ndims1 == 0) {
-      continue;
-    }
-
-    for (int j = 1; j < ndims1; j++) {
-      int dim1 = RAI_TensorDim(input1, j);
-      int dim2 = RAI_TensorDim(input2, j);
-      if (dim1 != dim2) {
+    if (op1->mctx == NULL || op2->mctx == NULL) {
         return 0;
-      }
     }
-  }
 
-  return 1;
+    if (op1->mctx->model != op2->mctx->model) {
+        return 0;
+    }
+
+    const int ninputs1 = RAI_ModelRunCtxNumInputs(op1->mctx);
+    const int ninputs2 = RAI_ModelRunCtxNumInputs(op2->mctx);
+
+    if (ninputs1 != ninputs2) {
+        return 0;
+    }
+
+    for (int i = 0; i < ninputs1; i++) {
+        RAI_Tensor *input1;
+        RAI_getTensorFromLocalContext(NULL, op1TensorsContext,
+                                      RedisModule_StringPtrLen(op1->inkeys[i], NULL), &input1,
+                                      op1->err);
+
+        RAI_Tensor *input2;
+        RAI_getTensorFromLocalContext(NULL, op2TensorsContext,
+                                      RedisModule_StringPtrLen(op2->inkeys[i], NULL), &input2,
+                                      op2->err);
+
+        if (input1 == NULL || input2 == NULL) {
+            return 0;
+        }
+
+        int ndims1 = RAI_TensorNumDims(input1);
+        int ndims2 = RAI_TensorNumDims(input2);
+
+        if (ndims1 != ndims2) {
+            return 0;
+        }
+
+        if (ndims1 == 0) {
+            continue;
+        }
+
+        for (int j = 1; j < ndims1; j++) {
+            int dim1 = RAI_TensorDim(input1, j);
+            int dim2 = RAI_TensorDim(input2, j);
+            if (dim1 != dim2) {
+                return 0;
+            }
+        }
+    }
+
+    return 1;
 }
 
 int RedisAI_DagDeviceComplete(RedisAI_RunInfo *rinfo) {
-  return rinfo->dagDeviceCompleteOpCount == rinfo->dagDeviceOpCount;
+    return rinfo->dagDeviceCompleteOpCount == rinfo->dagDeviceOpCount;
 }
 
 int RedisAI_DagComplete(RedisAI_RunInfo *rinfo) {
-  int completeOpCount = __atomic_load_n(rinfo->dagCompleteOpCount, __ATOMIC_RELAXED);
+    int completeOpCount = __atomic_load_n(rinfo->dagCompleteOpCount, __ATOMIC_RELAXED);
 
-  return completeOpCount == rinfo->dagOpCount;
+    return completeOpCount == rinfo->dagOpCount;
 }
 
-RAI_DagOp* RedisAI_DagCurrentOp(RedisAI_RunInfo *rinfo) {
-  if (rinfo->dagDeviceCompleteOpCount == rinfo->dagDeviceOpCount) {
-    return NULL;
-  }
+RAI_DagOp *RedisAI_DagCurrentOp(RedisAI_RunInfo *rinfo) {
+    if (rinfo->dagDeviceCompleteOpCount == rinfo->dagDeviceOpCount) {
+        return NULL;
+    }
 
-  return rinfo->dagDeviceOps[rinfo->dagDeviceCompleteOpCount];
+    return rinfo->dagDeviceOps[rinfo->dagDeviceCompleteOpCount];
 }
- 
-void RedisAI_DagCurrentOpInfo(RedisAI_RunInfo *rinfo,
-                              int *currentOpReady,
+
+void RedisAI_DagCurrentOpInfo(RedisAI_RunInfo *rinfo, int *currentOpReady,
                               int *currentOpBatchable) {
-  RAI_DagOp *currentOp_ = RedisAI_DagCurrentOp(rinfo);
+    RAI_DagOp *currentOp_ = RedisAI_DagCurrentOp(rinfo);
 
-  *currentOpReady = 0;
-  *currentOpBatchable = 0;
+    *currentOpReady = 0;
+    *currentOpBatchable = 0;
 
-  if (currentOp_ == NULL) {
-    return;
-  }
-
-  if (currentOp_->mctx && currentOp_->mctx->model->opts.batchsize > 0) {
-    *currentOpBatchable = 1;
-  }
-
-  uint n_inkeys = array_len(currentOp_->inkeys);
-
-  RAI_ContextReadLock(rinfo);
-
-  *currentOpReady = 1;
-  for (int i=0; i<n_inkeys; i++) {
-    if (AI_dictFind(rinfo->dagTensorsContext,
-                    RedisModule_StringPtrLen(currentOp_->inkeys[i], NULL)) == NULL) {
-      RAI_ContextUnlock(rinfo);
-      *currentOpReady = 0;
-      return;
+    if (currentOp_ == NULL) {
+        return;
     }
-  }
 
-  RAI_ContextUnlock(rinfo);
+    if (currentOp_->mctx && currentOp_->mctx->model->opts.batchsize > 0) {
+        *currentOpBatchable = 1;
+    }
+
+    uint n_inkeys = array_len(currentOp_->inkeys);
+
+    RAI_ContextReadLock(rinfo);
+
+    *currentOpReady = 1;
+    for (int i = 0; i < n_inkeys; i++) {
+        if (AI_dictFind(rinfo->dagTensorsContext,
+                        RedisModule_StringPtrLen(currentOp_->inkeys[i], NULL)) == NULL) {
+            RAI_ContextUnlock(rinfo);
+            *currentOpReady = 0;
+            return;
+        }
+    }
+
+    RAI_ContextUnlock(rinfo);
 }
 
-void RedisAI_DagOpBatchInfo(RedisAI_RunInfo *rinfo, RAI_DagOp *op,
-                            size_t *batchsize, size_t *minbatchsize,
-                            size_t *minbatchtimeout, size_t *inbatchsize) {
-  *batchsize = 0;
-  *minbatchsize = 0;
-  *minbatchtimeout = 0;
-  *inbatchsize = 0;
- 
-  RAI_ContextReadLock(rinfo);
+void RedisAI_DagOpBatchInfo(RedisAI_RunInfo *rinfo, RAI_DagOp *op, size_t *batchsize,
+                            size_t *minbatchsize, size_t *minbatchtimeout, size_t *inbatchsize) {
+    *batchsize = 0;
+    *minbatchsize = 0;
+    *minbatchtimeout = 0;
+    *inbatchsize = 0;
 
-  if (op->mctx) {
-    *batchsize = op->mctx->model->opts.batchsize;
-    *minbatchsize = op->mctx->model->opts.minbatchsize;
-    *minbatchtimeout = op->mctx->model->opts.minbatchtimeout;
-    *inbatchsize = RAI_DagOpBatchSize(op, rinfo->dagTensorsContext);
-  }
+    RAI_ContextReadLock(rinfo);
 
-  RAI_ContextUnlock(rinfo);
+    if (op->mctx) {
+        *batchsize = op->mctx->model->opts.batchsize;
+        *minbatchsize = op->mctx->model->opts.minbatchsize;
+        *minbatchtimeout = op->mctx->model->opts.minbatchtimeout;
+        *inbatchsize = RAI_DagOpBatchSize(op, rinfo->dagTensorsContext);
+    }
+
+    RAI_ContextUnlock(rinfo);
 }
 
-void RedisAI_DagOpBatchingMatch(RedisAI_RunInfo *rinfo1, RAI_DagOp *op1,
-                                RedisAI_RunInfo *rinfo2, RAI_DagOp *op2,
-                                int *batched, size_t *inbatchsize) {
-  *batched = 0;
-  *inbatchsize = 0;
- 
-  RAI_ContextReadLock(rinfo2);
+void RedisAI_DagOpBatchingMatch(RedisAI_RunInfo *rinfo1, RAI_DagOp *op1, RedisAI_RunInfo *rinfo2,
+                                RAI_DagOp *op2, int *batched, size_t *inbatchsize) {
+    *batched = 0;
+    *inbatchsize = 0;
 
-  if (op2->mctx) {
-    int match = RAI_DagOpBatchable(op1, rinfo1->dagTensorsContext,
-                                   op2, rinfo2->dagTensorsContext);
+    RAI_ContextReadLock(rinfo2);
 
-    if (match) {
-      *batched = 1;
-      *inbatchsize = RAI_DagOpBatchSize(op2, rinfo2->dagTensorsContext);
+    if (op2->mctx) {
+        int match =
+            RAI_DagOpBatchable(op1, rinfo1->dagTensorsContext, op2, rinfo2->dagTensorsContext);
+
+        if (match) {
+            *batched = 1;
+            *inbatchsize = RAI_DagOpBatchSize(op2, rinfo2->dagTensorsContext);
+        }
     }
-  }
 
-  RAI_ContextUnlock(rinfo2);
+    RAI_ContextUnlock(rinfo2);
 }
 
 void RedisAI_DagRunSessionStep(RedisAI_RunInfo *rinfo, const char *devicestr) {
-  RAI_DagOp *currentOp = RedisAI_DagCurrentOp(rinfo);
+    RAI_DagOp *currentOp = RedisAI_DagCurrentOp(rinfo);
 
-  switch (currentOp->commandType) {
+    switch (currentOp->commandType) {
     case REDISAI_DAG_CMD_TENSORSET: {
-      RedisAI_DagRunSession_TensorSet_Step(rinfo, currentOp);
-      break;
+        RedisAI_DagRunSession_TensorSet_Step(rinfo, currentOp);
+        break;
     }
     case REDISAI_DAG_CMD_TENSORGET: {
-      RedisAI_DagRunSession_TensorGet_Step(rinfo, currentOp);
-      break;
+        RedisAI_DagRunSession_TensorGet_Step(rinfo, currentOp);
+        break;
     }
     case REDISAI_DAG_CMD_MODELRUN: {
-      RedisAI_DagRunSession_ModelRun_Step(rinfo, currentOp);
-      break;
+        RedisAI_DagRunSession_ModelRun_Step(rinfo, currentOp);
+        break;
     }
     case REDISAI_DAG_CMD_SCRIPTRUN: {
-      RedisAI_DagRunSession_ScriptRun_Step(rinfo, currentOp);
-      break;
+        RedisAI_DagRunSession_ScriptRun_Step(rinfo, currentOp);
+        break;
     }
     default: {
-      /* unsupported DAG's command */
-      RAI_SetError(currentOp->err, RAI_EDAGRUN, "ERR unsupported command within DAG");
-      currentOp->result = REDISMODULE_ERR;
-      break;
+        /* unsupported DAG's command */
+        RAI_SetError(currentOp->err, RAI_EDAGRUN, "ERR unsupported command within DAG");
+        currentOp->result = REDISMODULE_ERR;
+        break;
     }
-  }
+    }
 
-  if (currentOp->result != REDISMODULE_OK) {
-    __atomic_store_n(rinfo->dagError, 1, __ATOMIC_RELAXED);
-  }
+    if (currentOp->result != REDISMODULE_OK) {
+        __atomic_store_n(rinfo->dagError, 1, __ATOMIC_RELAXED);
+    }
 }
 
 void RedisAI_BatchedDagRunSessionStep(RedisAI_RunInfo **batched_rinfo, const char *devicestr) {
-  // Assumption: ops are guaranteed to be all MODELRUN
+    // Assumption: ops are guaranteed to be all MODELRUN
 
-  int n_ops = array_len(batched_rinfo);
+    int n_ops = array_len(batched_rinfo);
 
-  assert(n_ops > 1);
+    assert(n_ops > 1);
 
-  RAI_DagOp *currentOps[n_ops];
+    RAI_DagOp *currentOps[n_ops];
 
-  for (int i=0; i<n_ops; i++) {
-    RedisAI_RunInfo *rinfo = batched_rinfo[i];
+    for (int i = 0; i < n_ops; i++) {
+        RedisAI_RunInfo *rinfo = batched_rinfo[i];
 
-    RAI_DagOp *currentOp = RedisAI_DagCurrentOp(rinfo);
+        RAI_DagOp *currentOp = RedisAI_DagCurrentOp(rinfo);
 
-    currentOps[i] = currentOp;
-  }
-
-  RedisAI_BatchedDagRunSession_ModelRun_Step(batched_rinfo, currentOps);
-
-  for (int i=0; i<n_ops; i++) {
-    RedisAI_RunInfo *rinfo = batched_rinfo[i];
-    RAI_DagOp *currentOp = currentOps[i];
-
-    if (currentOp->result != REDISMODULE_OK) {
-      __atomic_store_n(rinfo->dagError, 1, __ATOMIC_RELAXED);
+        currentOps[i] = currentOp;
     }
-  }
-  
-  return;
+
+    RedisAI_BatchedDagRunSession_ModelRun_Step(batched_rinfo, currentOps);
+
+    for (int i = 0; i < n_ops; i++) {
+        RedisAI_RunInfo *rinfo = batched_rinfo[i];
+        RAI_DagOp *currentOp = currentOps[i];
+
+        if (currentOp->result != REDISMODULE_OK) {
+            __atomic_store_n(rinfo->dagError, 1, __ATOMIC_RELAXED);
+        }
+    }
+
+    return;
 }
 
-int RedisAI_DagRun_Reply(RedisModuleCtx *ctx, RedisModuleString **argv,
-                         int argc) {
-  REDISMODULE_NOT_USED(argv);
-  REDISMODULE_NOT_USED(argc);
-  RedisAI_RunInfo *rinfo = RedisModule_GetBlockedClientPrivateData(ctx);
+int RedisAI_DagRun_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    RedisAI_RunInfo *rinfo = RedisModule_GetBlockedClientPrivateData(ctx);
 
-  int dag_error = 0;
-  char *detail_oneline;
+    int dag_error = 0;
+    char *detail_oneline;
 
-  size_t n_dagOps = array_len(rinfo->dagOps);
+    size_t n_dagOps = array_len(rinfo->dagOps);
 
-  if (*rinfo->timedOut) {
-    RedisModule_ReplyWithSimpleString(ctx, "TIMEDOUT");
-    RAI_FreeRunInfo(ctx, rinfo);
-    return REDISMODULE_OK;
-  }
-
-  if (rinfo->single_op_dag == 0) {
-    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-  }
-
-  for (size_t i = 0; i < n_dagOps; i++) {
-    RAI_DagOp *currentOp = rinfo->dagOps[i];
-    switch (currentOp->commandType) {
-      case REDISAI_DAG_CMD_TENSORSET: {
-        rinfo->dagReplyLength++;
-        if (currentOp->result == REDISMODULE_ERR) {
-          RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
-          dag_error = 1;
-        }
-        else if (currentOp->result == -1) {
-          RedisModule_ReplyWithSimpleString(ctx, "NA");
-        }
-        else {
-          RedisModule_ReplyWithSimpleString(ctx, "OK");
-        }
-        break;
-      }
-
-      case REDISAI_DAG_CMD_TENSORGET: {
-        rinfo->dagReplyLength++;
-        if (currentOp->result == REDISMODULE_ERR) {
-          RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
-          dag_error = 1;
-        } else {
-          if (array_len(currentOp->outTensors) > 0) {
-            RAI_Tensor *tensor = currentOp->outTensors[0];
-            RAI_parseTensorGetArgs(ctx, currentOp->argv, currentOp->argc,
-                                   tensor);
-          }
-          else if (currentOp->result == -1) {
-            RedisModule_ReplyWithSimpleString(ctx, "NA");
-          }
-          else {
-            RedisModule_ReplyWithError(
-                ctx, "ERR error getting tensor from local context");
-          }
-        }
-        break;
-      }
-
-      case REDISAI_DAG_CMD_MODELRUN: {
-        rinfo->dagReplyLength++;
-        struct RedisAI_RunStats *rstats = NULL;
-        const char *runkey =
-            RedisModule_StringPtrLen(currentOp->runkey, NULL);
-        RAI_GetRunStats(runkey,&rstats);
-        if (currentOp->result == REDISMODULE_ERR) {
-          RAI_SafeAddDataPoint(rstats, 0, 1, 1, 0);
-          RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
-          dag_error = 1;
-        }
-        else if (currentOp->result == -1) {
-          RedisModule_ReplyWithSimpleString(ctx, "NA");
-        }
-        else {
-          RAI_Tensor *t = NULL; 
-          if (array_len(currentOp->mctx->outputs) > 0) {
-            t = currentOp->mctx->outputs[0].tensor;
-          }
-          int batch_size = 0;
-          if (t) {
-            batch_size = RAI_TensorDim(t, 0);
-          }
-          RAI_SafeAddDataPoint(rstats, currentOp->duration_us, 1, 0, batch_size);
-          RedisModule_ReplyWithSimpleString(ctx, "OK");
-        }
-        break;
-      }
-
-      case REDISAI_DAG_CMD_SCRIPTRUN: {
-        rinfo->dagReplyLength++;
-        struct RedisAI_RunStats *rstats = NULL;
-        const char *runkey = RedisModule_StringPtrLen(currentOp->runkey, NULL);
-        RAI_GetRunStats(runkey,&rstats);
-        if (currentOp->result == REDISMODULE_ERR) {
-          RAI_SafeAddDataPoint(rstats, 0, 1, 1, 0);
-          RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
-          dag_error = 1;
-        }
-        else if (currentOp->result == -1) {
-          RedisModule_ReplyWithSimpleString(ctx, "NA");
-        }
-        else {
-          int batch_size = 1;
-          RAI_SafeAddDataPoint(rstats, currentOp->duration_us, 1, 0, batch_size);
-          RedisModule_ReplyWithSimpleString(ctx, "OK");
-        }
-        break;
-      }
-
-      default:
-        /* no-op */
-        break;
+    if (*rinfo->timedOut) {
+        RedisModule_ReplyWithSimpleString(ctx, "TIMEDOUT");
+        RAI_FreeRunInfo(ctx, rinfo);
+        return REDISMODULE_OK;
     }
-  }
 
-  if (dag_error) {
     if (rinfo->single_op_dag == 0) {
-      RedisModule_ReplySetArrayLength(ctx, rinfo->dagReplyLength);
+        RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     }
-    RAI_FreeRunInfo(ctx, rinfo);
-    return REDISMODULE_ERR;
-  }
 
-  AI_dictIterator *persist_iter =
-      AI_dictGetSafeIterator(rinfo->dagTensorsPersistedContext);
-  AI_dictEntry *persist_entry = AI_dictNext(persist_iter);
-  while (persist_entry) {
-    const char *persist_key_name = AI_dictGetKey(persist_entry);
-
-    AI_dictEntry *tensor_entry =
-        AI_dictFind(rinfo->dagTensorsContext, persist_key_name);
-
-    if (tensor_entry) {
-      RAI_Tensor *tensor = AI_dictGetVal(tensor_entry);
-
-      if (tensor == NULL) {
-        persist_entry = AI_dictNext(persist_iter);
-        continue;
-      }
-      RedisModuleKey *key;
-      char *demangled_key_name = RedisModule_Strdup(persist_key_name);
-      demangled_key_name[strlen(persist_key_name) - 4] = 0;
-      RedisModuleString *tensor_keyname = RedisModule_CreateString(
-          ctx, demangled_key_name, strlen(demangled_key_name));
-      const int status = RAI_OpenKey_Tensor(
-          ctx, tensor_keyname, &key, REDISMODULE_READ | REDISMODULE_WRITE);
-      RedisModule_Free(demangled_key_name);
-      if (status == REDISMODULE_ERR) {
-        RedisModule_ReplyWithError(ctx, "ERR could not save tensor");
-        rinfo->dagReplyLength++;
-      } else {
-        if (RedisModule_ModuleTypeSetValue(key, RedisAI_TensorType, RAI_TensorGetShallowCopy(tensor)) !=
-            REDISMODULE_OK) {
-          RedisModule_ReplyWithError(ctx, "ERR could not save tensor");
-          rinfo->dagReplyLength++;
+    for (size_t i = 0; i < n_dagOps; i++) {
+        RAI_DagOp *currentOp = rinfo->dagOps[i];
+        switch (currentOp->commandType) {
+        case REDISAI_DAG_CMD_TENSORSET: {
+            rinfo->dagReplyLength++;
+            if (currentOp->result == REDISMODULE_ERR) {
+                RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
+                dag_error = 1;
+            } else if (currentOp->result == -1) {
+                RedisModule_ReplyWithSimpleString(ctx, "NA");
+            } else {
+                RedisModule_ReplyWithSimpleString(ctx, "OK");
+            }
+            break;
         }
-      }
-      RedisModule_CloseKey(key);
-      RedisAI_ReplicateTensorSet(ctx, tensor_keyname, tensor);
-    } else {
-      RedisModule_ReplyWithError(
-          ctx, "ERR specified persistent key that was not used in DAG");
-      rinfo->dagReplyLength++;
 
-      RedisModule_Log(ctx, "warning",
-                      "on DAGRUN's PERSIST pecified persistent key (%s) that "
-                      "was not used on DAG. Logging all local context keys",
-                      persist_key_name);
-      AI_dictIterator *local_iter =
-          AI_dictGetSafeIterator(rinfo->dagTensorsContext);
-      AI_dictEntry *local_entry = AI_dictNext(local_iter);
-      while (local_entry) {
-        const char *localcontext_key_name = AI_dictGetKey(local_entry);
-        RedisModule_Log(ctx, "warning", "DAG's local context key (%s)",
-                        localcontext_key_name);
-        local_entry = AI_dictNext(local_iter);
-      }
-      AI_dictReleaseIterator(local_iter);
+        case REDISAI_DAG_CMD_TENSORGET: {
+            rinfo->dagReplyLength++;
+            if (currentOp->result == REDISMODULE_ERR) {
+                RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
+                dag_error = 1;
+            } else {
+                if (array_len(currentOp->outTensors) > 0) {
+                    RAI_Tensor *tensor = currentOp->outTensors[0];
+                    RAI_parseTensorGetArgs(ctx, currentOp->argv, currentOp->argc, tensor);
+                } else if (currentOp->result == -1) {
+                    RedisModule_ReplyWithSimpleString(ctx, "NA");
+                } else {
+                    RedisModule_ReplyWithError(ctx, "ERR error getting tensor from local context");
+                }
+            }
+            break;
+        }
 
-      for (size_t opN = 0; opN < array_len(rinfo->dagOps); opN++) {
-        RedisModule_Log(
-            ctx, "warning", "DAG's op n#  %zu - cmdType %d ( argc %d )", opN,
-            rinfo->dagOps[opN]->commandType, rinfo->dagOps[opN]->argc);
-      }
+        case REDISAI_DAG_CMD_MODELRUN: {
+            rinfo->dagReplyLength++;
+            struct RedisAI_RunStats *rstats = NULL;
+            const char *runkey = RedisModule_StringPtrLen(currentOp->runkey, NULL);
+            RAI_GetRunStats(runkey, &rstats);
+            if (currentOp->result == REDISMODULE_ERR) {
+                RAI_SafeAddDataPoint(rstats, 0, 1, 1, 0);
+                RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
+                dag_error = 1;
+            } else if (currentOp->result == -1) {
+                RedisModule_ReplyWithSimpleString(ctx, "NA");
+            } else {
+                RAI_Tensor *t = NULL;
+                if (array_len(currentOp->mctx->outputs) > 0) {
+                    t = currentOp->mctx->outputs[0].tensor;
+                }
+                int batch_size = 0;
+                if (t) {
+                    batch_size = RAI_TensorDim(t, 0);
+                }
+                RAI_SafeAddDataPoint(rstats, currentOp->duration_us, 1, 0, batch_size);
+                RedisModule_ReplyWithSimpleString(ctx, "OK");
+            }
+            break;
+        }
+
+        case REDISAI_DAG_CMD_SCRIPTRUN: {
+            rinfo->dagReplyLength++;
+            struct RedisAI_RunStats *rstats = NULL;
+            const char *runkey = RedisModule_StringPtrLen(currentOp->runkey, NULL);
+            RAI_GetRunStats(runkey, &rstats);
+            if (currentOp->result == REDISMODULE_ERR) {
+                RAI_SafeAddDataPoint(rstats, 0, 1, 1, 0);
+                RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
+                dag_error = 1;
+            } else if (currentOp->result == -1) {
+                RedisModule_ReplyWithSimpleString(ctx, "NA");
+            } else {
+                int batch_size = 1;
+                RAI_SafeAddDataPoint(rstats, currentOp->duration_us, 1, 0, batch_size);
+                RedisModule_ReplyWithSimpleString(ctx, "OK");
+            }
+            break;
+        }
+
+        default:
+            /* no-op */
+            break;
+        }
     }
 
-    persist_entry = AI_dictNext(persist_iter);
-  }
+    if (dag_error) {
+        if (rinfo->single_op_dag == 0) {
+            RedisModule_ReplySetArrayLength(ctx, rinfo->dagReplyLength);
+        }
+        RAI_FreeRunInfo(ctx, rinfo);
+        return REDISMODULE_ERR;
+    }
 
-  AI_dictReleaseIterator(persist_iter);
+    AI_dictIterator *persist_iter = AI_dictGetSafeIterator(rinfo->dagTensorsPersistedContext);
+    AI_dictEntry *persist_entry = AI_dictNext(persist_iter);
+    while (persist_entry) {
+        const char *persist_key_name = AI_dictGetKey(persist_entry);
 
-  if (rinfo->single_op_dag == 0) {
-    RedisModule_ReplySetArrayLength(ctx, rinfo->dagReplyLength);
-  }
+        AI_dictEntry *tensor_entry = AI_dictFind(rinfo->dagTensorsContext, persist_key_name);
 
-  RAI_FreeRunInfo(ctx, rinfo);
+        if (tensor_entry) {
+            RAI_Tensor *tensor = AI_dictGetVal(tensor_entry);
 
-  return REDISMODULE_OK;
+            if (tensor == NULL) {
+                persist_entry = AI_dictNext(persist_iter);
+                continue;
+            }
+            RedisModuleKey *key;
+            char *demangled_key_name = RedisModule_Strdup(persist_key_name);
+            demangled_key_name[strlen(persist_key_name) - 4] = 0;
+            RedisModuleString *tensor_keyname =
+                RedisModule_CreateString(ctx, demangled_key_name, strlen(demangled_key_name));
+            const int status =
+                RAI_OpenKey_Tensor(ctx, tensor_keyname, &key, REDISMODULE_READ | REDISMODULE_WRITE);
+            RedisModule_Free(demangled_key_name);
+            if (status == REDISMODULE_ERR) {
+                RedisModule_ReplyWithError(ctx, "ERR could not save tensor");
+                rinfo->dagReplyLength++;
+            } else {
+                if (RedisModule_ModuleTypeSetValue(key, RedisAI_TensorType,
+                                                   RAI_TensorGetShallowCopy(tensor)) !=
+                    REDISMODULE_OK) {
+                    RedisModule_ReplyWithError(ctx, "ERR could not save tensor");
+                    rinfo->dagReplyLength++;
+                }
+            }
+            RedisModule_CloseKey(key);
+            RedisAI_ReplicateTensorSet(ctx, tensor_keyname, tensor);
+        } else {
+            RedisModule_ReplyWithError(ctx,
+                                       "ERR specified persistent key that was not used in DAG");
+            rinfo->dagReplyLength++;
+
+            RedisModule_Log(ctx, "warning",
+                            "on DAGRUN's PERSIST pecified persistent key (%s) that "
+                            "was not used on DAG. Logging all local context keys",
+                            persist_key_name);
+            AI_dictIterator *local_iter = AI_dictGetSafeIterator(rinfo->dagTensorsContext);
+            AI_dictEntry *local_entry = AI_dictNext(local_iter);
+            while (local_entry) {
+                const char *localcontext_key_name = AI_dictGetKey(local_entry);
+                RedisModule_Log(ctx, "warning", "DAG's local context key (%s)",
+                                localcontext_key_name);
+                local_entry = AI_dictNext(local_iter);
+            }
+            AI_dictReleaseIterator(local_iter);
+
+            for (size_t opN = 0; opN < array_len(rinfo->dagOps); opN++) {
+                RedisModule_Log(ctx, "warning", "DAG's op n#  %zu - cmdType %d ( argc %d )", opN,
+                                rinfo->dagOps[opN]->commandType, rinfo->dagOps[opN]->argc);
+            }
+        }
+
+        persist_entry = AI_dictNext(persist_iter);
+    }
+
+    AI_dictReleaseIterator(persist_iter);
+
+    if (rinfo->single_op_dag == 0) {
+        RedisModule_ReplySetArrayLength(ctx, rinfo->dagReplyLength);
+    }
+
+    RAI_FreeRunInfo(ctx, rinfo);
+
+    return REDISMODULE_OK;
 }
 
 /**
  * DAGRUN Building Block to parse [LOAD <nkeys> key1 key2... ]
  */
-int RAI_parseDAGLoadArgs(RedisModuleCtx *ctx, RedisModuleString **argv,
-                         int argc, AI_dict **loadedContextDict,
-                         AI_dict **localContextDict,
+int RAI_parseDAGLoadArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                         AI_dict **loadedContextDict, AI_dict **localContextDict,
                          const char *chaining_operator) {
-  if (argc < 3) {
-    RedisModule_WrongArity(ctx);
-    return -1;
-  }
-
-  long long n_keys;
-  const int retval = RedisModule_StringToLongLong(argv[1], &n_keys);
-  if (retval != REDISMODULE_OK || n_keys <= 0) {
-    RedisModule_ReplyWithError(
-        ctx, "ERR invalid or negative value found in number of keys to LOAD");
-    return -1;
-  }
-  int number_loaded_keys = 0;
-  int separator_flag = 0;
-  size_t argpos = 2;
-  for (; (argpos <= argc - 1) && (number_loaded_keys < n_keys); argpos++) {
-    const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
-    if (!strcasecmp(arg_string, chaining_operator)) {
-      separator_flag = 1;
-      break;
-    } else {
-      RAI_Tensor *t;
-      RedisModuleKey *key;
-      const int status = RAI_GetTensorFromKeyspace(ctx, argv[argpos], &key, &t, REDISMODULE_READ);
-      if (status == REDISMODULE_ERR) {
-        RedisModule_Log(
-            ctx, "warning",
-            "on DAGRUN's LOAD could not load tensor %s from keyspace",
-            arg_string);
+    if (argc < 3) {
+        RedisModule_WrongArity(ctx);
         return -1;
-      }
-      RedisModule_CloseKey(key);
-      char *dictKey = (char*) RedisModule_Alloc((strlen(arg_string) + 5)*sizeof(char));
-      sprintf(dictKey, "%s%04d", arg_string, 1);
-      AI_dictAdd(*localContextDict, (void*)dictKey, (void *)RAI_TensorGetShallowCopy(t));
-      AI_dictAdd(*loadedContextDict, (void*)dictKey, (void *)1);
-      RedisModule_Free(dictKey);
-      number_loaded_keys++;
     }
-  }
-  if (number_loaded_keys != n_keys) {
-    RedisModule_WrongArity(ctx);
-    return -1;
-  }
-  return argpos;
+
+    long long n_keys;
+    const int retval = RedisModule_StringToLongLong(argv[1], &n_keys);
+    if (retval != REDISMODULE_OK || n_keys <= 0) {
+        RedisModule_ReplyWithError(ctx,
+                                   "ERR invalid or negative value found in number of keys to LOAD");
+        return -1;
+    }
+    int number_loaded_keys = 0;
+    int separator_flag = 0;
+    size_t argpos = 2;
+    for (; (argpos <= argc - 1) && (number_loaded_keys < n_keys); argpos++) {
+        const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
+        if (!strcasecmp(arg_string, chaining_operator)) {
+            separator_flag = 1;
+            break;
+        } else {
+            RAI_Tensor *t;
+            RedisModuleKey *key;
+            const int status =
+                RAI_GetTensorFromKeyspace(ctx, argv[argpos], &key, &t, REDISMODULE_READ);
+            if (status == REDISMODULE_ERR) {
+                RedisModule_Log(ctx, "warning",
+                                "on DAGRUN's LOAD could not load tensor %s from keyspace",
+                                arg_string);
+                return -1;
+            }
+            RedisModule_CloseKey(key);
+            char *dictKey = (char *)RedisModule_Alloc((strlen(arg_string) + 5) * sizeof(char));
+            sprintf(dictKey, "%s%04d", arg_string, 1);
+            AI_dictAdd(*localContextDict, (void *)dictKey, (void *)RAI_TensorGetShallowCopy(t));
+            AI_dictAdd(*loadedContextDict, (void *)dictKey, (void *)1);
+            RedisModule_Free(dictKey);
+            number_loaded_keys++;
+        }
+    }
+    if (number_loaded_keys != n_keys) {
+        RedisModule_WrongArity(ctx);
+        return -1;
+    }
+    return argpos;
 }
 
 /**
  * DAGRUN Building Block to parse [PERSIST <nkeys> key1 key2... ]
  */
-int RAI_parseDAGPersistArgs(RedisModuleCtx *ctx, RedisModuleString **argv,
-                            int argc, AI_dict **persistContextDict,
-                            const char *chaining_operator) {
-  if (argc < 3) {
-    RedisModule_WrongArity(ctx);
-    return -1;
-  }
-
-  long long n_keys;
-  const int retval = RedisModule_StringToLongLong(argv[1], &n_keys);
-  if (retval != REDISMODULE_OK || n_keys <= 0) {
-    RedisModule_ReplyWithError(
-        ctx,
-        "ERR invalid or negative value found in number of keys to PERSIST");
-    return -1;
-  }
-
-  int number_loaded_keys = 0;
-  int separator_flag = 0;
-  size_t argpos = 2;
-  for (; (argpos < argc) && (number_loaded_keys < n_keys); argpos++) {
-    const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
-    if (!strcasecmp(arg_string, chaining_operator)) {
-      separator_flag = 1;
-      break;
-    } else {
-      AI_dictAdd(*persistContextDict, (void*)arg_string, (void *)1);
-      number_loaded_keys++;
+int RAI_parseDAGPersistArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                            AI_dict **persistContextDict, const char *chaining_operator) {
+    if (argc < 3) {
+        RedisModule_WrongArity(ctx);
+        return -1;
     }
-  }
-  if (number_loaded_keys != n_keys) {
-    RedisModule_WrongArity(ctx);
-    return -1;
-  }
-  return argpos;
+
+    long long n_keys;
+    const int retval = RedisModule_StringToLongLong(argv[1], &n_keys);
+    if (retval != REDISMODULE_OK || n_keys <= 0) {
+        RedisModule_ReplyWithError(
+            ctx, "ERR invalid or negative value found in number of keys to PERSIST");
+        return -1;
+    }
+
+    int number_loaded_keys = 0;
+    int separator_flag = 0;
+    size_t argpos = 2;
+    for (; (argpos < argc) && (number_loaded_keys < n_keys); argpos++) {
+        const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
+        if (!strcasecmp(arg_string, chaining_operator)) {
+            separator_flag = 1;
+            break;
+        } else {
+            AI_dictAdd(*persistContextDict, (void *)arg_string, (void *)1);
+            number_loaded_keys++;
+        }
+    }
+    if (number_loaded_keys != n_keys) {
+        RedisModule_WrongArity(ctx);
+        return -1;
+    }
+    return argpos;
 }
 
-int RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
-                                                    RedisModuleString **argv, int argc){
-  for (size_t argpos = 1; argpos < argc; argpos++){
-    const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
-    if ( (!strcasecmp(arg_string, "LOAD") || !strcasecmp(arg_string, "PERSIST") ) && (argpos+1 < argc) ) {
-      long long n_keys;
-      argpos++;
-      const int retval = RedisModule_StringToLongLong(argv[argpos], &n_keys);
-      if(retval != REDISMODULE_OK){
-        return REDISMODULE_ERR;
-      }
-      argpos++;
-      if (n_keys > 0){
-        size_t last_persist_argpos = n_keys+argpos;
-        for (; argpos < last_persist_argpos &&  argpos < argc; argpos++){
-          RedisModule_KeyAtPos(ctx, argpos);
+int RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx, RedisModuleString **argv,
+                                                    int argc) {
+    for (size_t argpos = 1; argpos < argc; argpos++) {
+        const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
+        if ((!strcasecmp(arg_string, "LOAD") || !strcasecmp(arg_string, "PERSIST")) &&
+            (argpos + 1 < argc)) {
+            long long n_keys;
+            argpos++;
+            const int retval = RedisModule_StringToLongLong(argv[argpos], &n_keys);
+            if (retval != REDISMODULE_OK) {
+                return REDISMODULE_ERR;
+            }
+            argpos++;
+            if (n_keys > 0) {
+                size_t last_persist_argpos = n_keys + argpos;
+                for (; argpos < last_persist_argpos && argpos < argc; argpos++) {
+                    RedisModule_KeyAtPos(ctx, argpos);
+                }
+            }
         }
-      }
     }
-  }
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
 void RedisAI_FreeData(RedisModuleCtx *ctx, void *rinfo) {}
 
 void RedisAI_Disconnected(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc) {
-  RedisModule_Log(ctx, "warning", "Blocked client %p disconnected!",
-                  (void *)bc);
+    RedisModule_Log(ctx, "warning", "Blocked client %p disconnected!", (void *)bc);
 }
 
-int RedisAI_DagRunSyntaxParser(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                 int argc, int dagMode) {
+int RedisAI_DagRunSyntaxParser(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                               int dagMode) {
 
-  if (argc < 4) return RedisModule_WrongArity(ctx);
+    if (argc < 4)
+        return RedisModule_WrongArity(ctx);
 
-  RedisAI_RunInfo *rinfo = NULL;
-  if (RAI_InitRunInfo(&rinfo) == REDISMODULE_ERR) {
-    return RedisModule_ReplyWithError(
-        ctx,
-        "ERR Unable to allocate the memory and initialise the RedisAI_RunInfo "
-        "structure");
-  }
-  RAI_DagOp *currentDagOp = NULL;
-  RAI_InitDagOp(&currentDagOp);
-  rinfo->dagOps = array_append(rinfo->dagOps, currentDagOp);
-
-  int persistFlag = 0;
-  int loadFlag = 0;
-  int chainingOpCount = 0;
-
-  int argstart = 1;
-
-  // If we're parsing a AI.MODELRUN or AI.SCRIPTRUN command, we don't
-  // expect there to be a chaining |> operator
-  if (!strcasecmp(RedisModule_StringPtrLen(argv[0], NULL), "AI.MODELRUN") ||
-      !strcasecmp(RedisModule_StringPtrLen(argv[0], NULL), "AI.SCRIPTRUN")) {
-    argstart = 0;
-    chainingOpCount++;
-    rinfo->single_op_dag = 1;
-    rinfo->single_device_dag = 1;
-  }
-
-  for (size_t argpos = argstart; argpos <= argc - 1; argpos++) {
-    const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
-    if (!strcasecmp(arg_string, "LOAD")) {
-      loadFlag = 1;
-      const int parse_result = RAI_parseDAGLoadArgs(
-          ctx, &argv[argpos], argc - argpos, &(rinfo->dagTensorsLoadedContext),
-          &(rinfo->dagTensorsContext), "|>");
-      if (parse_result > 0) {
-        argpos += parse_result - 1;
-      } else {
-        RAI_FreeRunInfo(ctx, rinfo);
-        return REDISMODULE_ERR;
-      }
-    } else if (!strcasecmp(arg_string, "PERSIST")) {
-      if (dagMode == REDISAI_DAG_READONLY_MODE) {
-        RAI_FreeRunInfo(ctx, rinfo);
+    RedisAI_RunInfo *rinfo = NULL;
+    if (RAI_InitRunInfo(&rinfo) == REDISMODULE_ERR) {
         return RedisModule_ReplyWithError(
-            ctx, "ERR PERSIST cannot be specified in a read-only DAG");
-      }
-      persistFlag = 1;
-      const int parse_result =
-          RAI_parseDAGPersistArgs(ctx, &argv[argpos], argc - argpos,
-                                  &(rinfo->dagTensorsPersistedContext), "|>");
-      if (parse_result > 0) {
-        argpos += parse_result - 1;
-      } else {
-        RAI_FreeRunInfo(ctx, rinfo);
-        return REDISMODULE_ERR;
-      }
-    } else if (!strcasecmp(arg_string, "TIMEOUT")) {
-      if (!((chainingOpCount == 0) ||
-           (chainingOpCount  == 1 && rinfo->single_op_dag == 1))) {
-        RAI_FreeRunInfo(ctx, rinfo);
-        return RedisModule_ReplyWithError(
-            ctx, "ERR TIMEOUT not allowed within a DAG command");
-      }
-      if (argpos == argc - 1) {
-        RAI_FreeRunInfo(ctx, rinfo);
-        return RedisModule_ReplyWithError(
-            ctx, "ERR No value provided for TIMEOUT");
-      }
-      long long timeout;
-      const int retval = RedisModule_StringToLongLong(argv[argpos + 1], &timeout);
-      if (retval != REDISMODULE_OK || timeout <= 0) {
-        RAI_FreeRunInfo(ctx, rinfo);
-        return RedisModule_ReplyWithError(
-            ctx, "ERR Invalid value for TIMEOUT");
-      }
-      rinfo->timeout = timeout;
-      argpos += 1;
-      continue;
-    } else if (!strcasecmp(arg_string, "|>") && argpos < argc - 1) {
-      // on the first pipe operator, if LOAD or PERSIST were used, we've already
-      // allocated memory
-      if (chainingOpCount > 0) {
-        rinfo->dagOpCount++;
-        RAI_DagOp *currentDagOp = NULL;
-        RAI_InitDagOp(&currentDagOp);
-        rinfo->dagOps = array_append(rinfo->dagOps, currentDagOp);
-      }
-      chainingOpCount++;
-    } else {
-      if (!strcasecmp(arg_string, "AI.TENSORGET")) {
-        rinfo->dagOps[rinfo->dagOpCount]->commandType =
-            REDISAI_DAG_CMD_TENSORGET;
-        rinfo->dagOps[rinfo->dagOpCount]->devicestr = "CPU";
-      }
-      if (!strcasecmp(arg_string, "AI.TENSORSET")) {
-        rinfo->dagOps[rinfo->dagOpCount]->commandType =
-            REDISAI_DAG_CMD_TENSORSET;
-        rinfo->dagOps[rinfo->dagOpCount]->devicestr = "CPU";
-      }
-      if (!strcasecmp(arg_string, "AI.MODELRUN")) {
-        if (argc - 2 < argpos) {
-          return RedisModule_WrongArity(ctx);
-        }
-        RAI_DagOp *currentOp = rinfo->dagOps[rinfo->dagOpCount];
-        currentOp->commandType = REDISAI_DAG_CMD_MODELRUN;
-        RAI_Model *mto;
-        RedisModuleKey *modelKey;
-        const int status = RAI_GetModelFromKeyspace(
-            ctx, argv[argpos + 1], &modelKey, &mto, REDISMODULE_READ);
-        if (status == REDISMODULE_ERR) {
-          RAI_FreeRunInfo(ctx, rinfo);
-          return REDISMODULE_ERR;
-        }
-        currentOp->devicestr = mto->devicestr;
-        currentOp->runkey = argv[argpos + 1];
-        currentOp->mctx = RAI_ModelRunCtxCreate(mto);
-      }
-      if (!strcasecmp(arg_string, "AI.SCRIPTRUN")) {
-        if (argc - 3 < argpos) {
-          return RedisModule_WrongArity(ctx);
-        }
-        RAI_DagOp *currentOp = rinfo->dagOps[rinfo->dagOpCount];
-        currentOp->commandType = REDISAI_DAG_CMD_SCRIPTRUN;
-        RAI_Script *sto;
-        RedisModuleKey *scriptKey;
-        const int status = RAI_GetScriptFromKeyspace(
-            ctx, argv[argpos + 1], &scriptKey, &sto, REDISMODULE_READ);
-        if (status == REDISMODULE_ERR) {
-          RAI_FreeRunInfo(ctx, rinfo);
-          return REDISMODULE_ERR;
-        }
-        currentOp->devicestr = sto->devicestr;
-        const char *functionName =
-            RedisModule_StringPtrLen(argv[argpos + 2], NULL);
-        currentOp->runkey = argv[argpos + 1];
-        currentOp->sctx = RAI_ScriptRunCtxCreate(sto, functionName);
-      }
-      RedisModule_RetainString(NULL, argv[argpos]);
-      RAI_DagOp *currentOp = rinfo->dagOps[rinfo->dagOpCount];
-      currentOp->argv = array_append(currentOp->argv, argv[argpos]);
-      currentOp->argc++;
+            ctx, "ERR Unable to allocate the memory and initialise the RedisAI_RunInfo "
+                 "structure");
     }
-  }
+    RAI_DagOp *currentDagOp = NULL;
+    RAI_InitDagOp(&currentDagOp);
+    rinfo->dagOps = array_append(rinfo->dagOps, currentDagOp);
 
-  rinfo->dagOpCount = array_len(rinfo->dagOps);
+    int persistFlag = 0;
+    int loadFlag = 0;
+    int chainingOpCount = 0;
 
-  for (long long i=0; i<array_len(rinfo->dagOps); i++) {
-    RAI_DagOp *currentOp = rinfo->dagOps[i];
-    if(currentOp==NULL) continue;
-    int parse_result;
-    switch (currentOp->commandType) {
-      case REDISAI_DAG_CMD_TENSORSET:
-        currentOp->outkeys = array_append(currentOp->outkeys, currentOp->argv[1]);
-        break;
-      case REDISAI_DAG_CMD_TENSORGET:
-        currentOp->inkeys = array_append(currentOp->inkeys, currentOp->argv[1]);
-        break;
-      case REDISAI_DAG_CMD_MODELRUN:
-        parse_result = RedisAI_Parse_ModelRun_RedisCommand(
-            NULL, currentOp->argv, currentOp->argc, &(currentOp->mctx),
-            &(currentOp->inkeys), &(currentOp->outkeys),
-            &(currentOp->mctx->model), currentOp->err);
-        if (parse_result < 0) {
-          return RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
+    int argstart = 1;
+
+    // If we're parsing a AI.MODELRUN or AI.SCRIPTRUN command, we don't
+    // expect there to be a chaining |> operator
+    if (!strcasecmp(RedisModule_StringPtrLen(argv[0], NULL), "AI.MODELRUN") ||
+        !strcasecmp(RedisModule_StringPtrLen(argv[0], NULL), "AI.SCRIPTRUN")) {
+        argstart = 0;
+        chainingOpCount++;
+        rinfo->single_op_dag = 1;
+        rinfo->single_device_dag = 1;
+    }
+
+    for (size_t argpos = argstart; argpos <= argc - 1; argpos++) {
+        const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
+        if (!strcasecmp(arg_string, "LOAD")) {
+            loadFlag = 1;
+            const int parse_result = RAI_parseDAGLoadArgs(ctx, &argv[argpos], argc - argpos,
+                                                          &(rinfo->dagTensorsLoadedContext),
+                                                          &(rinfo->dagTensorsContext), "|>");
+            if (parse_result > 0) {
+                argpos += parse_result - 1;
+            } else {
+                RAI_FreeRunInfo(ctx, rinfo);
+                return REDISMODULE_ERR;
+            }
+        } else if (!strcasecmp(arg_string, "PERSIST")) {
+            if (dagMode == REDISAI_DAG_READONLY_MODE) {
+                RAI_FreeRunInfo(ctx, rinfo);
+                return RedisModule_ReplyWithError(
+                    ctx, "ERR PERSIST cannot be specified in a read-only DAG");
+            }
+            persistFlag = 1;
+            const int parse_result = RAI_parseDAGPersistArgs(
+                ctx, &argv[argpos], argc - argpos, &(rinfo->dagTensorsPersistedContext), "|>");
+            if (parse_result > 0) {
+                argpos += parse_result - 1;
+            } else {
+                RAI_FreeRunInfo(ctx, rinfo);
+                return REDISMODULE_ERR;
+            }
+        } else if (!strcasecmp(arg_string, "TIMEOUT")) {
+            if (!((chainingOpCount == 0) || (chainingOpCount == 1 && rinfo->single_op_dag == 1))) {
+                RAI_FreeRunInfo(ctx, rinfo);
+                return RedisModule_ReplyWithError(ctx,
+                                                  "ERR TIMEOUT not allowed within a DAG command");
+            }
+            if (argpos == argc - 1) {
+                RAI_FreeRunInfo(ctx, rinfo);
+                return RedisModule_ReplyWithError(ctx, "ERR No value provided for TIMEOUT");
+            }
+            long long timeout;
+            const int retval = RedisModule_StringToLongLong(argv[argpos + 1], &timeout);
+            if (retval != REDISMODULE_OK || timeout <= 0) {
+                RAI_FreeRunInfo(ctx, rinfo);
+                return RedisModule_ReplyWithError(ctx, "ERR Invalid value for TIMEOUT");
+            }
+            rinfo->timeout = timeout;
+            argpos += 1;
+            continue;
+        } else if (!strcasecmp(arg_string, "|>") && argpos < argc - 1) {
+            // on the first pipe operator, if LOAD or PERSIST were used, we've already
+            // allocated memory
+            if (chainingOpCount > 0) {
+                rinfo->dagOpCount++;
+                RAI_DagOp *currentDagOp = NULL;
+                RAI_InitDagOp(&currentDagOp);
+                rinfo->dagOps = array_append(rinfo->dagOps, currentDagOp);
+            }
+            chainingOpCount++;
+        } else {
+            if (!strcasecmp(arg_string, "AI.TENSORGET")) {
+                rinfo->dagOps[rinfo->dagOpCount]->commandType = REDISAI_DAG_CMD_TENSORGET;
+                rinfo->dagOps[rinfo->dagOpCount]->devicestr = "CPU";
+            }
+            if (!strcasecmp(arg_string, "AI.TENSORSET")) {
+                rinfo->dagOps[rinfo->dagOpCount]->commandType = REDISAI_DAG_CMD_TENSORSET;
+                rinfo->dagOps[rinfo->dagOpCount]->devicestr = "CPU";
+            }
+            if (!strcasecmp(arg_string, "AI.MODELRUN")) {
+                if (argc - 2 < argpos) {
+                    return RedisModule_WrongArity(ctx);
+                }
+                RAI_DagOp *currentOp = rinfo->dagOps[rinfo->dagOpCount];
+                currentOp->commandType = REDISAI_DAG_CMD_MODELRUN;
+                RAI_Model *mto;
+                RedisModuleKey *modelKey;
+                const int status = RAI_GetModelFromKeyspace(ctx, argv[argpos + 1], &modelKey, &mto,
+                                                            REDISMODULE_READ);
+                if (status == REDISMODULE_ERR) {
+                    RAI_FreeRunInfo(ctx, rinfo);
+                    return REDISMODULE_ERR;
+                }
+                currentOp->devicestr = mto->devicestr;
+                currentOp->runkey = argv[argpos + 1];
+                currentOp->mctx = RAI_ModelRunCtxCreate(mto);
+            }
+            if (!strcasecmp(arg_string, "AI.SCRIPTRUN")) {
+                if (argc - 3 < argpos) {
+                    return RedisModule_WrongArity(ctx);
+                }
+                RAI_DagOp *currentOp = rinfo->dagOps[rinfo->dagOpCount];
+                currentOp->commandType = REDISAI_DAG_CMD_SCRIPTRUN;
+                RAI_Script *sto;
+                RedisModuleKey *scriptKey;
+                const int status = RAI_GetScriptFromKeyspace(ctx, argv[argpos + 1], &scriptKey,
+                                                             &sto, REDISMODULE_READ);
+                if (status == REDISMODULE_ERR) {
+                    RAI_FreeRunInfo(ctx, rinfo);
+                    return REDISMODULE_ERR;
+                }
+                currentOp->devicestr = sto->devicestr;
+                const char *functionName = RedisModule_StringPtrLen(argv[argpos + 2], NULL);
+                currentOp->runkey = argv[argpos + 1];
+                currentOp->sctx = RAI_ScriptRunCtxCreate(sto, functionName);
+            }
+            RedisModule_RetainString(NULL, argv[argpos]);
+            RAI_DagOp *currentOp = rinfo->dagOps[rinfo->dagOpCount];
+            currentOp->argv = array_append(currentOp->argv, argv[argpos]);
+            currentOp->argc++;
         }
-        break;
-      case REDISAI_DAG_CMD_SCRIPTRUN:
-        parse_result = RedisAI_Parse_ScriptRun_RedisCommand(
-                NULL, currentOp->argv, currentOp->argc,
-                &(currentOp->inkeys), &(currentOp->outkeys),
+    }
+
+    rinfo->dagOpCount = array_len(rinfo->dagOps);
+
+    for (long long i = 0; i < array_len(rinfo->dagOps); i++) {
+        RAI_DagOp *currentOp = rinfo->dagOps[i];
+        if (currentOp == NULL)
+            continue;
+        int parse_result;
+        switch (currentOp->commandType) {
+        case REDISAI_DAG_CMD_TENSORSET:
+            currentOp->outkeys = array_append(currentOp->outkeys, currentOp->argv[1]);
+            break;
+        case REDISAI_DAG_CMD_TENSORGET:
+            currentOp->inkeys = array_append(currentOp->inkeys, currentOp->argv[1]);
+            break;
+        case REDISAI_DAG_CMD_MODELRUN:
+            parse_result = RedisAI_Parse_ModelRun_RedisCommand(
+                NULL, currentOp->argv, currentOp->argc, &(currentOp->mctx), &(currentOp->inkeys),
+                &(currentOp->outkeys), &(currentOp->mctx->model), currentOp->err);
+            if (parse_result < 0) {
+                return RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
+            }
+            break;
+        case REDISAI_DAG_CMD_SCRIPTRUN:
+            parse_result = RedisAI_Parse_ScriptRun_RedisCommand(
+                NULL, currentOp->argv, currentOp->argc, &(currentOp->inkeys), &(currentOp->outkeys),
                 &(currentOp->sctx->variadic), currentOp->err);
-        if (parse_result < 0) {
-          return RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
+            if (parse_result < 0) {
+                return RedisModule_ReplyWithError(ctx, currentOp->err->detail_oneline);
+            }
+            break;
         }
-        break;
-    }
-  }
-
-  if (rinfo->single_op_dag) {
-    RAI_DagOp* op = rinfo->dagOps[0];
-    RAI_Tensor *t;
-    RedisModuleKey *key;
-    for (size_t i=0; i<array_len(op->inkeys); i++) {
-      const char* inkey = RedisModule_StringPtrLen(op->inkeys[i], NULL);
-      const int status = RAI_GetTensorFromKeyspace(ctx, op->inkeys[i], &key, &t, REDISMODULE_READ);
-      if (status == REDISMODULE_ERR) {
-        RedisModule_Log(
-            ctx, "warning",
-            "on DAGRUN's LOAD could not load tensor %s from keyspace",
-            RedisModule_StringPtrLen(op->inkeys[i], NULL));
-        return -1;
-      }
-      RedisModule_CloseKey(key);
-      char *dictKey = (char*) RedisModule_Alloc((strlen(inkey) + 5)*sizeof(char));
-      sprintf(dictKey, "%s%04d", inkey, 1);
-      AI_dictAdd(rinfo->dagTensorsContext, (void*)dictKey, (void *)RAI_TensorGetShallowCopy(t));
-      AI_dictAdd(rinfo->dagTensorsLoadedContext, (void*)dictKey, (void *)1);
-      RedisModule_Free(dictKey);
-    } 
-
-    for (size_t i=0; i<array_len(op->outkeys); i++) {
-      const char* outkey = RedisModule_StringPtrLen(op->outkeys[i], NULL);
-      AI_dictAdd(rinfo->dagTensorsPersistedContext, (void*)outkey, (void *)1);
-    }
-  }
-
-  // At this point, we have built a sequence of DAG operations, each with its own
-  // input and output keys. The names of the keys will be used to look whether the
-  // inputs to a DAG operation have all been realized by previous operations (or if
-  // they are available as part of LOADed keys from keyspace).
-  // This strategy is fine if keys are not aliased, that is, if a command's output
-  // overwrites the key of a previous command. This would trick DAG operations into
-  // thinking that their input is ready when it's not.
-  // To overcome this, we make key names unique, so that names are not aliased. We
-  // mangle the names by appending a numerical suffix ":0001". After computing, we
-  // demangle the keys in order to persist them.
-
-  AI_dict* mangled_tensors = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
-  if (!mangled_tensors) {
-    return REDISMODULE_ERR;
-  }
-
-  {
-    AI_dictIterator *iter = AI_dictGetSafeIterator(rinfo->dagTensorsLoadedContext);
-    AI_dictEntry *entry = AI_dictNext(iter);
-    while (entry) {
-      char *key = (char *)AI_dictGetKey(entry);
-      char *demangled_key = RedisModule_Strdup(key);
-      demangled_key[strlen(key) - 4] = 0;
-      int *instance = RedisModule_Alloc(sizeof(int));
-      *instance = 1;
-      AI_dictAdd(mangled_tensors, (void *)demangled_key, (void *)instance);
-      RedisModule_Free(demangled_key);
-      entry = AI_dictNext(iter);
-    }
-    AI_dictReleaseIterator(iter);
-  }
-
-  for (long long i=0; i<array_len(rinfo->dagOps); i++) {
-    RAI_DagOp *currentOp = rinfo->dagOps[i];
-
-    RedisModuleString **mangled_inkeys = array_new(RedisModuleString*, array_len(currentOp->inkeys));
-    for (long long j=0; j<array_len(currentOp->inkeys); j++) {
-      const char* key = RedisModule_StringPtrLen(currentOp->inkeys[j], NULL);
-      AI_dictEntry *entry = AI_dictFind(mangled_tensors, key);
-      if (!entry) {
-        AI_dictRelease(mangled_tensors);
-        return RedisModule_ReplyWithError(ctx,
-                                          "ERR INPUT key cannot be found in DAG");
-      }
-      int *instance = AI_dictGetVal(entry);
-      RedisModuleString *mangled_key = RedisModule_CreateStringPrintf(ctx, "%s%04d", key, *instance);
-      mangled_inkeys = array_append(mangled_inkeys, mangled_key);
     }
 
-    RedisModuleString **mangled_outkeys = array_new(RedisModuleString*, array_len(currentOp->outkeys));
-    for (long long j=0; j<array_len(currentOp->outkeys); j++) {
-      const char* key = RedisModule_StringPtrLen(currentOp->outkeys[j], NULL);
-      AI_dictEntry *entry = AI_dictFind(mangled_tensors, key);
-      int *instance = NULL;
-      if (entry) {
-        instance = AI_dictGetVal(entry);
-        *instance += 1;
-      }
-      else {
-        instance = RedisModule_Alloc(sizeof(int));
-        *instance = 1;
-        AI_dictAdd(mangled_tensors, (void *)key, (void *)instance);
-      }
-      RedisModuleString *mangled_key = RedisModule_CreateStringPrintf(ctx, "%s%04d", key, *instance);
-      mangled_outkeys = array_append(mangled_outkeys, mangled_key);
-    }
-  
-    array_free(currentOp->inkeys);
-    array_free(currentOp->outkeys);
+    if (rinfo->single_op_dag) {
+        RAI_DagOp *op = rinfo->dagOps[0];
+        RAI_Tensor *t;
+        RedisModuleKey *key;
+        for (size_t i = 0; i < array_len(op->inkeys); i++) {
+            const char *inkey = RedisModule_StringPtrLen(op->inkeys[i], NULL);
+            const int status =
+                RAI_GetTensorFromKeyspace(ctx, op->inkeys[i], &key, &t, REDISMODULE_READ);
+            if (status == REDISMODULE_ERR) {
+                RedisModule_Log(ctx, "warning",
+                                "on DAGRUN's LOAD could not load tensor %s from keyspace",
+                                RedisModule_StringPtrLen(op->inkeys[i], NULL));
+                return -1;
+            }
+            RedisModule_CloseKey(key);
+            char *dictKey = (char *)RedisModule_Alloc((strlen(inkey) + 5) * sizeof(char));
+            sprintf(dictKey, "%s%04d", inkey, 1);
+            AI_dictAdd(rinfo->dagTensorsContext, (void *)dictKey,
+                       (void *)RAI_TensorGetShallowCopy(t));
+            AI_dictAdd(rinfo->dagTensorsLoadedContext, (void *)dictKey, (void *)1);
+            RedisModule_Free(dictKey);
+        }
 
-    currentOp->inkeys = mangled_inkeys;
-    currentOp->outkeys = mangled_outkeys;
-  }
-
-  AI_dict* mangled_persisted = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
-  {
-    AI_dictIterator *iter = AI_dictGetSafeIterator(rinfo->dagTensorsPersistedContext);
-    AI_dictEntry *entry = AI_dictNext(iter);
-    while (entry) {
-      char *key = (char *)AI_dictGetKey(entry);
-      AI_dictEntry *mangled_entry = AI_dictFind(mangled_tensors, key);
-      if (!mangled_entry) {
-        AI_dictRelease(mangled_tensors);
-        AI_dictRelease(mangled_persisted);
-        return RedisModule_ReplyWithError(ctx,
-                                          "ERR PERSIST key cannot be found in DAG");
-      } 
-      int *instance = AI_dictGetVal(mangled_entry);
-      RedisModuleString *mangled_key = RedisModule_CreateStringPrintf(ctx, "%s%04d", key, *instance);
-      const char* mangled_key_str = RedisModule_StringPtrLen(mangled_key, NULL);
-      AI_dictAdd(mangled_persisted, (void *)mangled_key_str, (void *)1);
-      entry = AI_dictNext(iter);
-    }
-    AI_dictReleaseIterator(iter);
-  }
-
-  AI_dictRelease(rinfo->dagTensorsPersistedContext);
-  rinfo->dagTensorsPersistedContext = mangled_persisted;
-
-  {
-    AI_dictIterator *iter = AI_dictGetSafeIterator(mangled_tensors);
-    AI_dictEntry *entry = AI_dictNext(iter);
-    while (entry) {
-      int *val = (int *)AI_dictGetVal(entry);
-      RedisModule_Free(val);
-      entry = AI_dictNext(iter);
-    }
-    AI_dictReleaseIterator(iter);
-  }
-  AI_dictRelease(mangled_tensors);
-  mangled_tensors = NULL;
-
-  for (long long i=0; i<array_len(rinfo->dagOps); i++) {
-    if (rinfo->dagOps[i]->devicestr == NULL) {
-      rinfo->dagOps[i]->devicestr = "CPU";
-    }
-  }
-
-  rinfo->client = RedisModule_BlockClient(ctx, RedisAI_DagRun_Reply, NULL, RedisAI_FreeData, 0);
-  RedisModule_SetDisconnectCallback(rinfo->client, RedisAI_Disconnected);
-
-  const char **devices = array_new(const char *, 10);
-
-  for (long long i=0; i<array_len(rinfo->dagOps); i++) {
-    const char* devicestr = rinfo->dagOps[i]->devicestr;
-    bool found = false;
-    for (long long j=0; j<array_len(devices); j++) {
-      if (strcasecmp(devicestr, devices[j]) == 0) {
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
-      devices = array_append(devices, devicestr);
-    }
-  }
-  
-  size_t ndevices = array_len(devices);
-
-  *rinfo->dagRefCount = ndevices;
-
-  RedisAI_RunInfo **rinfo_copies = array_new(RedisAI_RunInfo*, ndevices);
-  rinfo_copies = array_append(rinfo_copies, rinfo);
-
-  for (long long i=1; i<ndevices; i++) {
-    RedisAI_RunInfo *rinfo_copy;
-    RAI_ShallowCopyDagRunInfo(&rinfo_copy, rinfo);
-    rinfo_copies = array_append(rinfo_copies, rinfo_copy);
-  }
- 
-  for (long long i=0; i<ndevices; i++) {
-    RedisAI_RunInfo *rinfo = rinfo_copies[i];
-    for (long long j=0; j<rinfo->dagOpCount; j++) {
-      if (strcasecmp(rinfo->dagOps[j]->devicestr, devices[i]) == 0) {
-        rinfo->dagDeviceOps = array_append(rinfo->dagDeviceOps, rinfo->dagOps[j]);
-      }
+        for (size_t i = 0; i < array_len(op->outkeys); i++) {
+            const char *outkey = RedisModule_StringPtrLen(op->outkeys[i], NULL);
+            AI_dictAdd(rinfo->dagTensorsPersistedContext, (void *)outkey, (void *)1);
+        }
     }
 
-    rinfo->dagDeviceOpCount = array_len(rinfo->dagDeviceOps);
-  }
+    // At this point, we have built a sequence of DAG operations, each with its
+    // own input and output keys. The names of the keys will be used to look
+    // whether the inputs to a DAG operation have all been realized by previous
+    // operations (or if they are available as part of LOADed keys from keyspace).
+    // This strategy is fine if keys are not aliased, that is, if a command's
+    // output overwrites the key of a previous command. This would trick DAG
+    // operations into thinking that their input is ready when it's not. To
+    // overcome this, we make key names unique, so that names are not aliased. We
+    // mangle the names by appending a numerical suffix ":0001". After computing,
+    // we demangle the keys in order to persist them.
 
-  for (long long i=0; i<ndevices; i++) {
-    const char* devicestr = devices[i];
-    RunQueueInfo *run_queue_info = NULL;
-    if (ensureRunQueue(devicestr, &run_queue_info) == REDISMODULE_ERR) {
-      RAI_FreeRunInfo(ctx, rinfo);
-      return RedisModule_ReplyWithError(ctx,
-                                        "ERR Queue not initialized for device");
+    AI_dict *mangled_tensors = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
+    if (!mangled_tensors) {
+        return REDISMODULE_ERR;
     }
 
-    RedisAI_RunInfo *rinfo = rinfo_copies[i];
+    {
+        AI_dictIterator *iter = AI_dictGetSafeIterator(rinfo->dagTensorsLoadedContext);
+        AI_dictEntry *entry = AI_dictNext(iter);
+        while (entry) {
+            char *key = (char *)AI_dictGetKey(entry);
+            char *demangled_key = RedisModule_Strdup(key);
+            demangled_key[strlen(key) - 4] = 0;
+            int *instance = RedisModule_Alloc(sizeof(int));
+            *instance = 1;
+            AI_dictAdd(mangled_tensors, (void *)demangled_key, (void *)instance);
+            RedisModule_Free(demangled_key);
+            entry = AI_dictNext(iter);
+        }
+        AI_dictReleaseIterator(iter);
+    }
 
-    gettimeofday(&rinfo->queuingTime, NULL); 
+    for (long long i = 0; i < array_len(rinfo->dagOps); i++) {
+        RAI_DagOp *currentOp = rinfo->dagOps[i];
 
-    pthread_mutex_lock(&run_queue_info->run_queue_mutex);
-    queuePush(run_queue_info->run_queue, rinfo);
-    pthread_cond_signal(&run_queue_info->queue_condition_var);
-    pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
-  }
+        RedisModuleString **mangled_inkeys =
+            array_new(RedisModuleString *, array_len(currentOp->inkeys));
+        for (long long j = 0; j < array_len(currentOp->inkeys); j++) {
+            const char *key = RedisModule_StringPtrLen(currentOp->inkeys[j], NULL);
+            AI_dictEntry *entry = AI_dictFind(mangled_tensors, key);
+            if (!entry) {
+                AI_dictRelease(mangled_tensors);
+                return RedisModule_ReplyWithError(ctx, "ERR INPUT key cannot be found in DAG");
+            }
+            int *instance = AI_dictGetVal(entry);
+            RedisModuleString *mangled_key =
+                RedisModule_CreateStringPrintf(ctx, "%s%04d", key, *instance);
+            mangled_inkeys = array_append(mangled_inkeys, mangled_key);
+        }
 
-  array_free(devices);
-  array_free(rinfo_copies);
+        RedisModuleString **mangled_outkeys =
+            array_new(RedisModuleString *, array_len(currentOp->outkeys));
+        for (long long j = 0; j < array_len(currentOp->outkeys); j++) {
+            const char *key = RedisModule_StringPtrLen(currentOp->outkeys[j], NULL);
+            AI_dictEntry *entry = AI_dictFind(mangled_tensors, key);
+            int *instance = NULL;
+            if (entry) {
+                instance = AI_dictGetVal(entry);
+                *instance += 1;
+            } else {
+                instance = RedisModule_Alloc(sizeof(int));
+                *instance = 1;
+                AI_dictAdd(mangled_tensors, (void *)key, (void *)instance);
+            }
+            RedisModuleString *mangled_key =
+                RedisModule_CreateStringPrintf(ctx, "%s%04d", key, *instance);
+            mangled_outkeys = array_append(mangled_outkeys, mangled_key);
+        }
 
-  return REDISMODULE_OK;
+        array_free(currentOp->inkeys);
+        array_free(currentOp->outkeys);
+
+        currentOp->inkeys = mangled_inkeys;
+        currentOp->outkeys = mangled_outkeys;
+    }
+
+    AI_dict *mangled_persisted = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
+    {
+        AI_dictIterator *iter = AI_dictGetSafeIterator(rinfo->dagTensorsPersistedContext);
+        AI_dictEntry *entry = AI_dictNext(iter);
+        while (entry) {
+            char *key = (char *)AI_dictGetKey(entry);
+            AI_dictEntry *mangled_entry = AI_dictFind(mangled_tensors, key);
+            if (!mangled_entry) {
+                AI_dictRelease(mangled_tensors);
+                AI_dictRelease(mangled_persisted);
+                return RedisModule_ReplyWithError(ctx, "ERR PERSIST key cannot be found in DAG");
+            }
+            int *instance = AI_dictGetVal(mangled_entry);
+            RedisModuleString *mangled_key =
+                RedisModule_CreateStringPrintf(ctx, "%s%04d", key, *instance);
+            const char *mangled_key_str = RedisModule_StringPtrLen(mangled_key, NULL);
+            AI_dictAdd(mangled_persisted, (void *)mangled_key_str, (void *)1);
+            entry = AI_dictNext(iter);
+        }
+        AI_dictReleaseIterator(iter);
+    }
+
+    AI_dictRelease(rinfo->dagTensorsPersistedContext);
+    rinfo->dagTensorsPersistedContext = mangled_persisted;
+
+    {
+        AI_dictIterator *iter = AI_dictGetSafeIterator(mangled_tensors);
+        AI_dictEntry *entry = AI_dictNext(iter);
+        while (entry) {
+            int *val = (int *)AI_dictGetVal(entry);
+            RedisModule_Free(val);
+            entry = AI_dictNext(iter);
+        }
+        AI_dictReleaseIterator(iter);
+    }
+    AI_dictRelease(mangled_tensors);
+    mangled_tensors = NULL;
+
+    for (long long i = 0; i < array_len(rinfo->dagOps); i++) {
+        if (rinfo->dagOps[i]->devicestr == NULL) {
+            rinfo->dagOps[i]->devicestr = "CPU";
+        }
+    }
+
+    rinfo->client = RedisModule_BlockClient(ctx, RedisAI_DagRun_Reply, NULL, RedisAI_FreeData, 0);
+    RedisModule_SetDisconnectCallback(rinfo->client, RedisAI_Disconnected);
+
+    const char **devices = array_new(const char *, 10);
+
+    for (long long i = 0; i < array_len(rinfo->dagOps); i++) {
+        const char *devicestr = rinfo->dagOps[i]->devicestr;
+        bool found = false;
+        for (long long j = 0; j < array_len(devices); j++) {
+            if (strcasecmp(devicestr, devices[j]) == 0) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            devices = array_append(devices, devicestr);
+        }
+    }
+
+    size_t ndevices = array_len(devices);
+
+    *rinfo->dagRefCount = ndevices;
+
+    RedisAI_RunInfo **rinfo_copies = array_new(RedisAI_RunInfo *, ndevices);
+    rinfo_copies = array_append(rinfo_copies, rinfo);
+
+    for (long long i = 1; i < ndevices; i++) {
+        RedisAI_RunInfo *rinfo_copy;
+        RAI_ShallowCopyDagRunInfo(&rinfo_copy, rinfo);
+        rinfo_copies = array_append(rinfo_copies, rinfo_copy);
+    }
+
+    for (long long i = 0; i < ndevices; i++) {
+        RedisAI_RunInfo *rinfo = rinfo_copies[i];
+        for (long long j = 0; j < rinfo->dagOpCount; j++) {
+            if (strcasecmp(rinfo->dagOps[j]->devicestr, devices[i]) == 0) {
+                rinfo->dagDeviceOps = array_append(rinfo->dagDeviceOps, rinfo->dagOps[j]);
+            }
+        }
+
+        rinfo->dagDeviceOpCount = array_len(rinfo->dagDeviceOps);
+    }
+
+    for (long long i = 0; i < ndevices; i++) {
+        const char *devicestr = devices[i];
+        RunQueueInfo *run_queue_info = NULL;
+        if (ensureRunQueue(devicestr, &run_queue_info) == REDISMODULE_ERR) {
+            RAI_FreeRunInfo(ctx, rinfo);
+            return RedisModule_ReplyWithError(ctx, "ERR Queue not initialized for device");
+        }
+
+        RedisAI_RunInfo *rinfo = rinfo_copies[i];
+
+        gettimeofday(&rinfo->queuingTime, NULL);
+
+        pthread_mutex_lock(&run_queue_info->run_queue_mutex);
+        queuePush(run_queue_info->run_queue, rinfo);
+        pthread_cond_signal(&run_queue_info->queue_condition_var);
+        pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
+    }
+
+    array_free(devices);
+    array_free(rinfo_copies);
+
+    return REDISMODULE_OK;
 }

--- a/src/dag.h
+++ b/src/dag.h
@@ -1,8 +1,8 @@
 /**
  * dag.h
  *
- * Contains headers for the helper methods for both parsing, running the command in the
- * background, and replying DAG structured commands.
+ * Contains headers for the helper methods for both parsing, running the command
+ * in the background, and replying DAG structured commands.
  */
 
 #ifndef SRC_DAG_H_
@@ -39,8 +39,8 @@ int RedisAI_DagComplete(RedisAI_RunInfo *rinfo);
  * @param rinfo context in which RedisAI blocking commands operate.
  * @return pointer to current DAG op for device
  */
-RAI_DagOp* RedisAI_DagCurrentOp(RedisAI_RunInfo *rinfo);
- 
+RAI_DagOp *RedisAI_DagCurrentOp(RedisAI_RunInfo *rinfo);
+
 /**
  * Get information about current DAG op for the given device.
  * @param rinfo context in which RedisAI blocking commands operate.
@@ -50,9 +50,7 @@ RAI_DagOp* RedisAI_DagCurrentOp(RedisAI_RunInfo *rinfo);
  *            a MODELRUN and is BATCHSIZE greater than zero
  * @return
  */
-void RedisAI_DagCurrentOpInfo(RedisAI_RunInfo *rinfo,
-                              int *currentOpReady,
-                              int *currentOpBatchable);
+void RedisAI_DagCurrentOpInfo(RedisAI_RunInfo *rinfo, int *currentOpReady, int *currentOpBatchable);
 
 /**
  * Get batching information about a DAG op.
@@ -65,10 +63,9 @@ void RedisAI_DagCurrentOpInfo(RedisAI_RunInfo *rinfo,
  *            is, the size of the input tensors along the zero-th dimension
  * @return
  */
-void RedisAI_DagOpBatchInfo(RedisAI_RunInfo *rinfo, RAI_DagOp *op,
-                            size_t *batchsize, size_t *minbatchsize,
-                            size_t *minbatchtimeout, size_t *inbatchsize);
- 
+void RedisAI_DagOpBatchInfo(RedisAI_RunInfo *rinfo, RAI_DagOp *op, size_t *batchsize,
+                            size_t *minbatchsize, size_t *minbatchtimeout, size_t *inbatchsize);
+
 /**
  * Check that a DAG operation can be batched with a given batch operation.
  * @param rinfo1 given context in which RedisAI blocking commands operate.
@@ -79,17 +76,16 @@ void RedisAI_DagOpBatchInfo(RedisAI_RunInfo *rinfo, RAI_DagOp *op,
  * @param inbatchsize actual size of the batch in op2
  * @return
  */
-void RedisAI_DagOpBatchingMatch(RedisAI_RunInfo *rinfo1, RAI_DagOp *op1,
-                                RedisAI_RunInfo *rinfo2, RAI_DagOp *op2,
-                                int *batched, size_t *inbatchsize);
- 
+void RedisAI_DagOpBatchingMatch(RedisAI_RunInfo *rinfo1, RAI_DagOp *op1, RedisAI_RunInfo *rinfo2,
+                                RAI_DagOp *op2, int *batched, size_t *inbatchsize);
+
 /**
  * Run the first unrealized DAG operation in rinfo for the given device.
  * @param rinfo context in which RedisAI blocking commands operate.
  * @param devicestr device identifier associated with the current queue
  * @return
  */
-void RedisAI_DagRunSessionStep(RedisAI_RunInfo *rinfo, const char* devicestr);
+void RedisAI_DagRunSessionStep(RedisAI_RunInfo *rinfo, const char *devicestr);
 
 /**
  * Batch the first unrealized DAG operations for the given device for the
@@ -98,7 +94,7 @@ void RedisAI_DagRunSessionStep(RedisAI_RunInfo *rinfo, const char* devicestr);
  * @param devicestr device identifier associated with the current queue
  * @return
  */
-void RedisAI_BatchedDagRunSessionStep(RedisAI_RunInfo **rinfo, const char* devicestr);
+void RedisAI_BatchedDagRunSessionStep(RedisAI_RunInfo **rinfo, const char *devicestr);
 
 /**
  * Reply Callback called after a successful RedisModule_UnblockClient() after
@@ -109,8 +105,7 @@ void RedisAI_BatchedDagRunSessionStep(RedisAI_RunInfo **rinfo, const char* devic
  * @param argc Redis command number of arguments
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if the DAGRUN failed
  */
-int RedisAI_DagRun_Reply(RedisModuleCtx *ctx, RedisModuleString **argv,
-                         int argc);
+int RedisAI_DagRun_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 /**
  * DAGRUN Building Block to parse [LOAD <nkeys> key1 key2... ]
@@ -126,9 +121,8 @@ int RedisAI_DagRun_Reply(RedisModuleCtx *ctx, RedisModuleString **argv,
  * argument after the chaining operator is not considered
  * @return processed number of arguments on success, or -1 if the parsing failed
  */
-int RAI_parseDAGLoadArgs(RedisModuleCtx *ctx, RedisModuleString **argv,
-                         int argc, AI_dict **loadedContextDict,
-                         AI_dict **localContextDict,
+int RAI_parseDAGLoadArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                         AI_dict **loadedContextDict, AI_dict **localContextDict,
                          const char *chaining_operator);
 
 /**
@@ -143,9 +137,8 @@ int RAI_parseDAGLoadArgs(RedisModuleCtx *ctx, RedisModuleString **argv,
  * argument after the chaining operator is not considered
  * @return processed number of arguments on success, or -1 if the parsing failed
  */
-int RAI_parseDAGPersistArgs(RedisModuleCtx *ctx, RedisModuleString **argv,
-                            int argc, AI_dict **localContextDict,
-                            const char *chaining_operator);
+int RAI_parseDAGPersistArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                            AI_dict **localContextDict, const char *chaining_operator);
 
 /**
  * When a module command is called in order to obtain the position of
@@ -159,8 +152,8 @@ int RAI_parseDAGPersistArgs(RedisModuleCtx *ctx, RedisModuleString **argv,
  * @param argc Redis command number of arguments
  * @return
  */
-int RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
-                            RedisModuleString **argv, int argc);
+int RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx, RedisModuleString **argv,
+                                                    int argc);
 
 /**
  * DAGRUN and DAGRUN_RO parser, which reads the the sequence of
@@ -170,10 +163,11 @@ int RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
  * @param ctx Context in which Redis modules operate
  * @param argv Redis command arguments, as an array of strings
  * @param argc Redis command number of arguments
- * @param dagMode access mode, for now REDISAI_DAG_READONLY_MODE or REDISAI_DAG_WRITE_MODE
+ * @param dagMode access mode, for now REDISAI_DAG_READONLY_MODE or
+ * REDISAI_DAG_WRITE_MODE
  * @return
  */
-int RedisAI_DagRunSyntaxParser(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                 int argc, int dagMode);
+int RedisAI_DagRunSyntaxParser(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                               int dagMode);
 
 #endif /* SRC_DAG_H_ */

--- a/src/err.c
+++ b/src/err.c
@@ -13,44 +13,38 @@
 #include "string.h"
 
 char *RAI_Chomp(const char *src) {
-  char *str = RedisModule_Strdup(src);
-  size_t len = strlen(src);
-  for (size_t i = 0; i < len; i++) {
-    if (str[i] == '\n' || str[i] == '\r') {
-      str[i] = ' ';
+    char *str = RedisModule_Strdup(src);
+    size_t len = strlen(src);
+    for (size_t i = 0; i < len; i++) {
+        if (str[i] == '\n' || str[i] == '\r') {
+            str[i] = ' ';
+        }
     }
-  }
-  return str;
+    return str;
 }
 
-const char* RAI_GetError(RAI_Error *err) {
-  return err->detail;
-}
+const char *RAI_GetError(RAI_Error *err) { return err->detail; }
 
-const char* RAI_GetErrorOneLine(RAI_Error *err) {
-  return err->detail_oneline;
-}
+const char *RAI_GetErrorOneLine(RAI_Error *err) { return err->detail_oneline; }
 
-RAI_ErrorCode RAI_GetErrorCode(RAI_Error *err) {
-  return err->code;
-}
+RAI_ErrorCode RAI_GetErrorCode(RAI_Error *err) { return err->code; }
 
 void RAI_SetError(RAI_Error *err, RAI_ErrorCode code, const char *detail) {
-  if(!err){
-    return;
-  }
-  if (err->code != RAI_OK) {
-    return;
-  }
-  assert(!err->detail);
-  err->code = code;
+    if (!err) {
+        return;
+    }
+    if (err->code != RAI_OK) {
+        return;
+    }
+    assert(!err->detail);
+    err->code = code;
 
-  if (detail) {
-    err->detail = RedisModule_Strdup(detail);
-  } else {
-    err->detail = RedisModule_Strdup("ERR Generic error");
-  }
-  err->detail_oneline = RAI_Chomp(err->detail);
+    if (detail) {
+        err->detail = RedisModule_Strdup(detail);
+    } else {
+        err->detail = RedisModule_Strdup("ERR Generic error");
+    }
+    err->detail_oneline = RAI_Chomp(err->detail);
 }
 
 /**
@@ -60,35 +54,35 @@ void RAI_SetError(RAI_Error *err, RAI_ErrorCode code, const char *detail) {
  * failed.
  */
 int RAI_InitError(RAI_Error **result) {
-  RAI_Error *err;
-  err = (RAI_Error *)RedisModule_Calloc(1, sizeof(RAI_Error));
-  if (!err) {
-    return 1;
-  }
-  err->code = 0;
-  err->detail = NULL;
-  err->detail_oneline = NULL;
-  *result = err;
-  return 0;
+    RAI_Error *err;
+    err = (RAI_Error *)RedisModule_Calloc(1, sizeof(RAI_Error));
+    if (!err) {
+        return 1;
+    }
+    err->code = 0;
+    err->detail = NULL;
+    err->detail_oneline = NULL;
+    *result = err;
+    return 0;
 }
 
 void RAI_ClearError(RAI_Error *err) {
-  if (err) {
-    if (err->detail) {
-      RedisModule_Free(err->detail);
-      err->detail = NULL;
+    if (err) {
+        if (err->detail) {
+            RedisModule_Free(err->detail);
+            err->detail = NULL;
+        }
+        if (err->detail_oneline) {
+            RedisModule_Free(err->detail_oneline);
+            err->detail_oneline = NULL;
+        }
+        err->code = RAI_OK;
     }
-    if (err->detail_oneline) {
-      RedisModule_Free(err->detail_oneline);
-      err->detail_oneline = NULL;
-    }
-    err->code = RAI_OK;
-  }
 }
 
 void RAI_FreeError(RAI_Error *err) {
-  if (err) {
-    RAI_ClearError(err);
-    RedisModule_Free(err);
-  }
+    if (err) {
+        RAI_ClearError(err);
+        RedisModule_Free(err);
+    }
 }

--- a/src/err.h
+++ b/src/err.h
@@ -9,29 +9,29 @@
 #define SRC_ERR_H_
 
 typedef enum {
-  RAI_OK = 0,
-  RAI_EMODELIMPORT,
-  RAI_EMODELCONFIGURE,
-  RAI_EMODELCREATE,
-  RAI_EMODELRUN,
-  RAI_EMODELSERIALIZE,
-  RAI_EMODELFREE,
-  RAI_ESCRIPTIMPORT,
-  RAI_ESCRIPTCONFIGURE,
-  RAI_ESCRIPTCREATE,
-  RAI_ESCRIPTRUN,
-  RAI_EUNSUPPORTEDBACKEND,
-  RAI_EBACKENDNOTLOADED,
-  RAI_ESCRIPTFREE,
-  RAI_ETENSORSET,
-  RAI_ETENSORGET,
-  RAI_EDAGRUN,
+    RAI_OK = 0,
+    RAI_EMODELIMPORT,
+    RAI_EMODELCONFIGURE,
+    RAI_EMODELCREATE,
+    RAI_EMODELRUN,
+    RAI_EMODELSERIALIZE,
+    RAI_EMODELFREE,
+    RAI_ESCRIPTIMPORT,
+    RAI_ESCRIPTCONFIGURE,
+    RAI_ESCRIPTCREATE,
+    RAI_ESCRIPTRUN,
+    RAI_EUNSUPPORTEDBACKEND,
+    RAI_EBACKENDNOTLOADED,
+    RAI_ESCRIPTFREE,
+    RAI_ETENSORSET,
+    RAI_ETENSORGET,
+    RAI_EDAGRUN,
 } RAI_ErrorCode;
 
 typedef struct RAI_Error {
-  RAI_ErrorCode code;
-  char *detail;
-  char *detail_oneline;
+    RAI_ErrorCode code;
+    char *detail;
+    char *detail_oneline;
 } RAI_Error;
 
 /**
@@ -59,7 +59,7 @@ void RAI_SetError(RAI_Error *err, RAI_ErrorCode code, const char *detail);
  * @return error description
  * @param err
  */
-const char* RAI_GetError(RAI_Error *err);
+const char *RAI_GetError(RAI_Error *err);
 
 /**
  * Return the error description as one line
@@ -68,7 +68,7 @@ const char* RAI_GetError(RAI_Error *err);
  * @return error description as one line
  * @param err
  */
-const char* RAI_GetErrorOneLine(RAI_Error *err);
+const char *RAI_GetErrorOneLine(RAI_Error *err);
 
 /**
  * Return the error code

--- a/src/libtflite_c/tflite_c.cpp
+++ b/src/libtflite_c/tflite_c.cpp
@@ -8,55 +8,55 @@
 
 namespace {
 
-static DLDataType getDLDataType(const TfLiteTensor* tensor) {
-  DLDataType dtype;
-  dtype.lanes = 1;
-  switch (tensor->type) {
+static DLDataType getDLDataType(const TfLiteTensor *tensor) {
+    DLDataType dtype;
+    dtype.lanes = 1;
+    switch (tensor->type) {
     case kTfLiteUInt8:
-      dtype.bits = 8;
-      dtype.code = DLDataTypeCode::kDLUInt;
-      break;
+        dtype.bits = 8;
+        dtype.code = DLDataTypeCode::kDLUInt;
+        break;
     case kTfLiteInt64:
-      dtype.bits = 64;
-      dtype.code = DLDataTypeCode::kDLInt;
-      break;
+        dtype.bits = 64;
+        dtype.code = DLDataTypeCode::kDLInt;
+        break;
     case kTfLiteInt32:
-      dtype.bits = 32;
-      dtype.code = DLDataTypeCode::kDLInt;
-      break;
+        dtype.bits = 32;
+        dtype.code = DLDataTypeCode::kDLInt;
+        break;
     case kTfLiteInt16:
-      dtype.bits = 16;
-      dtype.code = DLDataTypeCode::kDLInt;
-      break;
+        dtype.bits = 16;
+        dtype.code = DLDataTypeCode::kDLInt;
+        break;
     case kTfLiteInt8:
-      dtype.bits = 8;
-      dtype.code = DLDataTypeCode::kDLInt;
-      break;
+        dtype.bits = 8;
+        dtype.code = DLDataTypeCode::kDLInt;
+        break;
     case kTfLiteFloat32:
-      dtype.bits = 32;
-      dtype.code = DLDataTypeCode::kDLFloat;
-      break;
+        dtype.bits = 32;
+        dtype.code = DLDataTypeCode::kDLFloat;
+        break;
     case kTfLiteFloat16:
-      // TODO: nope so far
-      dtype.bits = 16;
-      dtype.code = DLDataTypeCode::kDLFloat;
-      break;
+        // TODO: nope so far
+        dtype.bits = 16;
+        dtype.code = DLDataTypeCode::kDLFloat;
+        break;
     default:
-      break;
-  }
-  return dtype;
+        break;
+    }
+    return dtype;
 }
 
-static DLContext getDLContext(const TfLiteTensor* tensor, const int64_t& device_id) {
-  DLContext ctx;
-  ctx.device_id = device_id;
-  // if (tensor->.is_cuda()) {
-  //   ctx.device_type = DLDeviceType::kDLGPU;
-  // } else {
-  //   ctx.device_type = DLDeviceType::kDLCPU;
-  // }
-  ctx.device_type = DLDeviceType::kDLCPU;
-  return ctx;
+static DLContext getDLContext(const TfLiteTensor *tensor, const int64_t &device_id) {
+    DLContext ctx;
+    ctx.device_id = device_id;
+    // if (tensor->.is_cuda()) {
+    //   ctx.device_type = DLDeviceType::kDLGPU;
+    // } else {
+    //   ctx.device_type = DLDeviceType::kDLCPU;
+    // }
+    ctx.device_type = DLDeviceType::kDLCPU;
+    return ctx;
 }
 
 #if 0
@@ -77,249 +77,242 @@ static at::DeviceType getATenDeviceType(DLDeviceType device_type) {
 }
 #endif
 
-size_t dltensorBytes(DLManagedTensor* t) {
-  int64_t* shape = t->dl_tensor.shape;
-  size_t len = 1;
-  for (size_t i = 0 ; i < t->dl_tensor.ndim; ++i){
-    len *= shape[i];
-  }
+size_t dltensorBytes(DLManagedTensor *t) {
+    int64_t *shape = t->dl_tensor.shape;
+    size_t len = 1;
+    for (size_t i = 0; i < t->dl_tensor.ndim; ++i) {
+        len *= shape[i];
+    }
 
-  size_t bytes = len * t->dl_tensor.dtype.bits / 8;
+    size_t bytes = len * t->dl_tensor.dtype.bits / 8;
 
-  return bytes;
+    return bytes;
 }
 
-void copyToTfLiteTensor(std::shared_ptr<tflite::Interpreter> interpreter,
-                        int tflite_input, 
-                        DLManagedTensor* input) {
-  TfLiteTensor* tensor = interpreter->tensor(tflite_input);
+void copyToTfLiteTensor(std::shared_ptr<tflite::Interpreter> interpreter, int tflite_input,
+                        DLManagedTensor *input) {
+    TfLiteTensor *tensor = interpreter->tensor(tflite_input);
 
-  size_t nbytes = dltensorBytes(input);
+    size_t nbytes = dltensorBytes(input);
 
-  switch (tensor->type) {
+    switch (tensor->type) {
     case kTfLiteUInt8:
-      memcpy(interpreter->typed_tensor<uint8_t>(tflite_input), input->dl_tensor.data, nbytes);
-      break;
+        memcpy(interpreter->typed_tensor<uint8_t>(tflite_input), input->dl_tensor.data, nbytes);
+        break;
     case kTfLiteInt64:
-      memcpy(interpreter->typed_tensor<int64_t>(tflite_input), input->dl_tensor.data, nbytes);
-      break;
+        memcpy(interpreter->typed_tensor<int64_t>(tflite_input), input->dl_tensor.data, nbytes);
+        break;
     case kTfLiteInt32:
-      memcpy(interpreter->typed_tensor<int32_t>(tflite_input), input->dl_tensor.data, nbytes);
-      break;
+        memcpy(interpreter->typed_tensor<int32_t>(tflite_input), input->dl_tensor.data, nbytes);
+        break;
     case kTfLiteInt16:
-      memcpy(interpreter->typed_tensor<int16_t>(tflite_input), input->dl_tensor.data, nbytes);
-      break;
+        memcpy(interpreter->typed_tensor<int16_t>(tflite_input), input->dl_tensor.data, nbytes);
+        break;
     case kTfLiteInt8:
-      memcpy(interpreter->typed_tensor<int8_t>(tflite_input), input->dl_tensor.data, nbytes);
-      break;
+        memcpy(interpreter->typed_tensor<int8_t>(tflite_input), input->dl_tensor.data, nbytes);
+        break;
     case kTfLiteFloat32:
-      memcpy(interpreter->typed_tensor<float>(tflite_input), input->dl_tensor.data, nbytes);
-      break;
+        memcpy(interpreter->typed_tensor<float>(tflite_input), input->dl_tensor.data, nbytes);
+        break;
     case kTfLiteFloat16:
-      throw std::logic_error("Float16 not currently supported as input tensor data type");
-      break;
+        throw std::logic_error("Float16 not currently supported as input tensor data type");
+        break;
     default:
-      throw std::logic_error("Unsupported input data type");
-  }
+        throw std::logic_error("Unsupported input data type");
+    }
 }
 
-void deleter(DLManagedTensor * arg) {
-  delete[] (uint8_t*)arg->dl_tensor.data;
-  delete[] arg->dl_tensor.shape;
-  delete[] arg->dl_tensor.strides;
-  // FIXME
-  // delete arg;
+void deleter(DLManagedTensor *arg) {
+    delete[](uint8_t *) arg->dl_tensor.data;
+    delete[] arg->dl_tensor.shape;
+    delete[] arg->dl_tensor.strides;
+    // FIXME
+    // delete arg;
 }
 
-DLManagedTensor* toManagedDLPack(std::shared_ptr<tflite::Interpreter> interpreter,
-                                 int tflite_output, void* (*alloc)(size_t)) {
-  TfLiteTensor* tensor = interpreter->tensor(tflite_output);
+DLManagedTensor *toManagedDLPack(std::shared_ptr<tflite::Interpreter> interpreter,
+                                 int tflite_output, void *(*alloc)(size_t)) {
+    TfLiteTensor *tensor = interpreter->tensor(tflite_output);
 
-  TfLiteIntArray* output_dims = tensor->dims;
+    TfLiteIntArray *output_dims = tensor->dims;
 
-  DLDataType dtype = getDLDataType(tensor);
+    DLDataType dtype = getDLDataType(tensor);
 
-  int64_t device_id = 0;
-  DLContext ctx = getDLContext(tensor, device_id);
+    int64_t device_id = 0;
+    DLContext ctx = getDLContext(tensor, device_id);
 
-  DLTensor dl_tensor = (DLTensor){
-    .data = new uint8_t[tensor->bytes],
-    .ctx = ctx,
-    .ndim = output_dims->size,
-    .dtype = dtype,
-    .shape = new int64_t[output_dims->size],
-    .strides = new int64_t[output_dims->size],
-    .byte_offset = 0
-  };
+    DLTensor dl_tensor = (DLTensor){.data = new uint8_t[tensor->bytes],
+                                    .ctx = ctx,
+                                    .ndim = output_dims->size,
+                                    .dtype = dtype,
+                                    .shape = new int64_t[output_dims->size],
+                                    .strides = new int64_t[output_dims->size],
+                                    .byte_offset = 0};
 
-  for (size_t i=0; i<output_dims->size; i++) {
-    dl_tensor.shape[i] = output_dims->data[i];
-    dl_tensor.strides[i] = 1;
-  }
+    for (size_t i = 0; i < output_dims->size; i++) {
+        dl_tensor.shape[i] = output_dims->data[i];
+        dl_tensor.strides[i] = 1;
+    }
 
-  for (int64_t i=dl_tensor.ndim-2 ; i>=0 ; --i) {
-    dl_tensor.strides[i] *= dl_tensor.strides[i+1] * dl_tensor.shape[i+1];
-  }
+    for (int64_t i = dl_tensor.ndim - 2; i >= 0; --i) {
+        dl_tensor.strides[i] *= dl_tensor.strides[i + 1] * dl_tensor.shape[i + 1];
+    }
 
-  auto output_size = output_dims->data[output_dims->size - 1];
- 
-  switch (tensor->type) {
+    auto output_size = output_dims->data[output_dims->size - 1];
+
+    switch (tensor->type) {
     case kTfLiteUInt8:
-      memcpy(dl_tensor.data, interpreter->typed_tensor<uint8_t>(tflite_output), tensor->bytes);
-      break;
+        memcpy(dl_tensor.data, interpreter->typed_tensor<uint8_t>(tflite_output), tensor->bytes);
+        break;
     case kTfLiteInt64:
-      memcpy(dl_tensor.data, interpreter->typed_tensor<int64_t>(tflite_output), tensor->bytes);
-      break;
+        memcpy(dl_tensor.data, interpreter->typed_tensor<int64_t>(tflite_output), tensor->bytes);
+        break;
     case kTfLiteInt32:
-      memcpy(dl_tensor.data, interpreter->typed_tensor<int32_t>(tflite_output), tensor->bytes);
-      break;
+        memcpy(dl_tensor.data, interpreter->typed_tensor<int32_t>(tflite_output), tensor->bytes);
+        break;
     case kTfLiteInt16:
-      memcpy(dl_tensor.data, interpreter->typed_tensor<int16_t>(tflite_output), tensor->bytes);
-      break;
+        memcpy(dl_tensor.data, interpreter->typed_tensor<int16_t>(tflite_output), tensor->bytes);
+        break;
     case kTfLiteInt8:
-      memcpy(dl_tensor.data, interpreter->typed_tensor<int8_t>(tflite_output), tensor->bytes);
-      break;
+        memcpy(dl_tensor.data, interpreter->typed_tensor<int8_t>(tflite_output), tensor->bytes);
+        break;
     case kTfLiteFloat32:
-      memcpy(dl_tensor.data, interpreter->typed_tensor<float>(tflite_output), tensor->bytes);
-      break;
+        memcpy(dl_tensor.data, interpreter->typed_tensor<float>(tflite_output), tensor->bytes);
+        break;
     case kTfLiteFloat16:
-      throw std::logic_error("Float16 not currently supported as output tensor data type");
-      break;
+        throw std::logic_error("Float16 not currently supported as output tensor data type");
+        break;
     default:
-      throw std::logic_error("Unsupported output data type");
-  }
+        throw std::logic_error("Unsupported output data type");
+    }
 
-  // We use alloc here to allow deallocation from the module
-  DLManagedTensor* output = (DLManagedTensor*)alloc(sizeof(DLManagedTensor));
-  output->dl_tensor = dl_tensor;
-  output->manager_ctx = NULL;
-  output->deleter = deleter;
+    // We use alloc here to allow deallocation from the module
+    DLManagedTensor *output = (DLManagedTensor *)alloc(sizeof(DLManagedTensor));
+    output->dl_tensor = dl_tensor;
+    output->manager_ctx = NULL;
+    output->deleter = deleter;
 
-  return output;
+    return output;
 }
 
-void setError(const char* what, char **error, void* (*alloc)(size_t)) {
-  size_t len = strlen(what);
-  *error = (char*)alloc(len * sizeof(char));
-  strcpy(*error, what);
+void setError(const char *what, char **error, void *(*alloc)(size_t)) {
+    size_t len = strlen(what);
+    *error = (char *)alloc(len * sizeof(char));
+    strcpy(*error, what);
 }
 
 struct ModelContext {
-  std::shared_ptr<tflite::FlatBufferModel> model;
-  std::shared_ptr<tflite::Interpreter> interpreter;
-  std::string buffer;
-  DLDeviceType device;
-  int64_t device_id;
+    std::shared_ptr<tflite::FlatBufferModel> model;
+    std::shared_ptr<tflite::Interpreter> interpreter;
+    std::string buffer;
+    DLDeviceType device;
+    int64_t device_id;
 };
 
-}
+} // namespace
 
-extern "C" void tfliteBasicTest() {
-}
+extern "C" void tfliteBasicTest() {}
 
-extern "C" void* tfliteLoadModel(const char* graph, size_t graphlen, DLDeviceType device, int64_t device_id,
-                                 char **error, void* (*alloc)(size_t)) {
-  std::string graphstr(graph, graphlen);
+extern "C" void *tfliteLoadModel(const char *graph, size_t graphlen, DLDeviceType device,
+                                 int64_t device_id, char **error, void *(*alloc)(size_t)) {
+    std::string graphstr(graph, graphlen);
 
-  std::shared_ptr<tflite::FlatBufferModel> model;
-  std::unique_ptr<tflite::Interpreter> interpreter_;
-  model = tflite::FlatBufferModel::BuildFromBuffer(graphstr.c_str(), graphlen);
-  if (!model) {
-    setError("Failed to load model from buffer", error, alloc);
-    return NULL;
-  }
+    std::shared_ptr<tflite::FlatBufferModel> model;
+    std::unique_ptr<tflite::Interpreter> interpreter_;
+    model = tflite::FlatBufferModel::BuildFromBuffer(graphstr.c_str(), graphlen);
+    if (!model) {
+        setError("Failed to load model from buffer", error, alloc);
+        return NULL;
+    }
 
-  tflite::ops::builtin::BuiltinOpResolver resolver;
+    tflite::ops::builtin::BuiltinOpResolver resolver;
 
-  tflite::InterpreterBuilder(*model, resolver)(&interpreter_);
-  if (!interpreter_) {
-    setError("Failed to construct interpreter", error, alloc);
-    return NULL;
-  }
+    tflite::InterpreterBuilder(*model, resolver)(&interpreter_);
+    if (!interpreter_) {
+        setError("Failed to construct interpreter", error, alloc);
+        return NULL;
+    }
 
 #if RAI_TFLITE_USE_CUDA
-  if (device == DLDeviceType::kDLGPU) {
-    tflite::Interpreter::TfLiteDelegatePtr delegate = tflite::evaluation::CreateGPUDelegate(model.get());
-    if (interpreter_->ModifyGraphWithDelegate(std::move(delegate)) != kTfLiteOk) {
-      setError("Failed to set GPU delegate", error, alloc);
-      return NULL;
+    if (device == DLDeviceType::kDLGPU) {
+        tflite::Interpreter::TfLiteDelegatePtr delegate =
+            tflite::evaluation::CreateGPUDelegate(model.get());
+        if (interpreter_->ModifyGraphWithDelegate(std::move(delegate)) != kTfLiteOk) {
+            setError("Failed to set GPU delegate", error, alloc);
+            return NULL;
+        }
     }
-  }
 #endif
 
-  if (interpreter_->AllocateTensors() != kTfLiteOk) {
-    setError("Failed to allocate tensors", error, alloc);
-    return NULL;
-  }
-
-  std::shared_ptr<tflite::Interpreter> interpreter = std::move(interpreter_);
-
-  ModelContext* ctx = new ModelContext();
-  ctx->device = device;
-  ctx->device_id = device_id;
-  ctx->model = std::move(model);
-  ctx->interpreter = std::move(interpreter);
-  ctx->buffer = std::move(graphstr);
-
-  return ctx;
-}
-
-extern "C" void tfliteRunModel(void* ctx,
-                               long n_inputs, DLManagedTensor** inputs,
-                               long n_outputs, DLManagedTensor** outputs,
-                               char **error, void* (*alloc)(size_t)) {
-  ModelContext* ctx_ = (ModelContext*)ctx;
-
-  auto interpreter = ctx_->interpreter;
-  auto model = ctx_->model;
-
-  const std::vector<int> tflite_inputs = interpreter->inputs();
-  const std::vector<int> tflite_outputs = interpreter->outputs();
-
-  if (n_inputs != tflite_inputs.size()) {
-    setError("Inconsistent number of inputs", error, alloc);
-    return;
-  }
-
-  if (n_outputs != tflite_outputs.size()) {
-    setError("Inconsistent number of outputs", error, alloc);
-    return;
-  }
-
-  try {
-    for (size_t i=0; i<tflite_inputs.size(); i++) {
-      copyToTfLiteTensor(interpreter, tflite_inputs[i], inputs[i]);
+    if (interpreter_->AllocateTensors() != kTfLiteOk) {
+        setError("Failed to allocate tensors", error, alloc);
+        return NULL;
     }
-  }
-  catch(std::exception& e) {
-    setError(e.what(), error, alloc);
-    return;
-  }
 
-  if (interpreter->Invoke() != kTfLiteOk) {
-    setError("Failed to invoke TfLite", error, alloc);
-    return;
-  }
+    std::shared_ptr<tflite::Interpreter> interpreter = std::move(interpreter_);
 
-  try {
-    for (size_t i=0; i<tflite_outputs.size(); i++) {
-      outputs[i] = toManagedDLPack(interpreter, tflite_outputs[i], alloc);
+    ModelContext *ctx = new ModelContext();
+    ctx->device = device;
+    ctx->device_id = device_id;
+    ctx->model = std::move(model);
+    ctx->interpreter = std::move(interpreter);
+    ctx->buffer = std::move(graphstr);
+
+    return ctx;
+}
+
+extern "C" void tfliteRunModel(void *ctx, long n_inputs, DLManagedTensor **inputs, long n_outputs,
+                               DLManagedTensor **outputs, char **error, void *(*alloc)(size_t)) {
+    ModelContext *ctx_ = (ModelContext *)ctx;
+
+    auto interpreter = ctx_->interpreter;
+    auto model = ctx_->model;
+
+    const std::vector<int> tflite_inputs = interpreter->inputs();
+    const std::vector<int> tflite_outputs = interpreter->outputs();
+
+    if (n_inputs != tflite_inputs.size()) {
+        setError("Inconsistent number of inputs", error, alloc);
+        return;
     }
-  }
-  catch(std::exception& e) {
-    setError(e.what(), error, alloc);
-    return;
-  }
+
+    if (n_outputs != tflite_outputs.size()) {
+        setError("Inconsistent number of outputs", error, alloc);
+        return;
+    }
+
+    try {
+        for (size_t i = 0; i < tflite_inputs.size(); i++) {
+            copyToTfLiteTensor(interpreter, tflite_inputs[i], inputs[i]);
+        }
+    } catch (std::exception &e) {
+        setError(e.what(), error, alloc);
+        return;
+    }
+
+    if (interpreter->Invoke() != kTfLiteOk) {
+        setError("Failed to invoke TfLite", error, alloc);
+        return;
+    }
+
+    try {
+        for (size_t i = 0; i < tflite_outputs.size(); i++) {
+            outputs[i] = toManagedDLPack(interpreter, tflite_outputs[i], alloc);
+        }
+    } catch (std::exception &e) {
+        setError(e.what(), error, alloc);
+        return;
+    }
 }
 
-extern "C" void tfliteSerializeModel(void* ctx, char **buffer, size_t *len,
-                                     char **error, void* (*alloc)(size_t)) {
-  // NO OP
+extern "C" void tfliteSerializeModel(void *ctx, char **buffer, size_t *len, char **error,
+                                     void *(*alloc)(size_t)) {
+    // NO OP
 }
 
-extern "C" void tfliteDeallocContext(void* ctx) {
-  ModelContext* ctx_ = (ModelContext*)ctx;
-  if (ctx_) {
-    delete ctx_;
-  }
+extern "C" void tfliteDeallocContext(void *ctx) {
+    ModelContext *ctx_ = (ModelContext *)ctx;
+    if (ctx_) {
+        delete ctx_;
+    }
 }

--- a/src/libtflite_c/tflite_c.h
+++ b/src/libtflite_c/tflite_c.h
@@ -9,18 +9,16 @@ extern "C" {
 
 // void tfliteBasicTest();
 
-void* tfliteLoadModel(const char* model, size_t modellen, DLDeviceType device, int64_t device_id,
-                      char **error, void* (*alloc)(size_t));
+void *tfliteLoadModel(const char *model, size_t modellen, DLDeviceType device, int64_t device_id,
+                      char **error, void *(*alloc)(size_t));
 
-void tfliteRunModel(void* ctx,
-                    long nInputs, DLManagedTensor** inputs,
-                    long nOutputs, DLManagedTensor** outputs,
-                    char **error, void* (*alloc)(size_t));
+void tfliteRunModel(void *ctx, long nInputs, DLManagedTensor **inputs, long nOutputs,
+                    DLManagedTensor **outputs, char **error, void *(*alloc)(size_t));
 
-void tfliteSerializeModel(void* ctx, char **buffer, size_t *len,
-                          char **error, void* (*alloc)(size_t));
+void tfliteSerializeModel(void *ctx, char **buffer, size_t *len, char **error,
+                          void *(*alloc)(size_t));
 
-void tfliteDeallocContext(void* ctx);
+void tfliteDeallocContext(void *ctx);
 
 #ifdef __cplusplus
 }

--- a/src/libtorch_c/torch_c.cpp
+++ b/src/libtorch_c/torch_c.cpp
@@ -7,458 +7,433 @@
 #include <iostream>
 #include <sstream>
 
-
 namespace {
 
-static DLDataType getDLDataType(const at::Tensor& t) {
-  DLDataType dtype;
-  dtype.lanes = 1;
-  dtype.bits = t.element_size() * 8;
-  switch (t.scalar_type()) {
+static DLDataType getDLDataType(const at::Tensor &t) {
+    DLDataType dtype;
+    dtype.lanes = 1;
+    dtype.bits = t.element_size() * 8;
+    switch (t.scalar_type()) {
     case at::ScalarType::Byte:
-      dtype.code = DLDataTypeCode::kDLUInt;
-      break;
+        dtype.code = DLDataTypeCode::kDLUInt;
+        break;
     case at::ScalarType::Char:
-      dtype.code = DLDataTypeCode::kDLInt;
-      break;
+        dtype.code = DLDataTypeCode::kDLInt;
+        break;
     case at::ScalarType::Double:
-      dtype.code = DLDataTypeCode::kDLFloat;
-      break;
+        dtype.code = DLDataTypeCode::kDLFloat;
+        break;
     case at::ScalarType::Float:
-      dtype.code = DLDataTypeCode::kDLFloat;
-      break;
+        dtype.code = DLDataTypeCode::kDLFloat;
+        break;
     case at::ScalarType::Int:
-      dtype.code = DLDataTypeCode::kDLInt;
-      break;
+        dtype.code = DLDataTypeCode::kDLInt;
+        break;
     case at::ScalarType::Long:
-      dtype.code = DLDataTypeCode::kDLInt;
-      break;
+        dtype.code = DLDataTypeCode::kDLInt;
+        break;
     case at::ScalarType::Short:
-      dtype.code = DLDataTypeCode::kDLInt;
-      break;
+        dtype.code = DLDataTypeCode::kDLInt;
+        break;
     case at::ScalarType::Half:
-      dtype.code = DLDataTypeCode::kDLFloat;
-      break;
+        dtype.code = DLDataTypeCode::kDLFloat;
+        break;
     case at::ScalarType::Bool:
-      throw std::logic_error("Bool is not supported by dlpack");
+        throw std::logic_error("Bool is not supported by dlpack");
     case at::ScalarType::BFloat16:
-      throw std::logic_error("BFloat16 is not supported by dlpack");
+        throw std::logic_error("BFloat16 is not supported by dlpack");
     case at::ScalarType::QInt8:
-      throw std::logic_error("QInt8 is not supported by dlpack");
+        throw std::logic_error("QInt8 is not supported by dlpack");
     case at::ScalarType::QUInt8:
-      throw std::logic_error("QUInt8 is not supported by dlpack");
+        throw std::logic_error("QUInt8 is not supported by dlpack");
     case at::ScalarType::QInt32:
-      throw std::logic_error("QInt32 is not supported by dlpack");
+        throw std::logic_error("QInt32 is not supported by dlpack");
     case at::ScalarType::ComplexHalf:
-      throw std::logic_error("ComplexHalf is not supported by dlpack");
+        throw std::logic_error("ComplexHalf is not supported by dlpack");
     case at::ScalarType::ComplexFloat:
-      throw std::logic_error("ComplexFloat is not supported by dlpack");
+        throw std::logic_error("ComplexFloat is not supported by dlpack");
     case at::ScalarType::ComplexDouble:
-      throw std::logic_error("ComplexDouble is not supported by dlpack");
+        throw std::logic_error("ComplexDouble is not supported by dlpack");
     case at::ScalarType::Undefined:
-      throw std::logic_error("Undefined is not a valid ScalarType");
+        throw std::logic_error("Undefined is not a valid ScalarType");
     case at::ScalarType::NumOptions:
-      throw std::logic_error("NumOptions is not a valid ScalarType");
-  }
-  return dtype;
+        throw std::logic_error("NumOptions is not a valid ScalarType");
+    }
+    return dtype;
 }
 
-static DLContext getDLContext(const at::Tensor& tensor, const int64_t& device_id) {
-  DLContext ctx;
-  ctx.device_id = device_id;
-  if (tensor.is_cuda()) {
-    ctx.device_type = DLDeviceType::kDLGPU;
-  } else {
-    ctx.device_type = DLDeviceType::kDLCPU;
-  }
-  return ctx;
+static DLContext getDLContext(const at::Tensor &tensor, const int64_t &device_id) {
+    DLContext ctx;
+    ctx.device_id = device_id;
+    if (tensor.is_cuda()) {
+        ctx.device_type = DLDeviceType::kDLGPU;
+    } else {
+        ctx.device_type = DLDeviceType::kDLCPU;
+    }
+    return ctx;
 }
 
 static at::DeviceType getATenDeviceType(DLDeviceType device_type) {
-  switch (device_type) {
+    switch (device_type) {
     case DLDeviceType::kDLCPU:
-      return at::DeviceType::CPU;
+        return at::DeviceType::CPU;
     case DLDeviceType::kDLGPU:
-      return at::DeviceType::CUDA;
+        return at::DeviceType::CUDA;
     case DLDeviceType::kDLOpenCL:
-      return at::DeviceType::OPENCL;
+        return at::DeviceType::OPENCL;
     case DLDeviceType::kDLROCM:
-      return at::DeviceType::HIP;
+        return at::DeviceType::HIP;
     default:
-      throw std::logic_error("Unsupported device_type: " + std::to_string(device_type));
-  }
-  return at::DeviceType::CPU; // impossible
+        throw std::logic_error("Unsupported device_type: " + std::to_string(device_type));
+    }
+    return at::DeviceType::CPU; // impossible
 }
 
-at::ScalarType toScalarType(const DLDataType& dtype) {
-  at::ScalarType stype;
-  if (dtype.lanes != 1) throw std::logic_error("ATen does not support lanes != 1");
-  switch (dtype.code) {
+at::ScalarType toScalarType(const DLDataType &dtype) {
+    at::ScalarType stype;
+    if (dtype.lanes != 1)
+        throw std::logic_error("ATen does not support lanes != 1");
+    switch (dtype.code) {
     case DLDataTypeCode::kDLUInt:
-      switch (dtype.bits) {
+        switch (dtype.bits) {
         case 8:
-          stype = at::ScalarType::Byte;
-          break;
+            stype = at::ScalarType::Byte;
+            break;
         default:
-          throw std::logic_error("Unsupported kUInt bits " + std::to_string(dtype.bits));
-      }
-      break;
+            throw std::logic_error("Unsupported kUInt bits " + std::to_string(dtype.bits));
+        }
+        break;
     case DLDataTypeCode::kDLInt:
-      switch (dtype.bits) {
+        switch (dtype.bits) {
         case 8:
-          stype = at::ScalarType::Char;
-          break;
+            stype = at::ScalarType::Char;
+            break;
         case 16:
-          stype = at::ScalarType::Short;
-          break;
+            stype = at::ScalarType::Short;
+            break;
         case 32:
-          stype = at::ScalarType::Int;
-          break;
+            stype = at::ScalarType::Int;
+            break;
         case 64:
-          stype = at::ScalarType::Long;
-          break;
+            stype = at::ScalarType::Long;
+            break;
         default:
-          throw std::logic_error("Unsupported kInt bits " + std::to_string(dtype.bits));
-      }
-      break;
+            throw std::logic_error("Unsupported kInt bits " + std::to_string(dtype.bits));
+        }
+        break;
     case DLDataTypeCode::kDLFloat:
-      switch (dtype.bits) {
+        switch (dtype.bits) {
         case 16:
-          stype = at::ScalarType::Half;
-          break;
+            stype = at::ScalarType::Half;
+            break;
         case 32:
-          stype = at::ScalarType::Float;
-          break;
+            stype = at::ScalarType::Float;
+            break;
         case 64:
-          stype = at::ScalarType::Double;
-          break;
+            stype = at::ScalarType::Double;
+            break;
         default:
-          throw std::logic_error("Unsupported kFloat bits " + std::to_string(dtype.bits));
-      }
-      break;
+            throw std::logic_error("Unsupported kFloat bits " + std::to_string(dtype.bits));
+        }
+        break;
     default:
-      throw std::logic_error("Unsupported code " + std::to_string(dtype.code));
-  }
-  return stype;
+        throw std::logic_error("Unsupported code " + std::to_string(dtype.code));
+    }
+    return stype;
 }
 
-torch::Tensor fromDLPack(const DLTensor* src) {
-  at::DeviceType device_type = getATenDeviceType(src->ctx.device_type);
-  at::ScalarType stype = toScalarType(src->dtype);
-  // torch::Device device(device_type, src->ctx.device_id);
-  torch::Device device(device_type, -1);
-  // torch::DeviceType device = device_type;
-  return torch::from_blob(src->data,
-      at::IntArrayRef(src->shape, src->ndim),
-      at::IntArrayRef(src->strides, src->ndim),
-      torch::device(device).dtype(stype));
+torch::Tensor fromDLPack(const DLTensor *src) {
+    at::DeviceType device_type = getATenDeviceType(src->ctx.device_type);
+    at::ScalarType stype = toScalarType(src->dtype);
+    // torch::Device device(device_type, src->ctx.device_id);
+    torch::Device device(device_type, -1);
+    // torch::DeviceType device = device_type;
+    return torch::from_blob(src->data, at::IntArrayRef(src->shape, src->ndim),
+                            at::IntArrayRef(src->strides, src->ndim),
+                            torch::device(device).dtype(stype));
 }
 
 struct ATenDLMTensor {
-  torch::Tensor handle;
-  DLManagedTensor tensor;
+    torch::Tensor handle;
+    DLManagedTensor tensor;
 };
 
-void deleter(DLManagedTensor * arg) {
-  delete static_cast<ATenDLMTensor*>(arg->manager_ctx);
-}
+void deleter(DLManagedTensor *arg) { delete static_cast<ATenDLMTensor *>(arg->manager_ctx); }
 
-DLManagedTensor* toManagedDLPack(const torch::Tensor& src_) {
-  ATenDLMTensor * atDLMTensor(new ATenDLMTensor);
-  atDLMTensor->handle = src_;
-  auto& src = atDLMTensor->handle;
-  atDLMTensor->tensor.manager_ctx = atDLMTensor;
-  atDLMTensor->tensor.deleter = &deleter;
-  atDLMTensor->tensor.dl_tensor.data = src.data_ptr();
-  int64_t device_id = 0;
-  if (src.is_cuda()) {
-    device_id = src.get_device();
-  }
-  atDLMTensor->tensor.dl_tensor.ctx = getDLContext(src, device_id);
-  atDLMTensor->tensor.dl_tensor.ndim = src.dim();
-  atDLMTensor->tensor.dl_tensor.dtype = getDLDataType(src);
-  atDLMTensor->tensor.dl_tensor.shape = const_cast<int64_t*>(src.sizes().data());
-  atDLMTensor->tensor.dl_tensor.strides = const_cast<int64_t*>(src.strides().data());
-  atDLMTensor->tensor.dl_tensor.byte_offset = 0;
-  return &(atDLMTensor->tensor);
+DLManagedTensor *toManagedDLPack(const torch::Tensor &src_) {
+    ATenDLMTensor *atDLMTensor(new ATenDLMTensor);
+    atDLMTensor->handle = src_;
+    auto &src = atDLMTensor->handle;
+    atDLMTensor->tensor.manager_ctx = atDLMTensor;
+    atDLMTensor->tensor.deleter = &deleter;
+    atDLMTensor->tensor.dl_tensor.data = src.data_ptr();
+    int64_t device_id = 0;
+    if (src.is_cuda()) {
+        device_id = src.get_device();
+    }
+    atDLMTensor->tensor.dl_tensor.ctx = getDLContext(src, device_id);
+    atDLMTensor->tensor.dl_tensor.ndim = src.dim();
+    atDLMTensor->tensor.dl_tensor.dtype = getDLDataType(src);
+    atDLMTensor->tensor.dl_tensor.shape = const_cast<int64_t *>(src.sizes().data());
+    atDLMTensor->tensor.dl_tensor.strides = const_cast<int64_t *>(src.strides().data());
+    atDLMTensor->tensor.dl_tensor.byte_offset = 0;
+    return &(atDLMTensor->tensor);
 }
 
 struct ModuleContext {
-  std::shared_ptr<torch::jit::script::Module> module;
-  std::shared_ptr<torch::jit::script::CompilationUnit> cu;
-  DLDeviceType device;
-  int64_t device_id;
+    std::shared_ptr<torch::jit::script::Module> module;
+    std::shared_ptr<torch::jit::script::CompilationUnit> cu;
+    DLDeviceType device;
+    int64_t device_id;
 };
 
-void torchRunModule(ModuleContext* ctx, const char* fnName, int variadic,
-                    long nInputs, DLManagedTensor** inputs,
-                    long nOutputs, DLManagedTensor** outputs) {
-  // Checks device, if GPU then move input to GPU before running
-  // TODO: This will need to change at some point, as individual tensors will have their placement
-  // and script will only make sure that placement is correct
+void torchRunModule(ModuleContext *ctx, const char *fnName, int variadic, long nInputs,
+                    DLManagedTensor **inputs, long nOutputs, DLManagedTensor **outputs) {
+    // Checks device, if GPU then move input to GPU before running
+    // TODO: This will need to change at some point, as individual tensors will have their placement
+    // and script will only make sure that placement is correct
 
-  torch::DeviceType device_type;
-  switch (ctx->device) {
+    torch::DeviceType device_type;
+    switch (ctx->device) {
     case kDLCPU:
-      device_type = torch::kCPU;
-      break;
+        device_type = torch::kCPU;
+        break;
     case kDLGPU:
-      device_type = torch::kCUDA;
-      break;
+        device_type = torch::kCUDA;
+        break;
     default:
-      throw std::runtime_error(std::string("Unsupported device ") + std::to_string(ctx->device));
-  }
-
-  torch::Device device(device_type, ctx->device_id);
-
-  torch::jit::Stack stack;
-
-  for (int i=0; i<nInputs; i++) {
-    if (i == variadic) {
-      break;
-    }
-    DLTensor* input = &(inputs[i]->dl_tensor);
-    torch::Tensor tensor = fromDLPack(input);
-    stack.push_back(tensor.to(device));
-  }
-
-  if (variadic != -1 ) {
-    std::vector<torch::Tensor> args;
-    for (int i=variadic; i<nInputs; i++) {
-      DLTensor* input = &(inputs[i]->dl_tensor);
-      torch::Tensor tensor = fromDLPack(input);
-      tensor.to(device);
-      args.emplace_back(tensor);
-    }
-    stack.push_back(args);
-  }
-
-  if (ctx->module) {
-    torch::NoGradGuard guard;
-    torch::jit::script::Method method = ctx->module->get_method(fnName);
-    method.run(stack);
-  }
-  else {
-    torch::NoGradGuard guard;
-    torch::jit::Function& fn = ctx->cu->get_function(fnName);
-    fn.run(stack);
-  }
-
-  torch::DeviceType output_device_type = torch::kCPU;
-  torch::Device output_device(output_device_type, -1);
-
-  int count = 0;
-  for (size_t i=0; i<stack.size(); i++) {
-    if (count > nOutputs-1) {
-      throw std::runtime_error(std::string("Function returned unexpected number of outputs - ") + fnName);
+        throw std::runtime_error(std::string("Unsupported device ") + std::to_string(ctx->device));
     }
 
-    if (stack[i].isTensor()) {
-      outputs[count++] = toManagedDLPack(stack[i].toTensor().contiguous().to(output_device));
-    }
-    else if (stack[i].isTensorList()) {
-      auto list = stack[i].toTensorList();
-      for (size_t j=0; j<list.size(); j++) {
-        outputs[count++] = toManagedDLPack(list.get(j).contiguous().to(output_device));
-      }
-    }
-    else if (stack[i].isTuple()) {
-      auto& elements = stack[i].toTuple()->elements();
-      for (size_t j=0; j<elements.size(); j++) {
-        if (elements[j].isTensor()) {
-          outputs[count++] = toManagedDLPack(elements[j].toTensor().contiguous().to(output_device));
+    torch::Device device(device_type, ctx->device_id);
+
+    torch::jit::Stack stack;
+
+    for (int i = 0; i < nInputs; i++) {
+        if (i == variadic) {
+            break;
         }
-        else {
-          throw std::runtime_error(std::string("Function returned non-tensor values") + fnName);
+        DLTensor *input = &(inputs[i]->dl_tensor);
+        torch::Tensor tensor = fromDLPack(input);
+        stack.push_back(tensor.to(device));
+    }
+
+    if (variadic != -1) {
+        std::vector<torch::Tensor> args;
+        for (int i = variadic; i < nInputs; i++) {
+            DLTensor *input = &(inputs[i]->dl_tensor);
+            torch::Tensor tensor = fromDLPack(input);
+            tensor.to(device);
+            args.emplace_back(tensor);
         }
-      }
+        stack.push_back(args);
     }
-    else {
-      throw std::runtime_error(std::string("Function returned non-tensor values") + fnName);
+
+    if (ctx->module) {
+        torch::NoGradGuard guard;
+        torch::jit::script::Method method = ctx->module->get_method(fnName);
+        method.run(stack);
+    } else {
+        torch::NoGradGuard guard;
+        torch::jit::Function &fn = ctx->cu->get_function(fnName);
+        fn.run(stack);
     }
-  }
 
-  if (count != nOutputs) {
-    throw std::runtime_error(std::string("Function returned unexpected number of outputs - ") + fnName);
-  }
-}
+    torch::DeviceType output_device_type = torch::kCPU;
+    torch::Device output_device(output_device_type, -1);
 
-}
+    int count = 0;
+    for (size_t i = 0; i < stack.size(); i++) {
+        if (count > nOutputs - 1) {
+            throw std::runtime_error(
+                std::string("Function returned unexpected number of outputs - ") + fnName);
+        }
 
-extern "C" void torchBasicTest()
-{
-  torch::Tensor mat = torch::rand({3,3});
-  std::cout << mat << std::endl;
-}
-
-extern "C" DLManagedTensor* torchNewTensor(DLDataType dtype, long ndims, int64_t* shape, int64_t* strides, char* data)
-{
-  // at::DeviceType device_type = getATenDeviceType(kDLCPU);
-  at::ScalarType stype = toScalarType(dtype);
-  torch::Device device(getATenDeviceType(kDLCPU), -1);
-  torch::Tensor tensor = torch::from_blob(data,
-      at::IntArrayRef(shape, ndims),
-      at::IntArrayRef(strides, ndims),
-      // torch::device(at::DeviceType::CPU).dtype(stype));
-      torch::device(device).dtype(stype));
-
-  DLManagedTensor *dl_tensor = toManagedDLPack(tensor);
-
-  return dl_tensor;
-}
-
-extern "C" void* torchCompileScript(const char* script, DLDeviceType device, int64_t device_id,
-                                    char **error, void* (*alloc)(size_t))
-{
-  ModuleContext* ctx = new ModuleContext();
-  ctx->device = device;
-  ctx->device_id = device_id;
-  try {
-    auto cu = torch::jit::compile(script);
-    auto aten_device_type = getATenDeviceType(device);
-    if (aten_device_type == at::DeviceType::CUDA && !torch::cuda::is_available()) {
-      throw std::logic_error("GPU requested but Torch couldn't find CUDA");
+        if (stack[i].isTensor()) {
+            outputs[count++] = toManagedDLPack(stack[i].toTensor().contiguous().to(output_device));
+        } else if (stack[i].isTensorList()) {
+            auto list = stack[i].toTensorList();
+            for (size_t j = 0; j < list.size(); j++) {
+                outputs[count++] = toManagedDLPack(list.get(j).contiguous().to(output_device));
+            }
+        } else if (stack[i].isTuple()) {
+            auto &elements = stack[i].toTuple()->elements();
+            for (size_t j = 0; j < elements.size(); j++) {
+                if (elements[j].isTensor()) {
+                    outputs[count++] =
+                        toManagedDLPack(elements[j].toTensor().contiguous().to(output_device));
+                } else {
+                    throw std::runtime_error(std::string("Function returned non-tensor values") +
+                                             fnName);
+                }
+            }
+        } else {
+            throw std::runtime_error(std::string("Function returned non-tensor values") + fnName);
+        }
     }
-    ctx->cu = cu;
-    ctx->module = nullptr;
-  }
-  catch(std::exception& e) {
-    size_t len = strlen(e.what()) +1;
-    *error = (char*)alloc(len * sizeof(char));
-    strcpy(*error, e.what());
-    (*error)[len-1] = '\0';
-    delete ctx;
-    return NULL;
-  }
-  return ctx;
-}
 
-extern "C" void* torchLoadModel(const char* graph, size_t graphlen, DLDeviceType device, int64_t device_id,
-                                char **error, void* (*alloc)(size_t))
-{
-  std::string graphstr(graph, graphlen);
-  std::istringstream graph_stream(graphstr, std::ios_base::binary);
-  ModuleContext* ctx = new ModuleContext();
-  ctx->device = device;
-  ctx->device_id = device_id;
-  try {
-    // TODO: move to device now
-    auto module = std::make_shared<torch::jit::script::Module>(torch::jit::load(graph_stream));
-    auto aten_device_type = getATenDeviceType(device);
-    if (aten_device_type == at::DeviceType::CUDA && !torch::cuda::is_available()) {
-      throw std::logic_error("GPU requested but Torch couldn't find CUDA");
+    if (count != nOutputs) {
+        throw std::runtime_error(std::string("Function returned unexpected number of outputs - ") +
+                                 fnName);
     }
-    torch::Device aten_device(aten_device_type, device_id);
-    module->to(aten_device);
-    ctx->module = module;
-    ctx->cu = nullptr;
-  }
-  catch(std::exception& e) {
-    size_t len = strlen(e.what()) +1;
-    *error = (char*)alloc(len * sizeof(char));
-    strcpy(*error, e.what());
-    (*error)[len-1] = '\0';
-    // delete ctx;
-    return NULL;
-  }
-  return ctx;
 }
 
-extern "C" void torchRunScript(void* scriptCtx, const char* fnName, int variadic,
-                               long nInputs, DLManagedTensor** inputs,
-                               long nOutputs, DLManagedTensor** outputs,
-                               char **error, void* (*alloc)(size_t))
-{
-  ModuleContext* ctx = (ModuleContext*)scriptCtx;
-  try {
-    torchRunModule(ctx, fnName, variadic, nInputs, inputs, nOutputs, outputs);
-  }
-  catch(std::exception& e) {
-    size_t len = strlen(e.what()) +1;
-    *error = (char*)alloc(len * sizeof(char));
-    strcpy(*error, e.what());
-    (*error)[len-1] = '\0';
-  }
+} // namespace
+
+extern "C" void torchBasicTest() {
+    torch::Tensor mat = torch::rand({3, 3});
+    std::cout << mat << std::endl;
 }
 
-extern "C" void torchRunModel(void* modelCtx,
-                              long nInputs, DLManagedTensor** inputs,
-                              long nOutputs, DLManagedTensor** outputs,
-                              char **error, void* (*alloc)(size_t))
-{
-  ModuleContext* ctx = (ModuleContext*)modelCtx;
-  try {
-    torchRunModule(ctx, "forward", -1, nInputs, inputs, nOutputs, outputs);
-  }
-  catch(std::exception& e) {
-    size_t len = strlen(e.what()) +1;
-    *error = (char*)alloc(len * sizeof(char));
-    strcpy(*error, e.what());
-    (*error)[len-1] = '\0';
-  }
+extern "C" DLManagedTensor *torchNewTensor(DLDataType dtype, long ndims, int64_t *shape,
+                                           int64_t *strides, char *data) {
+    // at::DeviceType device_type = getATenDeviceType(kDLCPU);
+    at::ScalarType stype = toScalarType(dtype);
+    torch::Device device(getATenDeviceType(kDLCPU), -1);
+    torch::Tensor tensor =
+        torch::from_blob(data, at::IntArrayRef(shape, ndims), at::IntArrayRef(strides, ndims),
+                         // torch::device(at::DeviceType::CPU).dtype(stype));
+                         torch::device(device).dtype(stype));
+
+    DLManagedTensor *dl_tensor = toManagedDLPack(tensor);
+
+    return dl_tensor;
 }
 
-extern "C" void torchSerializeModel(void* modelCtx, char **buffer, size_t *len,
-                                    char **error, void* (*alloc)(size_t))
-{
-  ModuleContext* ctx = (ModuleContext*)modelCtx;
-  std::ostringstream out;
-  try {
-    ctx->module->save(out);
-    auto out_str = out.str();
-    int size = out_str.size();
-    *buffer = (char *)alloc(size);
-    memcpy(*buffer, out_str.c_str(), size);
-    *len = size;
-  }
-  catch(std::exception& e) {
-    size_t len = strlen(e.what()) +1;
-    *error = (char*)alloc(len * sizeof(char));
-    strcpy(*error, e.what());
-    (*error)[len-1] = '\0';
-  }
-}
-
-extern "C" void torchDeallocContext(void* ctx)
-{
-  ModuleContext* ctx_ = (ModuleContext*)ctx;
-  if (ctx_) {
-    delete ctx_;
-  }
-}
-
-extern "C" void torchSetInterOpThreads(int num_threads, char **error,
-                                       void* (*alloc)(size_t))
-{
-  int current_num_interop_threads = torch::get_num_interop_threads();
-  if (current_num_interop_threads != num_threads){
+extern "C" void *torchCompileScript(const char *script, DLDeviceType device, int64_t device_id,
+                                    char **error, void *(*alloc)(size_t)) {
+    ModuleContext *ctx = new ModuleContext();
+    ctx->device = device;
+    ctx->device_id = device_id;
     try {
-      torch::set_num_interop_threads(num_threads);
+        auto cu = torch::jit::compile(script);
+        auto aten_device_type = getATenDeviceType(device);
+        if (aten_device_type == at::DeviceType::CUDA && !torch::cuda::is_available()) {
+            throw std::logic_error("GPU requested but Torch couldn't find CUDA");
+        }
+        ctx->cu = cu;
+        ctx->module = nullptr;
+    } catch (std::exception &e) {
+        size_t len = strlen(e.what()) + 1;
+        *error = (char *)alloc(len * sizeof(char));
+        strcpy(*error, e.what());
+        (*error)[len - 1] = '\0';
+        delete ctx;
+        return NULL;
     }
-    catch (std::exception) {
-      std::string error_msg = "Cannot set number of inter-op threads after parallel work has started";
-      size_t len = error_msg.length() +1;
-      *error = (char *)alloc(len * sizeof(char));
-      strcpy(*error, error_msg.c_str());
-      (*error)[len-1] = '\0';
-    }
-  }
+    return ctx;
 }
 
-
-extern "C" void torchSetIntraOpThreads(int num_threads, char **error,
-                                       void* (*alloc)(size_t)){
-  int current_num_threads = torch::get_num_threads();
-  if (current_num_threads != num_threads) {
+extern "C" void *torchLoadModel(const char *graph, size_t graphlen, DLDeviceType device,
+                                int64_t device_id, char **error, void *(*alloc)(size_t)) {
+    std::string graphstr(graph, graphlen);
+    std::istringstream graph_stream(graphstr, std::ios_base::binary);
+    ModuleContext *ctx = new ModuleContext();
+    ctx->device = device;
+    ctx->device_id = device_id;
     try {
-      torch::set_num_threads(num_threads);
+        // TODO: move to device now
+        auto module = std::make_shared<torch::jit::script::Module>(torch::jit::load(graph_stream));
+        auto aten_device_type = getATenDeviceType(device);
+        if (aten_device_type == at::DeviceType::CUDA && !torch::cuda::is_available()) {
+            throw std::logic_error("GPU requested but Torch couldn't find CUDA");
+        }
+        torch::Device aten_device(aten_device_type, device_id);
+        module->to(aten_device);
+        ctx->module = module;
+        ctx->cu = nullptr;
+    } catch (std::exception &e) {
+        size_t len = strlen(e.what()) + 1;
+        *error = (char *)alloc(len * sizeof(char));
+        strcpy(*error, e.what());
+        (*error)[len - 1] = '\0';
+        // delete ctx;
+        return NULL;
     }
-    catch (std::exception) {
-      std::string error_msg = "Cannot set number of intra-op threads after parallel work has started";
-      size_t len = error_msg.length() +1;
-      *error = (char *)alloc(len * sizeof(char));
-      strcpy(*error, error_msg.c_str());
-      (*error)[len-1] = '\0';
+    return ctx;
+}
+
+extern "C" void torchRunScript(void *scriptCtx, const char *fnName, int variadic, long nInputs,
+                               DLManagedTensor **inputs, long nOutputs, DLManagedTensor **outputs,
+                               char **error, void *(*alloc)(size_t)) {
+    ModuleContext *ctx = (ModuleContext *)scriptCtx;
+    try {
+        torchRunModule(ctx, fnName, variadic, nInputs, inputs, nOutputs, outputs);
+    } catch (std::exception &e) {
+        size_t len = strlen(e.what()) + 1;
+        *error = (char *)alloc(len * sizeof(char));
+        strcpy(*error, e.what());
+        (*error)[len - 1] = '\0';
     }
-  }
+}
+
+extern "C" void torchRunModel(void *modelCtx, long nInputs, DLManagedTensor **inputs, long nOutputs,
+                              DLManagedTensor **outputs, char **error, void *(*alloc)(size_t)) {
+    ModuleContext *ctx = (ModuleContext *)modelCtx;
+    try {
+        torchRunModule(ctx, "forward", -1, nInputs, inputs, nOutputs, outputs);
+    } catch (std::exception &e) {
+        size_t len = strlen(e.what()) + 1;
+        *error = (char *)alloc(len * sizeof(char));
+        strcpy(*error, e.what());
+        (*error)[len - 1] = '\0';
+    }
+}
+
+extern "C" void torchSerializeModel(void *modelCtx, char **buffer, size_t *len, char **error,
+                                    void *(*alloc)(size_t)) {
+    ModuleContext *ctx = (ModuleContext *)modelCtx;
+    std::ostringstream out;
+    try {
+        ctx->module->save(out);
+        auto out_str = out.str();
+        int size = out_str.size();
+        *buffer = (char *)alloc(size);
+        memcpy(*buffer, out_str.c_str(), size);
+        *len = size;
+    } catch (std::exception &e) {
+        size_t len = strlen(e.what()) + 1;
+        *error = (char *)alloc(len * sizeof(char));
+        strcpy(*error, e.what());
+        (*error)[len - 1] = '\0';
+    }
+}
+
+extern "C" void torchDeallocContext(void *ctx) {
+    ModuleContext *ctx_ = (ModuleContext *)ctx;
+    if (ctx_) {
+        delete ctx_;
+    }
+}
+
+extern "C" void torchSetInterOpThreads(int num_threads, char **error, void *(*alloc)(size_t)) {
+    int current_num_interop_threads = torch::get_num_interop_threads();
+    if (current_num_interop_threads != num_threads) {
+        try {
+            torch::set_num_interop_threads(num_threads);
+        } catch (std::exception) {
+            std::string error_msg =
+                "Cannot set number of inter-op threads after parallel work has started";
+            size_t len = error_msg.length() + 1;
+            *error = (char *)alloc(len * sizeof(char));
+            strcpy(*error, error_msg.c_str());
+            (*error)[len - 1] = '\0';
+        }
+    }
+}
+
+extern "C" void torchSetIntraOpThreads(int num_threads, char **error, void *(*alloc)(size_t)) {
+    int current_num_threads = torch::get_num_threads();
+    if (current_num_threads != num_threads) {
+        try {
+            torch::set_num_threads(num_threads);
+        } catch (std::exception) {
+            std::string error_msg =
+                "Cannot set number of intra-op threads after parallel work has started";
+            size_t len = error_msg.length() + 1;
+            *error = (char *)alloc(len * sizeof(char));
+            strcpy(*error, error_msg.c_str());
+            (*error)[len - 1] = '\0';
+        }
+    }
 }

--- a/src/libtorch_c/torch_c.h
+++ b/src/libtorch_c/torch_c.h
@@ -9,34 +9,30 @@ extern "C" {
 
 void torchBasicTest();
 
-DLManagedTensor* torchNewTensor(DLDataType dtype, long ndims,
-                                int64_t* shape, int64_t* strides,
-                                char* data);
+DLManagedTensor *torchNewTensor(DLDataType dtype, long ndims, int64_t *shape, int64_t *strides,
+                                char *data);
 
-void* torchCompileScript(const char* script, DLDeviceType device, int64_t device_id,
-                         char **error, void* (*alloc)(size_t));
+void *torchCompileScript(const char *script, DLDeviceType device, int64_t device_id, char **error,
+                         void *(*alloc)(size_t));
 
-void* torchLoadModel(const char* model, size_t modellen, DLDeviceType device, int64_t device_id,
-                     char **error, void* (*alloc)(size_t));
+void *torchLoadModel(const char *model, size_t modellen, DLDeviceType device, int64_t device_id,
+                     char **error, void *(*alloc)(size_t));
 
-void torchRunScript(void* scriptCtx, const char* fnName, int variadic,
-                    long nInputs, DLManagedTensor** inputs,
-                    long nOutputs, DLManagedTensor** outputs,
-                    char **error, void* (*alloc)(size_t));
+void torchRunScript(void *scriptCtx, const char *fnName, int variadic, long nInputs,
+                    DLManagedTensor **inputs, long nOutputs, DLManagedTensor **outputs,
+                    char **error, void *(*alloc)(size_t));
 
-void torchRunModel(void* modelCtx,
-                   long nInputs, DLManagedTensor** inputs,
-                   long nOutputs, DLManagedTensor** outputs,
-                   char **error, void* (*alloc)(size_t));
+void torchRunModel(void *modelCtx, long nInputs, DLManagedTensor **inputs, long nOutputs,
+                   DLManagedTensor **outputs, char **error, void *(*alloc)(size_t));
 
-void torchSerializeModel(void* modelCtx, char **buffer, size_t *len,
-                         char **error, void* (*alloc)(size_t));
+void torchSerializeModel(void *modelCtx, char **buffer, size_t *len, char **error,
+                         void *(*alloc)(size_t));
 
-void torchDeallocContext(void* ctx);
+void torchDeallocContext(void *ctx);
 
-void torchSetInterOpThreads(int num_threads, char **error, void* (*alloc)(size_t));
+void torchSetInterOpThreads(int num_threads, char **error, void *(*alloc)(size_t));
 
-void torchSetIntraOpThreads(int num_threadsm, char **error, void* (*alloc)(size_t));
+void torchSetIntraOpThreads(int num_threadsm, char **error, void *(*alloc)(size_t));
 
 #ifdef __cplusplus
 }

--- a/src/model.c
+++ b/src/model.c
@@ -8,630 +8,609 @@
  */
 
 #include "model.h"
-#include "model_struct.h"
 #include "backends.h"
-#include "stats.h"
 #include "backends/util.h"
-#include <pthread.h>
+#include "model_struct.h"
 #include "rmutil/alloc.h"
+#include "run_info.h"
+#include "stats.h"
 #include "util/arr_rm_alloc.h"
 #include "util/dict.h"
-#include "run_info.h"
+#include <pthread.h>
 
 RedisModuleType *RedisAI_ModelType = NULL;
 
-static void* RAI_Model_RdbLoad(struct RedisModuleIO *io, int encver) {
-  // if (encver != RAI_ENC_VER) {
-  //   /* We should actually log an error here, or try to implement
-  //      the ability to load older versions of our data structure. */
-  //   return NULL;
-  // }
+static void *RAI_Model_RdbLoad(struct RedisModuleIO *io, int encver) {
+    // if (encver != RAI_ENC_VER) {
+    //   /* We should actually log an error here, or try to implement
+    //      the ability to load older versions of our data structure. */
+    //   return NULL;
+    // }
 
-  RAI_Backend backend = RedisModule_LoadUnsigned(io);
-  const char *devicestr = RedisModule_LoadStringBuffer(io, NULL);
+    RAI_Backend backend = RedisModule_LoadUnsigned(io);
+    const char *devicestr = RedisModule_LoadStringBuffer(io, NULL);
 
-  const char *tag = RedisModule_LoadStringBuffer(io, NULL);
+    const char *tag = RedisModule_LoadStringBuffer(io, NULL);
 
-  const size_t batchsize = RedisModule_LoadUnsigned(io);
-  const size_t minbatchsize = RedisModule_LoadUnsigned(io);
+    const size_t batchsize = RedisModule_LoadUnsigned(io);
+    const size_t minbatchsize = RedisModule_LoadUnsigned(io);
 
-  const size_t ninputs = RedisModule_LoadUnsigned(io);
-  const char **inputs = RedisModule_Alloc(ninputs * sizeof(char*));
+    const size_t ninputs = RedisModule_LoadUnsigned(io);
+    const char **inputs = RedisModule_Alloc(ninputs * sizeof(char *));
 
-  for (size_t i=0; i<ninputs; i++) {
-    inputs[i] = RedisModule_LoadStringBuffer(io, NULL);
-  }
-
-  const size_t noutputs = RedisModule_LoadUnsigned(io);
-
-  const char **outputs = RedisModule_Alloc(ninputs * sizeof(char*));
-
-  for (size_t i=0; i<noutputs; i++) {
-    outputs[i] = RedisModule_LoadStringBuffer(io, NULL);
-  }
-
-  RAI_ModelOpts opts = {
-    .batchsize = batchsize,
-    .minbatchsize = minbatchsize,
-    .backends_intra_op_parallelism = getBackendsIntraOpParallelism(),
-    .backends_inter_op_parallelism = getBackendsInterOpParallelism(),
-  };
-
-  size_t len;
-  char *buffer = NULL;
-
-  if (encver <= 100) {
-    buffer = RedisModule_LoadStringBuffer(io, &len);
-  }
-  else {
-    len = RedisModule_LoadUnsigned(io);
-    buffer = RedisModule_Alloc(len);
-    const size_t n_chunks = RedisModule_LoadUnsigned(io);
-    long long chunk_offset = 0;
-    for (size_t i=0; i<n_chunks; i++) {
-      size_t chunk_len;
-      char *chunk_buffer = RedisModule_LoadStringBuffer(io, &chunk_len);
-      memcpy(buffer + chunk_offset, chunk_buffer, chunk_len);
-      chunk_offset += chunk_len;
-      RedisModule_Free(chunk_buffer);
+    for (size_t i = 0; i < ninputs; i++) {
+        inputs[i] = RedisModule_LoadStringBuffer(io, NULL);
     }
-  }
 
-  RAI_Error err = {0};
+    const size_t noutputs = RedisModule_LoadUnsigned(io);
 
-  RAI_Model *model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs, outputs,
-                                     buffer, len, &err);
+    const char **outputs = RedisModule_Alloc(ninputs * sizeof(char *));
 
-  if (err.code == RAI_EBACKENDNOTLOADED) {
-    RedisModuleCtx* ctx = RedisModule_GetContextFromIO(io);
-    int ret = RAI_LoadDefaultBackend(ctx, backend);
-    if (ret == REDISMODULE_ERR) {
-      RedisModule_Log(ctx, "error", "Could not load default backend");
-      RAI_ClearError(&err);
-      return NULL;
+    for (size_t i = 0; i < noutputs; i++) {
+        outputs[i] = RedisModule_LoadStringBuffer(io, NULL);
     }
-    RAI_ClearError(&err);
-    model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs, outputs, buffer, len, &err);
-  }
- 
-  if (err.code != RAI_OK) {
-    RedisModuleCtx* ctx = RedisModule_GetContextFromIO(io);
-    RedisModule_Log(ctx, "error", "%s", err.detail);
-    RAI_ClearError(&err);
-    if (buffer) {
-      RedisModule_Free(buffer);
+
+    RAI_ModelOpts opts = {
+        .batchsize = batchsize,
+        .minbatchsize = minbatchsize,
+        .backends_intra_op_parallelism = getBackendsIntraOpParallelism(),
+        .backends_inter_op_parallelism = getBackendsInterOpParallelism(),
+    };
+
+    size_t len;
+    char *buffer = NULL;
+
+    if (encver <= 100) {
+        buffer = RedisModule_LoadStringBuffer(io, &len);
+    } else {
+        len = RedisModule_LoadUnsigned(io);
+        buffer = RedisModule_Alloc(len);
+        const size_t n_chunks = RedisModule_LoadUnsigned(io);
+        long long chunk_offset = 0;
+        for (size_t i = 0; i < n_chunks; i++) {
+            size_t chunk_len;
+            char *chunk_buffer = RedisModule_LoadStringBuffer(io, &chunk_len);
+            memcpy(buffer + chunk_offset, chunk_buffer, chunk_len);
+            chunk_offset += chunk_len;
+            RedisModule_Free(chunk_buffer);
+        }
     }
-    return NULL;
-  }
 
-  RedisModule_Free(inputs);
-  RedisModule_Free(outputs);
-  RedisModule_Free(buffer);
+    RAI_Error err = {0};
 
-  RedisModuleCtx* stats_ctx = RedisModule_GetContextFromIO(io);
-  RedisModuleString* stats_keystr = RedisModule_CreateStringFromString(stats_ctx,
-                                                                       RedisModule_GetKeyNameFromIO(io));
-  const char* stats_devicestr = RedisModule_Strdup(devicestr);
-  const char* stats_tag = RedisModule_Strdup(tag);
+    RAI_Model *model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs,
+                                       outputs, buffer, len, &err);
 
-  model->infokey = RAI_AddStatsEntry(stats_ctx, stats_keystr, RAI_MODEL, backend, stats_devicestr, stats_tag);
+    if (err.code == RAI_EBACKENDNOTLOADED) {
+        RedisModuleCtx *ctx = RedisModule_GetContextFromIO(io);
+        int ret = RAI_LoadDefaultBackend(ctx, backend);
+        if (ret == REDISMODULE_ERR) {
+            RedisModule_Log(ctx, "error", "Could not load default backend");
+            RAI_ClearError(&err);
+            return NULL;
+        }
+        RAI_ClearError(&err);
+        model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs, outputs,
+                                buffer, len, &err);
+    }
 
-  RedisModule_Free(stats_keystr);
+    if (err.code != RAI_OK) {
+        RedisModuleCtx *ctx = RedisModule_GetContextFromIO(io);
+        RedisModule_Log(ctx, "error", "%s", err.detail);
+        RAI_ClearError(&err);
+        if (buffer) {
+            RedisModule_Free(buffer);
+        }
+        return NULL;
+    }
 
-  return model;
+    RedisModule_Free(inputs);
+    RedisModule_Free(outputs);
+    RedisModule_Free(buffer);
+
+    RedisModuleCtx *stats_ctx = RedisModule_GetContextFromIO(io);
+    RedisModuleString *stats_keystr =
+        RedisModule_CreateStringFromString(stats_ctx, RedisModule_GetKeyNameFromIO(io));
+    const char *stats_devicestr = RedisModule_Strdup(devicestr);
+    const char *stats_tag = RedisModule_Strdup(tag);
+
+    model->infokey =
+        RAI_AddStatsEntry(stats_ctx, stats_keystr, RAI_MODEL, backend, stats_devicestr, stats_tag);
+
+    RedisModule_Free(stats_keystr);
+
+    return model;
 }
 
 static void RAI_Model_RdbSave(RedisModuleIO *io, void *value) {
-  RAI_Model *model = (RAI_Model*)value;
-  char *buffer = NULL;
-  size_t len = 0;
-  RAI_Error err = {0};
+    RAI_Model *model = (RAI_Model *)value;
+    char *buffer = NULL;
+    size_t len = 0;
+    RAI_Error err = {0};
 
-  int ret = RAI_ModelSerialize(model, &buffer, &len, &err);
+    int ret = RAI_ModelSerialize(model, &buffer, &len, &err);
 
-  if (err.code != RAI_OK) {
-    RedisModuleCtx* stats_ctx = RedisModule_GetContextFromIO(io);
-    printf("ERR: %s\n", err.detail);
-    RAI_ClearError(&err);
-    if (buffer) {
-      RedisModule_Free(buffer);
+    if (err.code != RAI_OK) {
+        RedisModuleCtx *stats_ctx = RedisModule_GetContextFromIO(io);
+        printf("ERR: %s\n", err.detail);
+        RAI_ClearError(&err);
+        if (buffer) {
+            RedisModule_Free(buffer);
+        }
+        return;
     }
-    return;
-  }
 
-  RedisModule_SaveUnsigned(io, model->backend);
-  RedisModule_SaveStringBuffer(io, model->devicestr, strlen(model->devicestr) + 1);
-  RedisModule_SaveStringBuffer(io, model->tag, strlen(model->tag) + 1);
-  RedisModule_SaveUnsigned(io, model->opts.batchsize);
-  RedisModule_SaveUnsigned(io, model->opts.minbatchsize);
-  RedisModule_SaveUnsigned(io, model->ninputs);
-  for (size_t i=0; i<model->ninputs; i++) {
-    RedisModule_SaveStringBuffer(io, model->inputs[i], strlen(model->inputs[i]) + 1);
-  }
-  RedisModule_SaveUnsigned(io, model->noutputs);
-  for (size_t i=0; i<model->noutputs; i++) {
-    RedisModule_SaveStringBuffer(io, model->outputs[i], strlen(model->outputs[i]) + 1);
-  }
-  long long chunk_size = getModelChunkSize();
-  const size_t n_chunks = len / chunk_size + 1;
-  RedisModule_SaveUnsigned(io, len);
-  RedisModule_SaveUnsigned(io, n_chunks);
-  for (size_t i=0; i<n_chunks; i++) {
-    size_t chunk_len = i < n_chunks - 1 ? chunk_size : len % chunk_size;
-    RedisModule_SaveStringBuffer(io, buffer + i * chunk_size, chunk_len);
-  }
+    RedisModule_SaveUnsigned(io, model->backend);
+    RedisModule_SaveStringBuffer(io, model->devicestr, strlen(model->devicestr) + 1);
+    RedisModule_SaveStringBuffer(io, model->tag, strlen(model->tag) + 1);
+    RedisModule_SaveUnsigned(io, model->opts.batchsize);
+    RedisModule_SaveUnsigned(io, model->opts.minbatchsize);
+    RedisModule_SaveUnsigned(io, model->ninputs);
+    for (size_t i = 0; i < model->ninputs; i++) {
+        RedisModule_SaveStringBuffer(io, model->inputs[i], strlen(model->inputs[i]) + 1);
+    }
+    RedisModule_SaveUnsigned(io, model->noutputs);
+    for (size_t i = 0; i < model->noutputs; i++) {
+        RedisModule_SaveStringBuffer(io, model->outputs[i], strlen(model->outputs[i]) + 1);
+    }
+    long long chunk_size = getModelChunkSize();
+    const size_t n_chunks = len / chunk_size + 1;
+    RedisModule_SaveUnsigned(io, len);
+    RedisModule_SaveUnsigned(io, n_chunks);
+    for (size_t i = 0; i < n_chunks; i++) {
+        size_t chunk_len = i < n_chunks - 1 ? chunk_size : len % chunk_size;
+        RedisModule_SaveStringBuffer(io, buffer + i * chunk_size, chunk_len);
+    }
 
-  if (buffer) {
-    RedisModule_Free(buffer);
-  }
+    if (buffer) {
+        RedisModule_Free(buffer);
+    }
 }
 
 static void RAI_Model_AofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *value) {
-  RAI_Model *model = (RAI_Model*)value;
+    RAI_Model *model = (RAI_Model *)value;
 
-  char *buffer = NULL;
-  size_t len = 0;
-  RAI_Error err = {0};
+    char *buffer = NULL;
+    size_t len = 0;
+    RAI_Error err = {0};
 
-  int ret = RAI_ModelSerialize(model, &buffer, &len, &err);
+    int ret = RAI_ModelSerialize(model, &buffer, &len, &err);
 
-  if (err.code != RAI_OK) {
-    
-    printf("ERR: %s\n", err.detail);
-    RAI_ClearError(&err);
-    if (buffer) {
-      RedisModule_Free(buffer);
+    if (err.code != RAI_OK) {
+
+        printf("ERR: %s\n", err.detail);
+        RAI_ClearError(&err);
+        if (buffer) {
+            RedisModule_Free(buffer);
+        }
+        return;
     }
-    return;
-  }
 
-  // AI.MODELSET model_key backend device [INPUTS name1 name2 ... OUTPUTS name1 name2 ...] model_blob
+    // AI.MODELSET model_key backend device [INPUTS name1 name2 ... OUTPUTS name1
+    // name2 ...] model_blob
 
-  RedisModuleString **inputs_ = array_new(RedisModuleString*, model->ninputs);
-  RedisModuleString **outputs_ = array_new(RedisModuleString*, model->noutputs);
+    RedisModuleString **inputs_ = array_new(RedisModuleString *, model->ninputs);
+    RedisModuleString **outputs_ = array_new(RedisModuleString *, model->noutputs);
 
-  RedisModuleCtx *ctx = RedisModule_GetContextFromIO(aof);
+    RedisModuleCtx *ctx = RedisModule_GetContextFromIO(aof);
 
-  for (size_t i=0; i<model->ninputs; i++) {
-    inputs_ = array_append(inputs_, RedisModule_CreateString(ctx, model->inputs[i], strlen(model->inputs[i])));
-  }
+    for (size_t i = 0; i < model->ninputs; i++) {
+        inputs_ = array_append(
+            inputs_, RedisModule_CreateString(ctx, model->inputs[i], strlen(model->inputs[i])));
+    }
 
-  for (size_t i=0; i<model->noutputs; i++) {
-    outputs_ = array_append(outputs_, RedisModule_CreateString(ctx, model->outputs[i], strlen(model->outputs[i])));
-  }
+    for (size_t i = 0; i < model->noutputs; i++) {
+        outputs_ = array_append(
+            outputs_, RedisModule_CreateString(ctx, model->outputs[i], strlen(model->outputs[i])));
+    }
 
-  long long chunk_size = getModelChunkSize();
-  const size_t n_chunks = len / chunk_size + 1;
-  RedisModuleString **buffers_ = array_new(RedisModuleString*, n_chunks);
+    long long chunk_size = getModelChunkSize();
+    const size_t n_chunks = len / chunk_size + 1;
+    RedisModuleString **buffers_ = array_new(RedisModuleString *, n_chunks);
 
-  for (size_t i=0; i<n_chunks; i++) {
-    size_t chunk_len = i < n_chunks - 1 ? chunk_size : len % chunk_size;
-    buffers_ = array_append(buffers_, RedisModule_CreateString(ctx, buffer + i * chunk_size, chunk_len));
-  }
+    for (size_t i = 0; i < n_chunks; i++) {
+        size_t chunk_len = i < n_chunks - 1 ? chunk_size : len % chunk_size;
+        buffers_ = array_append(buffers_,
+                                RedisModule_CreateString(ctx, buffer + i * chunk_size, chunk_len));
+    }
 
-  if (buffer) {
-    RedisModule_Free(buffer);
-  }
+    if (buffer) {
+        RedisModule_Free(buffer);
+    }
 
-  const char* backendstr = RAI_BackendName(model->backend);
+    const char *backendstr = RAI_BackendName(model->backend);
 
-  RedisModule_EmitAOF(aof, "AI.MODELSET", "slccclclcvcvcv",
-                      key,
-                      backendstr, model->devicestr, model->tag,
-                      "BATCHSIZE", model->opts.batchsize,
-                      "MINBATCHSIZE", model->opts.minbatchsize,
-                      "INPUTS", inputs_, model->ninputs,
-                      "OUTPUTS", outputs_, model->noutputs,
-                      "BLOB", buffers_, n_chunks);
+    RedisModule_EmitAOF(aof, "AI.MODELSET", "slccclclcvcvcv", key, backendstr, model->devicestr,
+                        model->tag, "BATCHSIZE", model->opts.batchsize, "MINBATCHSIZE",
+                        model->opts.minbatchsize, "INPUTS", inputs_, model->ninputs, "OUTPUTS",
+                        outputs_, model->noutputs, "BLOB", buffers_, n_chunks);
 
-  for (size_t i=0; i<model->ninputs; i++) {
-    RedisModule_FreeString(ctx, inputs_[i]);
-  }
-  array_free(inputs_);
+    for (size_t i = 0; i < model->ninputs; i++) {
+        RedisModule_FreeString(ctx, inputs_[i]);
+    }
+    array_free(inputs_);
 
-  for (size_t i=0; i<model->noutputs; i++) {
-    RedisModule_FreeString(ctx, outputs_[i]);
-  }
-  array_free(outputs_);
+    for (size_t i = 0; i < model->noutputs; i++) {
+        RedisModule_FreeString(ctx, outputs_[i]);
+    }
+    array_free(outputs_);
 
-  for (size_t i=0; i<n_chunks; i++) {
-    RedisModule_FreeString(ctx, buffers_[i]);
-  }
-  array_free(buffers_);
+    for (size_t i = 0; i < n_chunks; i++) {
+        RedisModule_FreeString(ctx, buffers_[i]);
+    }
+    array_free(buffers_);
 }
-
 
 /* Return REDISMODULE_ERR if there was an error getting the Model.
  * Return REDISMODULE_OK if the model value stored at key was correctly
  * returned and available at *model variable. */
-int RAI_GetModelFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
-                              RedisModuleKey **key, RAI_Model **model,
-                              int mode) {
-  *key = RedisModule_OpenKey(ctx, keyName, mode);
-  if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) {
-    RedisModule_CloseKey(*key);
-    RedisModule_ReplyWithError(ctx, "ERR model key is empty");
-    return REDISMODULE_ERR;
-  }
-  if (RedisModule_ModuleTypeGetType(*key) != RedisAI_ModelType) {
-    RedisModule_CloseKey(*key);
-    RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-    return REDISMODULE_ERR;
-  }
-  *model = RedisModule_ModuleTypeGetValue(*key);
-  return REDISMODULE_OK;
+int RAI_GetModelFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key,
+                             RAI_Model **model, int mode) {
+    *key = RedisModule_OpenKey(ctx, keyName, mode);
+    if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) {
+        RedisModule_CloseKey(*key);
+        RedisModule_ReplyWithError(ctx, "ERR model key is empty");
+        return REDISMODULE_ERR;
+    }
+    if (RedisModule_ModuleTypeGetType(*key) != RedisAI_ModelType) {
+        RedisModule_CloseKey(*key);
+        RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        return REDISMODULE_ERR;
+    }
+    *model = RedisModule_ModuleTypeGetValue(*key);
+    return REDISMODULE_OK;
 }
 
 // TODO: pass err in?
 static void RAI_Model_DTFree(void *value) {
-  RAI_Error err = {0};
-  RAI_ModelFree(value, &err);
-  if (err.code != RAI_OK) {
-    printf("ERR: %s\n", err.detail);
-    RAI_ClearError(&err);
-  }
+    RAI_Error err = {0};
+    RAI_ModelFree(value, &err);
+    if (err.code != RAI_OK) {
+        printf("ERR: %s\n", err.detail);
+        RAI_ClearError(&err);
+    }
 }
 
-int RAI_ModelInit(RedisModuleCtx* ctx) {
-  RedisModuleTypeMethods tmModel = {
-      .version = REDISMODULE_TYPE_METHOD_VERSION,
-      .rdb_load = RAI_Model_RdbLoad,
-      .rdb_save = RAI_Model_RdbSave,
-      .aof_rewrite = RAI_Model_AofRewrite,
-      .mem_usage = NULL,
-      .free = RAI_Model_DTFree,
-      .digest = NULL
-  };
+int RAI_ModelInit(RedisModuleCtx *ctx) {
+    RedisModuleTypeMethods tmModel = {.version = REDISMODULE_TYPE_METHOD_VERSION,
+                                      .rdb_load = RAI_Model_RdbLoad,
+                                      .rdb_save = RAI_Model_RdbSave,
+                                      .aof_rewrite = RAI_Model_AofRewrite,
+                                      .mem_usage = NULL,
+                                      .free = RAI_Model_DTFree,
+                                      .digest = NULL};
 
-  RedisAI_ModelType = RedisModule_CreateDataType(ctx, "AI__MODEL", RAI_ENC_VER_MM, &tmModel);
-  return RedisAI_ModelType != NULL;
+    RedisAI_ModelType = RedisModule_CreateDataType(ctx, "AI__MODEL", RAI_ENC_VER_MM, &tmModel);
+    return RedisAI_ModelType != NULL;
 }
 
-RAI_Model *RAI_ModelCreate(RAI_Backend backend, const char* devicestr, const char* tag, RAI_ModelOpts opts,
-                           size_t ninputs, const char **inputs,
-                           size_t noutputs, const char **outputs,
-                           const char *modeldef, size_t modellen, RAI_Error* err) {
-  RAI_Model *model;
-  if (backend == RAI_BACKEND_TENSORFLOW) {
-    if (!RAI_backends.tf.model_create_with_nodes) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
-      return NULL;
+RAI_Model *RAI_ModelCreate(RAI_Backend backend, const char *devicestr, const char *tag,
+                           RAI_ModelOpts opts, size_t ninputs, const char **inputs, size_t noutputs,
+                           const char **outputs, const char *modeldef, size_t modellen,
+                           RAI_Error *err) {
+    RAI_Model *model;
+    if (backend == RAI_BACKEND_TENSORFLOW) {
+        if (!RAI_backends.tf.model_create_with_nodes) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
+            return NULL;
+        }
+        model = RAI_backends.tf.model_create_with_nodes(backend, devicestr, opts, ninputs, inputs,
+                                                        noutputs, outputs, modeldef, modellen, err);
+    } else if (backend == RAI_BACKEND_TFLITE) {
+        if (!RAI_backends.tflite.model_create) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
+            return NULL;
+        }
+        model = RAI_backends.tflite.model_create(backend, devicestr, opts, modeldef, modellen, err);
+    } else if (backend == RAI_BACKEND_TORCH) {
+        if (!RAI_backends.torch.model_create) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
+            return NULL;
+        }
+        model = RAI_backends.torch.model_create(backend, devicestr, opts, modeldef, modellen, err);
+    } else if (backend == RAI_BACKEND_ONNXRUNTIME) {
+        if (!RAI_backends.onnx.model_create) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
+            return NULL;
+        }
+        model = RAI_backends.onnx.model_create(backend, devicestr, opts, modeldef, modellen, err);
+    } else {
+        RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "ERR Unsupported backend");
+        return NULL;
     }
-    model = RAI_backends.tf.model_create_with_nodes(backend, devicestr, opts, ninputs, inputs, noutputs, outputs, modeldef, modellen, err);
-  }
-  else if (backend == RAI_BACKEND_TFLITE) {
-    if (!RAI_backends.tflite.model_create) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
-      return NULL;
-    }
-    model = RAI_backends.tflite.model_create(backend, devicestr, opts, modeldef, modellen, err);
-  }
-  else if (backend == RAI_BACKEND_TORCH) {
-    if (!RAI_backends.torch.model_create) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
-      return NULL;
-    }
-    model = RAI_backends.torch.model_create(backend, devicestr, opts, modeldef, modellen, err);
-  }
-  else if (backend == RAI_BACKEND_ONNXRUNTIME) {
-    if (!RAI_backends.onnx.model_create) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
-      return NULL;
-    }
-    model = RAI_backends.onnx.model_create(backend, devicestr, opts, modeldef, modellen, err);
-  }
-  else {
-    RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "ERR Unsupported backend");
-    return NULL;
-  }
 
-  if (model) {
-    model->tag = RedisModule_Strdup(tag);
-  }
+    if (model) {
+        model->tag = RedisModule_Strdup(tag);
+    }
 
-  return model;
+    return model;
 }
 
-void RAI_ModelFree(RAI_Model* model, RAI_Error* err) {
-  if (__atomic_sub_fetch(&model->refCount, 1, __ATOMIC_RELAXED) > 0){
-    return;
-  }
-
-  if (model->backend == RAI_BACKEND_TENSORFLOW) {
-    if (!RAI_backends.tf.model_free) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
-      return;
+void RAI_ModelFree(RAI_Model *model, RAI_Error *err) {
+    if (__atomic_sub_fetch(&model->refCount, 1, __ATOMIC_RELAXED) > 0) {
+        return;
     }
-    RAI_backends.tf.model_free(model, err);
-  }
-  else if (model->backend == RAI_BACKEND_TFLITE) {
-    if (!RAI_backends.tflite.model_free) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
-      return;
-    }
-    RAI_backends.tflite.model_free(model, err);
-  }
-  else if (model->backend == RAI_BACKEND_TORCH) {
-    if (!RAI_backends.torch.model_free) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
-      return;
-    }
-    RAI_backends.torch.model_free(model, err);
-  }
-  else if (model->backend == RAI_BACKEND_ONNXRUNTIME) {
-    if (!RAI_backends.onnx.model_free) {
-      RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
-      return;
-    }
-    RAI_backends.onnx.model_free(model, err);
-  }
-  else {
-    RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "Unsupported backend");
-    return;
-  }
 
-  RedisModule_Free(model->tag);
+    if (model->backend == RAI_BACKEND_TENSORFLOW) {
+        if (!RAI_backends.tf.model_free) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
+            return;
+        }
+        RAI_backends.tf.model_free(model, err);
+    } else if (model->backend == RAI_BACKEND_TFLITE) {
+        if (!RAI_backends.tflite.model_free) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
+            return;
+        }
+        RAI_backends.tflite.model_free(model, err);
+    } else if (model->backend == RAI_BACKEND_TORCH) {
+        if (!RAI_backends.torch.model_free) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
+            return;
+        }
+        RAI_backends.torch.model_free(model, err);
+    } else if (model->backend == RAI_BACKEND_ONNXRUNTIME) {
+        if (!RAI_backends.onnx.model_free) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
+            return;
+        }
+        RAI_backends.onnx.model_free(model, err);
+    } else {
+        RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "Unsupported backend");
+        return;
+    }
 
-  RAI_RemoveStatsEntry(model->infokey);
+    RedisModule_Free(model->tag);
 
-  RedisModule_Free(model);
+    RAI_RemoveStatsEntry(model->infokey);
+
+    RedisModule_Free(model);
 }
 
-RAI_ModelRunCtx* RAI_ModelRunCtxCreate(RAI_Model* model) {
+RAI_ModelRunCtx *RAI_ModelRunCtxCreate(RAI_Model *model) {
 #define PARAM_INITIAL_SIZE 10
-  RAI_ModelRunCtx* mctx = RedisModule_Calloc(1, sizeof(*mctx));
-  mctx->model = RAI_ModelGetShallowCopy(model);
-  mctx->inputs = array_new(RAI_ModelCtxParam, PARAM_INITIAL_SIZE);
-  mctx->outputs = array_new(RAI_ModelCtxParam, PARAM_INITIAL_SIZE);
-  return mctx;
+    RAI_ModelRunCtx *mctx = RedisModule_Calloc(1, sizeof(*mctx));
+    mctx->model = RAI_ModelGetShallowCopy(model);
+    mctx->inputs = array_new(RAI_ModelCtxParam, PARAM_INITIAL_SIZE);
+    mctx->outputs = array_new(RAI_ModelCtxParam, PARAM_INITIAL_SIZE);
+    return mctx;
 #undef PARAM_INITIAL_SIZE
 }
 
-static int Model_RunCtxAddParam(RAI_ModelRunCtx* mctx, RAI_ModelCtxParam** paramArr,
-                                const char* name, RAI_Tensor* tensor) {
+static int Model_RunCtxAddParam(RAI_ModelRunCtx *mctx, RAI_ModelCtxParam **paramArr,
+                                const char *name, RAI_Tensor *tensor) {
 
-  RAI_ModelCtxParam param = {
-      .name = name,
-      .tensor = tensor ? RAI_TensorGetShallowCopy(tensor): NULL,
-  };
-  *paramArr = array_append(*paramArr, param);
-  return 1;
+    RAI_ModelCtxParam param = {
+        .name = name,
+        .tensor = tensor ? RAI_TensorGetShallowCopy(tensor) : NULL,
+    };
+    *paramArr = array_append(*paramArr, param);
+    return 1;
 }
 
-int RAI_ModelRunCtxAddInput(RAI_ModelRunCtx* mctx, const char* inputName, RAI_Tensor* inputTensor) {
-  return Model_RunCtxAddParam(mctx, &mctx->inputs, inputName, inputTensor);
+int RAI_ModelRunCtxAddInput(RAI_ModelRunCtx *mctx, const char *inputName, RAI_Tensor *inputTensor) {
+    return Model_RunCtxAddParam(mctx, &mctx->inputs, inputName, inputTensor);
 }
 
-int RAI_ModelRunCtxAddOutput(RAI_ModelRunCtx* mctx, const char* outputName) {
-  return Model_RunCtxAddParam(mctx, &mctx->outputs, outputName, NULL);
+int RAI_ModelRunCtxAddOutput(RAI_ModelRunCtx *mctx, const char *outputName) {
+    return Model_RunCtxAddParam(mctx, &mctx->outputs, outputName, NULL);
 }
 
-size_t RAI_ModelRunCtxNumInputs(RAI_ModelRunCtx* mctx) {
-  return array_len(mctx->inputs);
+size_t RAI_ModelRunCtxNumInputs(RAI_ModelRunCtx *mctx) { return array_len(mctx->inputs); }
+
+size_t RAI_ModelRunCtxNumOutputs(RAI_ModelRunCtx *mctx) { return array_len(mctx->outputs); }
+
+RAI_Tensor *RAI_ModelRunCtxInputTensor(RAI_ModelRunCtx *mctx, size_t index) {
+    assert(RAI_ModelRunCtxNumInputs(mctx) > index && index >= 0);
+    return mctx->inputs[index].tensor;
 }
 
-size_t RAI_ModelRunCtxNumOutputs(RAI_ModelRunCtx* mctx) {
-  return array_len(mctx->outputs);
+RAI_Tensor *RAI_ModelRunCtxOutputTensor(RAI_ModelRunCtx *mctx, size_t index) {
+    assert(RAI_ModelRunCtxNumOutputs(mctx) > index && index >= 0);
+    return mctx->outputs[index].tensor;
 }
 
-RAI_Tensor* RAI_ModelRunCtxInputTensor(RAI_ModelRunCtx* mctx, size_t index) {
-  assert(RAI_ModelRunCtxNumInputs(mctx) > index && index >= 0);
-  return mctx->inputs[index].tensor;
-}
+void RAI_ModelRunCtxFree(RAI_ModelRunCtx *mctx, int freeTensors) {
+    if (freeTensors) {
+        for (size_t i = 0; i < array_len(mctx->inputs); ++i) {
+            RAI_TensorFree(mctx->inputs[i].tensor);
+        }
 
-RAI_Tensor* RAI_ModelRunCtxOutputTensor(RAI_ModelRunCtx* mctx, size_t index) {
-  assert(RAI_ModelRunCtxNumOutputs(mctx) > index && index >= 0);
-  return mctx->outputs[index].tensor;
-}
-
-void RAI_ModelRunCtxFree(RAI_ModelRunCtx* mctx, int freeTensors) {
-  if (freeTensors) {
-    for (size_t i=0; i<array_len(mctx->inputs); ++i) {
-      RAI_TensorFree(mctx->inputs[i].tensor);
+        for (size_t i = 0; i < array_len(mctx->outputs); ++i) {
+            if (mctx->outputs[i].tensor) {
+                RAI_TensorFree(mctx->outputs[i].tensor);
+            }
+        }
     }
 
-    for (size_t i = 0 ; i < array_len(mctx->outputs) ; ++i) {
-      if (mctx->outputs[i].tensor) {
-        RAI_TensorFree(mctx->outputs[i].tensor);
-      }
+    array_free(mctx->inputs);
+    array_free(mctx->outputs);
+
+    RAI_Error err = {0};
+    RAI_ModelFree(mctx->model, &err);
+
+    if (err.code != RAI_OK) {
+        // TODO: take it to client somehow
+        RAI_ClearError(&err);
     }
-  }
 
-  array_free(mctx->inputs);
-  array_free(mctx->outputs);
-
-  RAI_Error err = {0};
-  RAI_ModelFree(mctx->model, &err);
-
-  if (err.code != RAI_OK) {
-    // TODO: take it to client somehow
-    RAI_ClearError(&err);
-  }
-
-  RedisModule_Free(mctx);
+    RedisModule_Free(mctx);
 }
 
-int RAI_ModelRun(RAI_ModelRunCtx** mctxs, long long n, RAI_Error* err) {
-  int ret;
+int RAI_ModelRun(RAI_ModelRunCtx **mctxs, long long n, RAI_Error *err) {
+    int ret;
 
-  if (n == 0) {
-    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Nothing to run");
-    return REDISMODULE_ERR;
-  }
+    if (n == 0) {
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Nothing to run");
+        return REDISMODULE_ERR;
+    }
 
-  RAI_ModelRunCtx** mctxs_arr = array_newlen(RAI_ModelRunCtx*, n);
-  for (int i=0; i<n; i++) {
-    mctxs_arr[i] = mctxs[i];
-  }
+    RAI_ModelRunCtx **mctxs_arr = array_newlen(RAI_ModelRunCtx *, n);
+    for (int i = 0; i < n; i++) {
+        mctxs_arr[i] = mctxs[i];
+    }
 
-  switch (mctxs_arr[0]->model->backend) {
+    switch (mctxs_arr[0]->model->backend) {
     case RAI_BACKEND_TENSORFLOW:
-      if (!RAI_backends.tf.model_run) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
-        return REDISMODULE_ERR;
-      }
-      ret = RAI_backends.tf.model_run(mctxs_arr, err);
-      break;
+        if (!RAI_backends.tf.model_run) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
+            return REDISMODULE_ERR;
+        }
+        ret = RAI_backends.tf.model_run(mctxs_arr, err);
+        break;
     case RAI_BACKEND_TFLITE:
-      if (!RAI_backends.tflite.model_run) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
-        return REDISMODULE_ERR;
-      }
-      ret = RAI_backends.tflite.model_run(mctxs_arr, err);
-      break;
+        if (!RAI_backends.tflite.model_run) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
+            return REDISMODULE_ERR;
+        }
+        ret = RAI_backends.tflite.model_run(mctxs_arr, err);
+        break;
     case RAI_BACKEND_TORCH:
-      if (!RAI_backends.torch.model_run) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
-        return REDISMODULE_ERR;
-      }
-      ret = RAI_backends.torch.model_run(mctxs_arr, err);
-      break;
+        if (!RAI_backends.torch.model_run) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
+            return REDISMODULE_ERR;
+        }
+        ret = RAI_backends.torch.model_run(mctxs_arr, err);
+        break;
     case RAI_BACKEND_ONNXRUNTIME:
-      if (!RAI_backends.onnx.model_run) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
-        return REDISMODULE_ERR;
-      }
-      ret = RAI_backends.onnx.model_run(mctxs_arr, err);
-      break;
+        if (!RAI_backends.onnx.model_run) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
+            return REDISMODULE_ERR;
+        }
+        ret = RAI_backends.onnx.model_run(mctxs_arr, err);
+        break;
     default:
-      RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "ERR Unsupported backend");
-      return REDISMODULE_ERR;
-  }
+        RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "ERR Unsupported backend");
+        return REDISMODULE_ERR;
+    }
 
-  array_free(mctxs_arr);
+    array_free(mctxs_arr);
 
-  return ret;
+    return ret;
 }
 
-RAI_Model* RAI_ModelGetShallowCopy(RAI_Model* model) {
-  __atomic_fetch_add(&model->refCount, 1, __ATOMIC_RELAXED);  
-  return model;
+RAI_Model *RAI_ModelGetShallowCopy(RAI_Model *model) {
+    __atomic_fetch_add(&model->refCount, 1, __ATOMIC_RELAXED);
+    return model;
 }
 
 int RAI_ModelSerialize(RAI_Model *model, char **buffer, size_t *len, RAI_Error *err) {
-  int ret;
+    int ret;
 
-  switch (model->backend) {
+    switch (model->backend) {
     case RAI_BACKEND_TENSORFLOW:
-      if (!RAI_backends.tf.model_serialize) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
-        return REDISMODULE_ERR;
-      }
-      ret = RAI_backends.tf.model_serialize(model, buffer, len, err);
-      break;
+        if (!RAI_backends.tf.model_serialize) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TF");
+            return REDISMODULE_ERR;
+        }
+        ret = RAI_backends.tf.model_serialize(model, buffer, len, err);
+        break;
     case RAI_BACKEND_TFLITE:
-      if (!RAI_backends.tflite.model_serialize) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
-        return REDISMODULE_ERR;
-      }
-      ret = RAI_backends.tflite.model_serialize(model, buffer, len, err);
-      break;
+        if (!RAI_backends.tflite.model_serialize) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TFLITE");
+            return REDISMODULE_ERR;
+        }
+        ret = RAI_backends.tflite.model_serialize(model, buffer, len, err);
+        break;
     case RAI_BACKEND_TORCH:
-      if (!RAI_backends.torch.model_serialize) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
-        return REDISMODULE_ERR;
-      }
-      ret = RAI_backends.torch.model_serialize(model, buffer, len, err);
-      break;
+        if (!RAI_backends.torch.model_serialize) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
+            return REDISMODULE_ERR;
+        }
+        ret = RAI_backends.torch.model_serialize(model, buffer, len, err);
+        break;
     case RAI_BACKEND_ONNXRUNTIME:
-      if (!RAI_backends.onnx.model_serialize) {
-        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
-        return REDISMODULE_ERR;
-      }
-      ret = RAI_backends.onnx.model_serialize(model, buffer, len, err);
-      break;
+        if (!RAI_backends.onnx.model_serialize) {
+            RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: ONNX");
+            return REDISMODULE_ERR;
+        }
+        ret = RAI_backends.onnx.model_serialize(model, buffer, len, err);
+        break;
     default:
-      RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "ERR Unsupported backend");
-      return REDISMODULE_ERR;
-  }
-
-  return ret;
-}
-
-int RedisAI_ModelRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
-                                                    RedisModuleString **argv, int argc){
-  RedisModule_KeyAtPos(ctx, 1);
-  size_t startpos = 2;
-  if (startpos >= argc) {
-    return REDISMODULE_ERR;
-  }
-  const char *str = RedisModule_StringPtrLen(argv[startpos], NULL);
-  if (!strcasecmp(str, "TIMEOUT")) {
-    startpos += 2;
-  }
-  startpos += 1;
-  if (startpos >= argc) {
-    return REDISMODULE_ERR;
-  }
-  for (size_t argpos = startpos; argpos < argc; argpos++){
-    str = RedisModule_StringPtrLen(argv[argpos], NULL);
-    if (!strcasecmp(str, "OUTPUTS")) {
-      continue;
+        RAI_SetError(err, RAI_EUNSUPPORTEDBACKEND, "ERR Unsupported backend");
+        return REDISMODULE_ERR;
     }
-    RedisModule_KeyAtPos(ctx,argpos);
-  }
-  return REDISMODULE_OK;
+
+    return ret;
 }
 
-int RedisAI_Parse_ModelRun_RedisCommand(RedisModuleCtx *ctx,
-                                        RedisModuleString **argv, int argc,
-                                        RAI_ModelRunCtx **mctx,
-                                        RedisModuleString ***inkeys,
-                                        RedisModuleString ***outkeys,
-                                        RAI_Model **mto,
+int RedisAI_ModelRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx, RedisModuleString **argv,
+                                                      int argc) {
+    RedisModule_KeyAtPos(ctx, 1);
+    size_t startpos = 2;
+    if (startpos >= argc) {
+        return REDISMODULE_ERR;
+    }
+    const char *str = RedisModule_StringPtrLen(argv[startpos], NULL);
+    if (!strcasecmp(str, "TIMEOUT")) {
+        startpos += 2;
+    }
+    startpos += 1;
+    if (startpos >= argc) {
+        return REDISMODULE_ERR;
+    }
+    for (size_t argpos = startpos; argpos < argc; argpos++) {
+        str = RedisModule_StringPtrLen(argv[argpos], NULL);
+        if (!strcasecmp(str, "OUTPUTS")) {
+            continue;
+        }
+        RedisModule_KeyAtPos(ctx, argpos);
+    }
+    return REDISMODULE_OK;
+}
+
+int RedisAI_Parse_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                                        RAI_ModelRunCtx **mctx, RedisModuleString ***inkeys,
+                                        RedisModuleString ***outkeys, RAI_Model **mto,
                                         RAI_Error *error) {
-  if (argc < 3) {
-    RAI_SetError(error, RAI_EMODELRUN,
-                 "ERR wrong number of arguments for 'AI.MODELRUN' command");
-    return -1;
-  }
-
-  const char *inputstr = RedisModule_StringPtrLen(argv[2], NULL);
-  if (strcasecmp(inputstr, "INPUTS")) {
-    RAI_SetError(error, RAI_EMODELRUN, "ERR INPUTS not specified");
-    return -1;
-  }
-
-  int is_input = 0;
-  size_t ninputs = 0;
-  size_t noutputs = 0;
-  int outputs_flag_count = 0;
-  size_t argpos = 3;
-
-  for (; argpos <= argc - 1; argpos++) {
-    const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
-    if (!strcasecmp(arg_string, "OUTPUTS") && outputs_flag_count == 0) {
-      is_input = 1;
-      outputs_flag_count = 1;
-    } else {
-      RedisModule_RetainString(ctx, argv[argpos]);
-      if (is_input == 0) {
-        *inkeys = array_append(*inkeys, argv[argpos]);
-        ninputs++;
-      } else {
-        *outkeys = array_append(*outkeys, argv[argpos]);
-        noutputs++;
-      }
+    if (argc < 3) {
+        RAI_SetError(error, RAI_EMODELRUN,
+                     "ERR wrong number of arguments for 'AI.MODELRUN' command");
+        return -1;
     }
-  }
-  if ((*mto)->inputs && array_len((*mto)->inputs) != ninputs) {
-    RAI_SetError(
-        error, RAI_EMODELRUN,
-        "Number of names given as INPUTS during MODELSET and keys given as "
-        "INPUTS here do not match");
-    return -1;
-  }
 
-  if ((*mto)->outputs && array_len((*mto)->outputs) != noutputs) {
-    RAI_SetError(
-        error, RAI_EMODELRUN,
-        "Number of names given as OUTPUTS during MODELSET and keys given as "
-        "OUTPUTS here do not match");
-    return -1;
-  }
-  return argpos;
+    const char *inputstr = RedisModule_StringPtrLen(argv[2], NULL);
+    if (strcasecmp(inputstr, "INPUTS")) {
+        RAI_SetError(error, RAI_EMODELRUN, "ERR INPUTS not specified");
+        return -1;
+    }
+
+    int is_input = 0;
+    size_t ninputs = 0;
+    size_t noutputs = 0;
+    int outputs_flag_count = 0;
+    size_t argpos = 3;
+
+    for (; argpos <= argc - 1; argpos++) {
+        const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
+        if (!strcasecmp(arg_string, "OUTPUTS") && outputs_flag_count == 0) {
+            is_input = 1;
+            outputs_flag_count = 1;
+        } else {
+            RedisModule_RetainString(ctx, argv[argpos]);
+            if (is_input == 0) {
+                *inkeys = array_append(*inkeys, argv[argpos]);
+                ninputs++;
+            } else {
+                *outkeys = array_append(*outkeys, argv[argpos]);
+                noutputs++;
+            }
+        }
+    }
+    if ((*mto)->inputs && array_len((*mto)->inputs) != ninputs) {
+        RAI_SetError(error, RAI_EMODELRUN,
+                     "Number of names given as INPUTS during MODELSET and keys given as "
+                     "INPUTS here do not match");
+        return -1;
+    }
+
+    if ((*mto)->outputs && array_len((*mto)->outputs) != noutputs) {
+        RAI_SetError(error, RAI_EMODELRUN,
+                     "Number of names given as OUTPUTS during MODELSET and keys given as "
+                     "OUTPUTS here do not match");
+        return -1;
+    }
+    return argpos;
 }
 
-RedisModuleType *RAI_ModelRedisType(void) {
-    return RedisAI_ModelType;
-}
+RedisModuleType *RAI_ModelRedisType(void) { return RedisAI_ModelType; }

--- a/src/model.h
+++ b/src/model.h
@@ -19,7 +19,7 @@
 #include "tensor.h"
 #include "util/dict.h"
 
-extern RedisModuleType* RedisAI_ModelType;
+extern RedisModuleType *RedisAI_ModelType;
 
 /**
  * Helper method to register the RedisModuleType type exported by the module.
@@ -27,7 +27,7 @@ extern RedisModuleType* RedisAI_ModelType;
  * @param ctx Context in which Redis modules operate
  * @return
  */
-int RAI_ModelInit(RedisModuleCtx* ctx);
+int RAI_ModelInit(RedisModuleCtx *ctx);
 
 /**
  * Helper method to allocated and initialize a RAI_Model. Depending on the
@@ -49,11 +49,10 @@ int RAI_ModelInit(RedisModuleCtx* ctx);
  * failures
  * @return RAI_Model model structure on success, or NULL if failed
  */
-RAI_Model* RAI_ModelCreate(RAI_Backend backend, const char* devicestr,
-                           const char* tag, RAI_ModelOpts opts, size_t ninputs,
-                           const char** inputs, size_t noutputs,
-                           const char** outputs, const char* modeldef,
-                           size_t modellen, RAI_Error* err);
+RAI_Model *RAI_ModelCreate(RAI_Backend backend, const char *devicestr, const char *tag,
+                           RAI_ModelOpts opts, size_t ninputs, const char **inputs, size_t noutputs,
+                           const char **outputs, const char *modeldef, size_t modellen,
+                           RAI_Error *err);
 
 /**
  * Frees the memory of the RAI_Model when the model reference count reaches
@@ -63,7 +62,7 @@ RAI_Model* RAI_ModelCreate(RAI_Backend backend, const char* devicestr,
  * @param error error data structure to store error message in the case of
  * failures
  */
-void RAI_ModelFree(RAI_Model* model, RAI_Error* err);
+void RAI_ModelFree(RAI_Model *model, RAI_Error *err);
 
 /**
  * Allocates the RAI_ModelRunCtx data structure required for async background
@@ -72,7 +71,7 @@ void RAI_ModelFree(RAI_Model* model, RAI_Error* err);
  * @param model input model
  * @return RAI_ModelRunCtx to be used within
  */
-RAI_ModelRunCtx* RAI_ModelRunCtxCreate(RAI_Model* model);
+RAI_ModelRunCtx *RAI_ModelRunCtxCreate(RAI_Model *model);
 
 /**
  * Frees the RAI_ModelRunCtx data structure used within for async background
@@ -81,7 +80,7 @@ RAI_ModelRunCtx* RAI_ModelRunCtxCreate(RAI_Model* model);
  * @param mctx
  * @param freeTensors free input and output tensors or leave them allocated
  */
-void RAI_ModelRunCtxFree(RAI_ModelRunCtx* mctx, int freeTensors);
+void RAI_ModelRunCtxFree(RAI_ModelRunCtx *mctx, int freeTensors);
 
 /**
  * Allocates a RAI_ModelCtxParam data structure, and enforces a shallow copy of
@@ -93,8 +92,7 @@ void RAI_ModelRunCtxFree(RAI_ModelRunCtx* mctx, int freeTensors);
  * @param inputTensor input tensor structure
  * @return returns 1 on success ( always returns success )
  */
-int RAI_ModelRunCtxAddInput(RAI_ModelRunCtx* mctx, const char* inputName,
-                            RAI_Tensor* inputTensor);
+int RAI_ModelRunCtxAddInput(RAI_ModelRunCtx *mctx, const char *inputName, RAI_Tensor *inputTensor);
 
 /**
  * Allocates a RAI_ModelCtxParam data structure, and sets the tensor reference
@@ -105,7 +103,7 @@ int RAI_ModelRunCtxAddInput(RAI_ModelRunCtx* mctx, const char* inputName,
  * @param outputName output tensor name
  * @return returns 1 on success ( always returns success )
  */
-int RAI_ModelRunCtxAddOutput(RAI_ModelRunCtx* mctx, const char* outputName);
+int RAI_ModelRunCtxAddOutput(RAI_ModelRunCtx *mctx, const char *outputName);
 
 /**
  * Returns the total number of input tensors of the RAI_ModelRunCtx
@@ -113,7 +111,7 @@ int RAI_ModelRunCtxAddOutput(RAI_ModelRunCtx* mctx, const char* outputName);
  * @param mctx RAI_ModelRunCtx
  * @return the total number of input tensors of the RAI_ModelRunCtx
  */
-size_t RAI_ModelRunCtxNumInputs(RAI_ModelRunCtx* mctx);
+size_t RAI_ModelRunCtxNumInputs(RAI_ModelRunCtx *mctx);
 
 /**
  * Returns the total number of output tensors of the RAI_ModelCtxParam
@@ -121,7 +119,7 @@ size_t RAI_ModelRunCtxNumInputs(RAI_ModelRunCtx* mctx);
  * @param mctx RAI_ModelRunCtx
  * @return the total number of output tensors of the RAI_ModelCtxParam
  */
-size_t RAI_ModelRunCtxNumOutputs(RAI_ModelRunCtx* mctx);
+size_t RAI_ModelRunCtxNumOutputs(RAI_ModelRunCtx *mctx);
 
 /**
  * Get the RAI_Tensor at the input array index position
@@ -130,7 +128,7 @@ size_t RAI_ModelRunCtxNumOutputs(RAI_ModelRunCtx* mctx);
  * @param index input array index position
  * @return RAI_Tensor
  */
-RAI_Tensor* RAI_ModelRunCtxInputTensor(RAI_ModelRunCtx* mctx, size_t index);
+RAI_Tensor *RAI_ModelRunCtxInputTensor(RAI_ModelRunCtx *mctx, size_t index);
 
 /**
  * Get the RAI_Tensor at the output array index position
@@ -139,7 +137,7 @@ RAI_Tensor* RAI_ModelRunCtxInputTensor(RAI_ModelRunCtx* mctx, size_t index);
  * @param index input array index position
  * @return RAI_Tensor
  */
-RAI_Tensor* RAI_ModelRunCtxOutputTensor(RAI_ModelRunCtx* mctx, size_t index);
+RAI_Tensor *RAI_ModelRunCtxOutputTensor(RAI_ModelRunCtx *mctx, size_t index);
 
 /**
  * Given the input array of mctxs, run the associated backend
@@ -157,7 +155,7 @@ RAI_Tensor* RAI_ModelRunCtxOutputTensor(RAI_ModelRunCtx* mctx, size_t index);
  * @return REDISMODULE_OK if the underlying backend `model_run` runned
  * successfully, or REDISMODULE_ERR if failed.
  */
-int RAI_ModelRun(RAI_ModelRunCtx** mctxs, long long n, RAI_Error* err);
+int RAI_ModelRun(RAI_ModelRunCtx **mctxs, long long n, RAI_Error *err);
 
 /**
  * Every call to this function, will make the RAI_Model 'model' requiring an
@@ -167,7 +165,7 @@ int RAI_ModelRun(RAI_ModelRunCtx** mctxs, long long n, RAI_Error* err);
  * @param input model
  * @return model
  */
-RAI_Model* RAI_ModelGetShallowCopy(RAI_Model* model);
+RAI_Model *RAI_ModelGetShallowCopy(RAI_Model *model);
 
 /**
  * Serializes a model given the RAI_Model pointer, saving the serialized data
@@ -181,8 +179,7 @@ RAI_Model* RAI_ModelGetShallowCopy(RAI_Model* model);
  * @return REDISMODULE_OK if the underlying backend `model_serialize` ran
  * successfully, or REDISMODULE_ERR if failed.
  * */
-int RAI_ModelSerialize(RAI_Model* model, char** buffer, size_t* len,
-                       RAI_Error* err);
+int RAI_ModelSerialize(RAI_Model *model, char **buffer, size_t *len, RAI_Error *err);
 
 /**
  * Helper method to get a Model from keyspace. In the case of failure the key is
@@ -198,8 +195,8 @@ int RAI_ModelSerialize(RAI_Model* model, char** buffer, size_t* len,
  * returned and available at *model variable, or REDISMODULE_ERR if there was
  * an error getting the Model
  */
-int RAI_GetModelFromKeyspace(RedisModuleCtx* ctx, RedisModuleString* keyName,
-                             RedisModuleKey** key, RAI_Model** model, int mode);
+int RAI_GetModelFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key,
+                             RAI_Model **model, int mode);
 
 /**
  * When a module command is called in order to obtain the position of
@@ -213,8 +210,8 @@ int RAI_GetModelFromKeyspace(RedisModuleCtx* ctx, RedisModuleString* keyName,
  * @param argc Redis command number of arguments
  * @return
  */
-int RedisAI_ModelRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
-                            RedisModuleString **argv, int argc);
+int RedisAI_ModelRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx, RedisModuleString **argv,
+                                                      int argc);
 
 /**
  * Helper method to parse AI.MODELRUN arguments
@@ -229,10 +226,10 @@ int RedisAI_ModelRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
  * parsing failures
  * @return processed number of arguments on success, or -1 if the parsing failed
  */
-int RedisAI_Parse_ModelRun_RedisCommand(
-    RedisModuleCtx* ctx, RedisModuleString** argv, int argc,
-    RAI_ModelRunCtx** mctx, RedisModuleString*** inkeys, RedisModuleString*** outkeys,
-    RAI_Model** mto, RAI_Error* error);
+int RedisAI_Parse_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                                        RAI_ModelRunCtx **mctx, RedisModuleString ***inkeys,
+                                        RedisModuleString ***outkeys, RAI_Model **mto,
+                                        RAI_Error *error);
 
 /**
  * @brief  Returns the redis module type representing a model.

--- a/src/model_struct.h
+++ b/src/model_struct.h
@@ -5,45 +5,45 @@
 #include "tensor_struct.h"
 
 typedef struct RAI_ModelOpts {
-  size_t batchsize;
-  size_t minbatchsize;
-  size_t minbatchtimeout;
-  long long backends_intra_op_parallelism;  //  number of threads used within an
-  //  individual op for parallelism.
-  long long backends_inter_op_parallelism;  //  number of threads used for parallelism
-                                            //  between independent operations.
+    size_t batchsize;
+    size_t minbatchsize;
+    size_t minbatchtimeout;
+    long long backends_intra_op_parallelism; //  number of threads used within an
+    //  individual op for parallelism.
+    long long backends_inter_op_parallelism; //  number of threads used for parallelism
+                                             //  between independent operations.
 } RAI_ModelOpts;
 
 typedef struct RAI_Model {
-  void* model;
-  // TODO: use session pool? The ideal would be to use one session per client.
-  //       If a client disconnects, we dispose the session or reuse it for
-  //       another client.
-  void *session;
-  RAI_Backend backend;
-  char* devicestr;
-  char* tag;
-  RAI_ModelOpts opts;
-  char **inputs;
-  size_t ninputs;
-  char **outputs;
-  size_t noutputs;
-  long long refCount;
-  char* data;
-  long long datalen;
-  void* infokey;
+    void *model;
+    // TODO: use session pool? The ideal would be to use one session per client.
+    //       If a client disconnects, we dispose the session or reuse it for
+    //       another client.
+    void *session;
+    RAI_Backend backend;
+    char *devicestr;
+    char *tag;
+    RAI_ModelOpts opts;
+    char **inputs;
+    size_t ninputs;
+    char **outputs;
+    size_t noutputs;
+    long long refCount;
+    char *data;
+    long long datalen;
+    void *infokey;
 } RAI_Model;
 
 typedef struct RAI_ModelCtxParam {
-  const char* name;
-  RAI_Tensor* tensor;
+    const char *name;
+    RAI_Tensor *tensor;
 } RAI_ModelCtxParam;
 
 typedef struct RAI_ModelRunCtx {
-  size_t ctxtype;
-  RAI_Model* model;
-  RAI_ModelCtxParam* inputs;
-  RAI_ModelCtxParam* outputs;
+    size_t ctxtype;
+    RAI_Model *model;
+    RAI_ModelCtxParam *inputs;
+    RAI_ModelCtxParam *outputs;
 } RAI_ModelRunCtx;
 
 #endif /* SRC_MODEL_STRUCT_H_ */

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -1,26 +1,26 @@
 #include "redismodule.h"
 #include "tensor.h"
 
-#include "model.h"
-#include "dag.h"
-#include "background_workers.h"
-#include "script.h"
 #include "backends.h"
-#include "stats.h"
-#include <string.h>
-#include <pthread.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <unistd.h>
-#include <stdbool.h>
 #include "backends/util.h"
+#include "background_workers.h"
+#include "dag.h"
+#include "model.h"
+#include "script.h"
+#include "stats.h"
+#include <pthread.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 #include "rmutil/alloc.h"
+#include "rmutil/args.h"
+#include "run_info.h"
 #include "util/arr_rm_alloc.h"
 #include "util/dict.h"
 #include "util/queue.h"
-#include "rmutil/args.h"
-#include "run_info.h"
 #include "version.h"
 
 #define REDISAI_H_INCLUDE
@@ -48,7 +48,7 @@ void getRedisVersion() {
     const char *replyStr = RedisModule_CallReplyStringPtr(reply, &len);
 
     int n = sscanf(replyStr, "# Server\nredis_version:%d.%d.%d", &redisMajorVersion,
-                 &redisMinorVersion, &redisPatchVersion);
+                   &redisMinorVersion, &redisPatchVersion);
 
     assert(n == 3);
 
@@ -69,9 +69,7 @@ void getRedisVersion() {
     RedisModule_FreeThreadSafeContext(ctx);
 }
 
-static inline int IsEnterprise() {
-  return rlecMajorVersion != -1;
-}
+static inline int IsEnterprise() { return rlecMajorVersion != -1; }
 
 /* ----------------------- RedisAI Module Commands ------------------------- */
 
@@ -79,894 +77,902 @@ static inline int IsEnterprise() {
  * AI.TENSORSET key type dim1..dimN [BLOB data | VALUES val1..valN]
  */
 int RedisAI_TensorSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc < 4) return RedisModule_WrongArity(ctx);
+    if (argc < 4)
+        return RedisModule_WrongArity(ctx);
 
-  RedisModuleKey *key;
-  const int status = RAI_OpenKey_Tensor(ctx, argv[1], &key, REDISMODULE_READ|REDISMODULE_WRITE);
-  if(status==REDISMODULE_ERR){
-      return REDISMODULE_ERR;
-  }
+    RedisModuleKey *key;
+    const int status = RAI_OpenKey_Tensor(ctx, argv[1], &key, REDISMODULE_READ | REDISMODULE_WRITE);
+    if (status == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
 
-  RAI_Tensor *t=NULL;
-  RAI_Error err;
-  const int parse_result = RAI_parseTensorSetArgs(ctx,argv,argc,&t,1,&err);
+    RAI_Tensor *t = NULL;
+    RAI_Error err;
+    const int parse_result = RAI_parseTensorSetArgs(ctx, argv, argc, &t, 1, &err);
 
-  // if the number of parsed args is negative something went wrong
-  if(parse_result<0){
+    // if the number of parsed args is negative something went wrong
+    if (parse_result < 0) {
+        RedisModule_CloseKey(key);
+        return REDISMODULE_ERR;
+    }
+
+    if (RedisModule_ModuleTypeSetValue(key, RedisAI_TensorType, t) != REDISMODULE_OK) {
+        RAI_TensorFree(t);
+        RedisModule_CloseKey(key);
+        return RedisModule_ReplyWithError(ctx, "ERR could not save tensor");
+    }
     RedisModule_CloseKey(key);
-    return REDISMODULE_ERR;
-  }
-
-  if( RedisModule_ModuleTypeSetValue(key, RedisAI_TensorType, t) != REDISMODULE_OK ){
-    RAI_TensorFree(t);
-    RedisModule_CloseKey(key);
-    return RedisModule_ReplyWithError(ctx, "ERR could not save tensor");
-  }
-  RedisModule_CloseKey(key);
-  RedisModule_ReplyWithSimpleString(ctx, "OK");
-  RedisModule_ReplicateVerbatim(ctx);
-  return REDISMODULE_OK;
-}
-
-/**
-* AI.TENSORGET tensor_key [META] [BLOB | VALUES]
-*/
-int RedisAI_TensorGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc < 2 || argc > 4) return RedisModule_WrongArity(ctx);
-
-  RAI_Tensor *t;
-  RedisModuleKey *key;
-  const int status = RAI_GetTensorFromKeyspace(ctx, argv[1], &key, &t, REDISMODULE_READ);
-  if(status==REDISMODULE_ERR){
-  return REDISMODULE_ERR;
-  }
-
-  const int parse_result = RAI_parseTensorGetArgs(ctx, argv, argc, t);
-
-  RedisModule_CloseKey(key);
-  // if the number of parsed args is negative something went wrong
-  if (parse_result < 0) {
-    return REDISMODULE_ERR;
-  }
-  return REDISMODULE_OK;
-}
-
-/**
-* AI.MODELSET model_key backend device [TAG tag] [BATCHSIZE n [MINBATCHSIZE m]] [INPUTS name1 name2 ... OUTPUTS name1 name2 ...] BLOB model_blob
-*/
-int RedisAI_ModelSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  RedisModule_AutoMemory(ctx);
-
-  if (argc < 4) return RedisModule_WrongArity(ctx);
-
-  ArgsCursor ac;
-  ArgsCursor_InitRString(&ac, argv+1, argc-1);
-
-  RedisModuleString* keystr;
-  AC_GetRString(&ac, &keystr, 0);
-
-  const char* bckstr;
-  int backend;
-  AC_GetString(&ac, &bckstr, NULL, 0); 
-  if (strcasecmp(bckstr, "TF") == 0) {
-    backend = RAI_BACKEND_TENSORFLOW;
-  }
-  else if (strcasecmp(bckstr, "TFLITE") == 0) {
-    backend = RAI_BACKEND_TFLITE;
-  }
-  else if (strcasecmp(bckstr, "TORCH") == 0) {
-    backend = RAI_BACKEND_TORCH;
-  }
-  else if (strcasecmp(bckstr, "ONNX") == 0) {
-    backend = RAI_BACKEND_ONNXRUNTIME;
-  }
-  else {
-    return RedisModule_ReplyWithError(ctx, "ERR unsupported backend");
-  }
-
-  const char* devicestr;
-  AC_GetString(&ac, &devicestr, NULL, 0); 
-
-  if (strlen(devicestr) > 10 ||
-      strcasecmp(devicestr, "INPUTS") == 0 ||
-      strcasecmp(devicestr, "OUTPUTS") == 0 ||
-      strcasecmp(devicestr, "TAG") == 0 ||
-      strcasecmp(devicestr, "BATCHSIZE") == 0 ||
-      strcasecmp(devicestr, "MINBATCHSIZE") == 0 ||
-      strcasecmp(devicestr, "MINBATCHTIMEOUT") == 0 ||
-      strcasecmp(devicestr, "BLOB") == 0
-      ) {
-    return RedisModule_ReplyWithError(ctx, "ERR Invalid DEVICE");
-  }
-
-  const char* tag = "";
-  if (AC_AdvanceIfMatch(&ac, "TAG")) {
-    AC_GetString(&ac, &tag, NULL, 0);
-  }
-
-  unsigned long long batchsize = 0;
-  if (AC_AdvanceIfMatch(&ac, "BATCHSIZE")) {
-    if (backend == RAI_BACKEND_TFLITE) {
-      return RedisModule_ReplyWithError(ctx, "ERR Auto-batching not supported by the TFLITE backend");
-    }
-    if (AC_GetUnsignedLongLong(&ac, &batchsize, 0) != AC_OK) {
-      return RedisModule_ReplyWithError(ctx, "ERR Invalid argument for BATCHSIZE");
-    }
-  }
-
-  unsigned long long minbatchsize = 0;
-  if (AC_AdvanceIfMatch(&ac, "MINBATCHSIZE")) {
-    if (batchsize == 0) {
-      return RedisModule_ReplyWithError(ctx, "ERR MINBATCHSIZE specified without BATCHSIZE");
-    }
-    if (AC_GetUnsignedLongLong(&ac, &minbatchsize, 0) != AC_OK) {
-      return RedisModule_ReplyWithError(ctx, "ERR Invalid argument for MINBATCHSIZE");
-    }
-  }
-
-  unsigned long long minbatchtimeout = 0;
-  if (AC_AdvanceIfMatch(&ac, "MINBATCHTIMEOUT")) {
-    if (batchsize == 0) {
-      return RedisModule_ReplyWithError(ctx, "ERR MINBATCHTIMEOUT specified without BATCHSIZE");
-    }
-    if (minbatchsize == 0) {
-      return RedisModule_ReplyWithError(ctx, "ERR MINBATCHTIMEOUT specified without MINBATCHSIZE");
-    }
-    if (AC_GetUnsignedLongLong(&ac, &minbatchtimeout, 0) != AC_OK) {
-      return RedisModule_ReplyWithError(ctx, "ERR Invalid argument for MINBATCHTIMEOUT");
-    }
-  }
-
-  if (AC_IsAtEnd(&ac)) {
-    return RedisModule_ReplyWithError(ctx, "ERR Insufficient arguments, missing model BLOB");
-  }
-
-  ArgsCursor optionsac;
-  const char* blob_matches[] = {"BLOB"};
-  AC_GetSliceUntilMatches(&ac, &optionsac, 1, blob_matches);
-
-  if (optionsac.argc == 0 && backend == RAI_BACKEND_TENSORFLOW) {
-    return RedisModule_ReplyWithError(ctx, "ERR Insufficient arguments, INPUTS and OUTPUTS not specified");
-  }
-
-  ArgsCursor inac = {0};
-  ArgsCursor outac = {0};
-  if (optionsac.argc > 0 && backend == RAI_BACKEND_TENSORFLOW) {
-    if (!AC_AdvanceIfMatch(&optionsac, "INPUTS")) {
-      return RedisModule_ReplyWithError(ctx, "ERR INPUTS not specified");
-    }
-
-    const char* matches[] = {"OUTPUTS"};
-    AC_GetSliceUntilMatches(&optionsac, &inac, 1, matches);
-
-    if (!AC_IsAtEnd(&optionsac)) {
-      if (!AC_AdvanceIfMatch(&optionsac, "OUTPUTS")) {
-        return RedisModule_ReplyWithError(ctx, "ERR OUTPUTS not specified");
-      }
-
-      AC_GetSliceToEnd(&optionsac, &outac);
-    }
-  }
-
-  size_t ninputs = inac.argc;
-  const char *inputs[ninputs];
-  for (size_t i=0; i<ninputs; i++) {
-    AC_GetString(&inac, inputs+i, NULL, 0); 
-  }
-
-  size_t noutputs = outac.argc;
-  const char *outputs[noutputs];
-  for (size_t i=0; i<noutputs; i++) {
-    AC_GetString(&outac, outputs+i, NULL, 0); 
-  }
-
-  RAI_ModelOpts opts = {
-    .batchsize = batchsize,
-    .minbatchsize = minbatchsize,
-    .minbatchtimeout = minbatchtimeout,
-    .backends_intra_op_parallelism = getBackendsIntraOpParallelism(),
-    .backends_inter_op_parallelism = getBackendsInterOpParallelism(),
-  };
-
-  RAI_Model *model = NULL;
-
-  AC_AdvanceUntilMatches(&ac, 1, blob_matches);
-
-  if (AC_IsAtEnd(&ac)) {
-    return RedisModule_ReplyWithError(ctx, "ERR Insufficient arguments, missing model BLOB");
-  }
-
-  AC_Advance(&ac);
-
-  ArgsCursor blobsac;
-  AC_GetSliceToEnd(&ac, &blobsac);
-
-  size_t modellen;
-  char *modeldef;
-
-  if (blobsac.argc == 1) {
-    AC_GetString(&blobsac, (const char**)&modeldef, &modellen, 0); 
-  }
-  else {
-    const char *chunks[blobsac.argc];
-    size_t chunklens[blobsac.argc];
-    modellen = 0;
-    while (!AC_IsAtEnd(&blobsac)) {
-      AC_GetString(&blobsac, &chunks[blobsac.offset], &chunklens[blobsac.offset], 0); 
-      modellen += chunklens[blobsac.offset-1];
-    }
-    
-    modeldef = RedisModule_Calloc(modellen, sizeof(char));
-    size_t offset = 0;
-    for (size_t i=0; i<blobsac.argc; i++) {
-      memcpy(modeldef + offset, chunks[i], chunklens[i]);
-      offset += chunklens[i];
-    }
-  }
-
-  RAI_Error err = {0};
-
-  model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs, outputs, modeldef, modellen, &err);
-
-  if (err.code == RAI_EBACKENDNOTLOADED) {
-    RedisModule_Log(ctx, "warning", "backend %s not loaded, will try loading default backend", bckstr);
-    int ret = RAI_LoadDefaultBackend(ctx, backend);
-    if (ret == REDISMODULE_ERR) {
-      RedisModule_Log(ctx, "error", "could not load %s default backend", bckstr);
-      int ret = RedisModule_ReplyWithError(ctx, "ERR Could not load backend");
-      RAI_ClearError(&err);
-      return ret;
-    }
-    RAI_ClearError(&err);
-    model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs, outputs, modeldef, modellen, &err);
-  }
-
-  if (blobsac.argc > 1) {
-    RedisModule_Free(modeldef);
-  }
-
-  if (err.code != RAI_OK) {
-    RedisModule_Log(ctx, "error", "%s", err.detail);
-    int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
-    RAI_ClearError(&err);
-    return ret;
-  }
-
-  // TODO: if backend loaded, make sure there's a queue
-  RunQueueInfo *run_queue_info = NULL;
-  if (ensureRunQueue(devicestr,&run_queue_info) != REDISMODULE_OK){
-    RAI_ModelFree(model, &err);
-    if (err.code != RAI_OK) {
-      RedisModule_Log(ctx, "error", "%s", err.detail);
-      int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
-      RAI_ClearError(&err);
-      return ret;
-    }
-    return RedisModule_ReplyWithError(ctx, "ERR Could not initialize queue on requested device");
-  }
-
-  RedisModuleKey *key = RedisModule_OpenKey(ctx, keystr,
-      REDISMODULE_READ|REDISMODULE_WRITE);
-  int type = RedisModule_KeyType(key);
-  if (type != REDISMODULE_KEYTYPE_EMPTY &&
-      !(type == REDISMODULE_KEYTYPE_MODULE &&
-        RedisModule_ModuleTypeGetType(key) == RedisAI_ModelType)) {
-    RedisModule_CloseKey(key);
-    RAI_ModelFree(model, &err);
-    if (err.code != RAI_OK) {
-      RedisModule_Log(ctx, "error", "%s", err.detail);
-      int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
-      RAI_ClearError(&err);
-      return ret;
-    }
-    return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-  }
-
-  RedisModule_ModuleTypeSetValue(key, RedisAI_ModelType, model);
-
-  model->infokey = RAI_AddStatsEntry(ctx, keystr, RAI_MODEL, backend, devicestr, tag);
-
-  RedisModule_CloseKey(key);
-
-  RedisModule_ReplyWithSimpleString(ctx, "OK");
-
-  RedisModule_ReplicateVerbatim(ctx);
-
-  return REDISMODULE_OK;
-}
-
-void RAI_ReplyWithChunks(RedisModuleCtx *ctx, const char* buffer, long long len) {
-  long long chunk_size = getModelChunkSize();
-  const size_t n_chunks = len / chunk_size + 1;
-  if (n_chunks > 1) {
-    RedisModule_ReplyWithArray(ctx, (long)n_chunks);
-    for (size_t i=0; i<n_chunks; i++) {
-      size_t chunk_len = i < n_chunks - 1 ? chunk_size : len % chunk_size;
-      RedisModule_ReplyWithStringBuffer(ctx, buffer + i * chunk_size, chunk_len);
-    }
-  }
-  else {
-    RedisModule_ReplyWithStringBuffer(ctx, buffer, len);
-  }
-}
-
-/**
-* AI.MODELGET model_key [META] [BLOB]
-*/
-int RedisAI_ModelGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc < 2 || argc > 4) return RedisModule_WrongArity(ctx);
-
-  RAI_Model *mto;
-  RedisModuleKey *key;
-  const int status = RAI_GetModelFromKeyspace( ctx, argv[1], &key, &mto, REDISMODULE_READ );
-  if (status == REDISMODULE_ERR) {
-    return REDISMODULE_ERR;
-  }
-
-  int meta = 0;
-  int blob = 0;
-  for (int i=2; i<argc; i++) {
-    const char *optstr = RedisModule_StringPtrLen(argv[i], NULL);
-    if (!strcasecmp(optstr, "META")) {
-      meta = 1;
-    }
-    else if (!strcasecmp(optstr, "BLOB")) {
-      blob = 1;
-    }
-  }
-
-  if (!meta && !blob) {
-    RedisModule_CloseKey(key);
-    return RedisModule_ReplyWithError(ctx, "ERR no META or BLOB specified");
-  }
-
-  RAI_Error err = {0};
-
-  char *buffer = NULL;
-  size_t len = 0;
-
-  if (blob) {
-    RAI_ModelSerialize(mto, &buffer, &len, &err);
-
-    if (err.code != RAI_OK) {
-      #ifdef RAI_PRINT_BACKEND_ERRORS
-      printf("ERR: %s\n", err.detail);
-      #endif
-      int ret = RedisModule_ReplyWithError(ctx, err.detail);
-      RAI_ClearError(&err);
-      if (*buffer) {
-        RedisModule_Free(buffer);
-      }
-      return ret;
-    }
-  }
-
-  if (!meta && blob) {
-    RAI_ReplyWithChunks(ctx, buffer, len);
-    RedisModule_Free(buffer);
-    RedisModule_CloseKey(key);
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    RedisModule_ReplicateVerbatim(ctx);
     return REDISMODULE_OK;
-  }
-
-  const int outentries = blob ? 16 : 14;
-
-  RedisModule_ReplyWithArray(ctx, outentries);
-
-  RedisModule_ReplyWithCString(ctx, "backend");
-  const char *backendstr = RAI_BackendName(mto->backend);
-  RedisModule_ReplyWithCString(ctx, backendstr);
-
-  RedisModule_ReplyWithCString(ctx, "device");
-  RedisModule_ReplyWithCString(ctx, mto->devicestr);
-
-  RedisModule_ReplyWithCString(ctx, "tag");
-  RedisModule_ReplyWithCString(ctx, mto->tag ? mto->tag : "");
-
-  RedisModule_ReplyWithCString(ctx, "batchsize");
-  RedisModule_ReplyWithLongLong(ctx, (long)mto->opts.batchsize);
-
-  RedisModule_ReplyWithCString(ctx, "minbatchsize");
-  RedisModule_ReplyWithLongLong(ctx, (long)mto->opts.minbatchsize);
-
-  RedisModule_ReplyWithCString(ctx, "inputs");
-  const size_t ninputs = array_len(mto->inputs);
-  RedisModule_ReplyWithArray(ctx, (long)ninputs);
-
-  for (size_t i = 0; i < ninputs; i++) {
-    RedisModule_ReplyWithCString(ctx, mto->inputs[i]);
-  }
-
-  RedisModule_ReplyWithCString(ctx, "outputs");
-  const size_t noutputs = array_len(mto->outputs);
-  RedisModule_ReplyWithArray(ctx, (long)noutputs);
-
-  for (size_t i = 0; i < noutputs; i++) {
-    RedisModule_ReplyWithCString(ctx, mto->outputs[i]);
-  }
-
-  if (meta && blob) {
-    RedisModule_ReplyWithCString(ctx, "blob");
-    RAI_ReplyWithChunks(ctx, buffer, len);
-    RedisModule_Free(buffer);
-  }
-
-  RedisModule_CloseKey(key);
-
-  return REDISMODULE_OK;
 }
 
 /**
-* AI.MODELDEL model_key
-*/
+ * AI.TENSORGET tensor_key [META] [BLOB | VALUES]
+ */
+int RedisAI_TensorGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 2 || argc > 4)
+        return RedisModule_WrongArity(ctx);
+
+    RAI_Tensor *t;
+    RedisModuleKey *key;
+    const int status = RAI_GetTensorFromKeyspace(ctx, argv[1], &key, &t, REDISMODULE_READ);
+    if (status == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
+
+    const int parse_result = RAI_parseTensorGetArgs(ctx, argv, argc, t);
+
+    RedisModule_CloseKey(key);
+    // if the number of parsed args is negative something went wrong
+    if (parse_result < 0) {
+        return REDISMODULE_ERR;
+    }
+    return REDISMODULE_OK;
+}
+
+/**
+ * AI.MODELSET model_key backend device [TAG tag] [BATCHSIZE n [MINBATCHSIZE m]]
+ * [INPUTS name1 name2 ... OUTPUTS name1 name2 ...] BLOB model_blob
+ */
+int RedisAI_ModelSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+
+    if (argc < 4)
+        return RedisModule_WrongArity(ctx);
+
+    ArgsCursor ac;
+    ArgsCursor_InitRString(&ac, argv + 1, argc - 1);
+
+    RedisModuleString *keystr;
+    AC_GetRString(&ac, &keystr, 0);
+
+    const char *bckstr;
+    int backend;
+    AC_GetString(&ac, &bckstr, NULL, 0);
+    if (strcasecmp(bckstr, "TF") == 0) {
+        backend = RAI_BACKEND_TENSORFLOW;
+    } else if (strcasecmp(bckstr, "TFLITE") == 0) {
+        backend = RAI_BACKEND_TFLITE;
+    } else if (strcasecmp(bckstr, "TORCH") == 0) {
+        backend = RAI_BACKEND_TORCH;
+    } else if (strcasecmp(bckstr, "ONNX") == 0) {
+        backend = RAI_BACKEND_ONNXRUNTIME;
+    } else {
+        return RedisModule_ReplyWithError(ctx, "ERR unsupported backend");
+    }
+
+    const char *devicestr;
+    AC_GetString(&ac, &devicestr, NULL, 0);
+
+    if (strlen(devicestr) > 10 || strcasecmp(devicestr, "INPUTS") == 0 ||
+        strcasecmp(devicestr, "OUTPUTS") == 0 || strcasecmp(devicestr, "TAG") == 0 ||
+        strcasecmp(devicestr, "BATCHSIZE") == 0 || strcasecmp(devicestr, "MINBATCHSIZE") == 0 ||
+        strcasecmp(devicestr, "MINBATCHTIMEOUT") == 0 || strcasecmp(devicestr, "BLOB") == 0) {
+        return RedisModule_ReplyWithError(ctx, "ERR Invalid DEVICE");
+    }
+
+    const char *tag = "";
+    if (AC_AdvanceIfMatch(&ac, "TAG")) {
+        AC_GetString(&ac, &tag, NULL, 0);
+    }
+
+    unsigned long long batchsize = 0;
+    if (AC_AdvanceIfMatch(&ac, "BATCHSIZE")) {
+        if (backend == RAI_BACKEND_TFLITE) {
+            return RedisModule_ReplyWithError(
+                ctx, "ERR Auto-batching not supported by the TFLITE backend");
+        }
+        if (AC_GetUnsignedLongLong(&ac, &batchsize, 0) != AC_OK) {
+            return RedisModule_ReplyWithError(ctx, "ERR Invalid argument for BATCHSIZE");
+        }
+    }
+
+    unsigned long long minbatchsize = 0;
+    if (AC_AdvanceIfMatch(&ac, "MINBATCHSIZE")) {
+        if (batchsize == 0) {
+            return RedisModule_ReplyWithError(ctx, "ERR MINBATCHSIZE specified without BATCHSIZE");
+        }
+        if (AC_GetUnsignedLongLong(&ac, &minbatchsize, 0) != AC_OK) {
+            return RedisModule_ReplyWithError(ctx, "ERR Invalid argument for MINBATCHSIZE");
+        }
+    }
+
+    unsigned long long minbatchtimeout = 0;
+    if (AC_AdvanceIfMatch(&ac, "MINBATCHTIMEOUT")) {
+        if (batchsize == 0) {
+            return RedisModule_ReplyWithError(ctx,
+                                              "ERR MINBATCHTIMEOUT specified without BATCHSIZE");
+        }
+        if (minbatchsize == 0) {
+            return RedisModule_ReplyWithError(ctx,
+                                              "ERR MINBATCHTIMEOUT specified without MINBATCHSIZE");
+        }
+        if (AC_GetUnsignedLongLong(&ac, &minbatchtimeout, 0) != AC_OK) {
+            return RedisModule_ReplyWithError(ctx, "ERR Invalid argument for MINBATCHTIMEOUT");
+        }
+    }
+
+    if (AC_IsAtEnd(&ac)) {
+        return RedisModule_ReplyWithError(ctx, "ERR Insufficient arguments, missing model BLOB");
+    }
+
+    ArgsCursor optionsac;
+    const char *blob_matches[] = {"BLOB"};
+    AC_GetSliceUntilMatches(&ac, &optionsac, 1, blob_matches);
+
+    if (optionsac.argc == 0 && backend == RAI_BACKEND_TENSORFLOW) {
+        return RedisModule_ReplyWithError(
+            ctx, "ERR Insufficient arguments, INPUTS and OUTPUTS not specified");
+    }
+
+    ArgsCursor inac = {0};
+    ArgsCursor outac = {0};
+    if (optionsac.argc > 0 && backend == RAI_BACKEND_TENSORFLOW) {
+        if (!AC_AdvanceIfMatch(&optionsac, "INPUTS")) {
+            return RedisModule_ReplyWithError(ctx, "ERR INPUTS not specified");
+        }
+
+        const char *matches[] = {"OUTPUTS"};
+        AC_GetSliceUntilMatches(&optionsac, &inac, 1, matches);
+
+        if (!AC_IsAtEnd(&optionsac)) {
+            if (!AC_AdvanceIfMatch(&optionsac, "OUTPUTS")) {
+                return RedisModule_ReplyWithError(ctx, "ERR OUTPUTS not specified");
+            }
+
+            AC_GetSliceToEnd(&optionsac, &outac);
+        }
+    }
+
+    size_t ninputs = inac.argc;
+    const char *inputs[ninputs];
+    for (size_t i = 0; i < ninputs; i++) {
+        AC_GetString(&inac, inputs + i, NULL, 0);
+    }
+
+    size_t noutputs = outac.argc;
+    const char *outputs[noutputs];
+    for (size_t i = 0; i < noutputs; i++) {
+        AC_GetString(&outac, outputs + i, NULL, 0);
+    }
+
+    RAI_ModelOpts opts = {
+        .batchsize = batchsize,
+        .minbatchsize = minbatchsize,
+        .minbatchtimeout = minbatchtimeout,
+        .backends_intra_op_parallelism = getBackendsIntraOpParallelism(),
+        .backends_inter_op_parallelism = getBackendsInterOpParallelism(),
+    };
+
+    RAI_Model *model = NULL;
+
+    AC_AdvanceUntilMatches(&ac, 1, blob_matches);
+
+    if (AC_IsAtEnd(&ac)) {
+        return RedisModule_ReplyWithError(ctx, "ERR Insufficient arguments, missing model BLOB");
+    }
+
+    AC_Advance(&ac);
+
+    ArgsCursor blobsac;
+    AC_GetSliceToEnd(&ac, &blobsac);
+
+    size_t modellen;
+    char *modeldef;
+
+    if (blobsac.argc == 1) {
+        AC_GetString(&blobsac, (const char **)&modeldef, &modellen, 0);
+    } else {
+        const char *chunks[blobsac.argc];
+        size_t chunklens[blobsac.argc];
+        modellen = 0;
+        while (!AC_IsAtEnd(&blobsac)) {
+            AC_GetString(&blobsac, &chunks[blobsac.offset], &chunklens[blobsac.offset], 0);
+            modellen += chunklens[blobsac.offset - 1];
+        }
+
+        modeldef = RedisModule_Calloc(modellen, sizeof(char));
+        size_t offset = 0;
+        for (size_t i = 0; i < blobsac.argc; i++) {
+            memcpy(modeldef + offset, chunks[i], chunklens[i]);
+            offset += chunklens[i];
+        }
+    }
+
+    RAI_Error err = {0};
+
+    model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs, outputs,
+                            modeldef, modellen, &err);
+
+    if (err.code == RAI_EBACKENDNOTLOADED) {
+        RedisModule_Log(ctx, "warning", "backend %s not loaded, will try loading default backend",
+                        bckstr);
+        int ret = RAI_LoadDefaultBackend(ctx, backend);
+        if (ret == REDISMODULE_ERR) {
+            RedisModule_Log(ctx, "error", "could not load %s default backend", bckstr);
+            int ret = RedisModule_ReplyWithError(ctx, "ERR Could not load backend");
+            RAI_ClearError(&err);
+            return ret;
+        }
+        RAI_ClearError(&err);
+        model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs, outputs,
+                                modeldef, modellen, &err);
+    }
+
+    if (blobsac.argc > 1) {
+        RedisModule_Free(modeldef);
+    }
+
+    if (err.code != RAI_OK) {
+        RedisModule_Log(ctx, "error", "%s", err.detail);
+        int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
+        RAI_ClearError(&err);
+        return ret;
+    }
+
+    // TODO: if backend loaded, make sure there's a queue
+    RunQueueInfo *run_queue_info = NULL;
+    if (ensureRunQueue(devicestr, &run_queue_info) != REDISMODULE_OK) {
+        RAI_ModelFree(model, &err);
+        if (err.code != RAI_OK) {
+            RedisModule_Log(ctx, "error", "%s", err.detail);
+            int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
+            RAI_ClearError(&err);
+            return ret;
+        }
+        return RedisModule_ReplyWithError(ctx,
+                                          "ERR Could not initialize queue on requested device");
+    }
+
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, keystr, REDISMODULE_READ | REDISMODULE_WRITE);
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_EMPTY &&
+        !(type == REDISMODULE_KEYTYPE_MODULE &&
+          RedisModule_ModuleTypeGetType(key) == RedisAI_ModelType)) {
+        RedisModule_CloseKey(key);
+        RAI_ModelFree(model, &err);
+        if (err.code != RAI_OK) {
+            RedisModule_Log(ctx, "error", "%s", err.detail);
+            int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
+            RAI_ClearError(&err);
+            return ret;
+        }
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+    }
+
+    RedisModule_ModuleTypeSetValue(key, RedisAI_ModelType, model);
+
+    model->infokey = RAI_AddStatsEntry(ctx, keystr, RAI_MODEL, backend, devicestr, tag);
+
+    RedisModule_CloseKey(key);
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+
+    RedisModule_ReplicateVerbatim(ctx);
+
+    return REDISMODULE_OK;
+}
+
+void RAI_ReplyWithChunks(RedisModuleCtx *ctx, const char *buffer, long long len) {
+    long long chunk_size = getModelChunkSize();
+    const size_t n_chunks = len / chunk_size + 1;
+    if (n_chunks > 1) {
+        RedisModule_ReplyWithArray(ctx, (long)n_chunks);
+        for (size_t i = 0; i < n_chunks; i++) {
+            size_t chunk_len = i < n_chunks - 1 ? chunk_size : len % chunk_size;
+            RedisModule_ReplyWithStringBuffer(ctx, buffer + i * chunk_size, chunk_len);
+        }
+    } else {
+        RedisModule_ReplyWithStringBuffer(ctx, buffer, len);
+    }
+}
+
+/**
+ * AI.MODELGET model_key [META] [BLOB]
+ */
+int RedisAI_ModelGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 2 || argc > 4)
+        return RedisModule_WrongArity(ctx);
+
+    RAI_Model *mto;
+    RedisModuleKey *key;
+    const int status = RAI_GetModelFromKeyspace(ctx, argv[1], &key, &mto, REDISMODULE_READ);
+    if (status == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
+
+    int meta = 0;
+    int blob = 0;
+    for (int i = 2; i < argc; i++) {
+        const char *optstr = RedisModule_StringPtrLen(argv[i], NULL);
+        if (!strcasecmp(optstr, "META")) {
+            meta = 1;
+        } else if (!strcasecmp(optstr, "BLOB")) {
+            blob = 1;
+        }
+    }
+
+    if (!meta && !blob) {
+        RedisModule_CloseKey(key);
+        return RedisModule_ReplyWithError(ctx, "ERR no META or BLOB specified");
+    }
+
+    RAI_Error err = {0};
+
+    char *buffer = NULL;
+    size_t len = 0;
+
+    if (blob) {
+        RAI_ModelSerialize(mto, &buffer, &len, &err);
+
+        if (err.code != RAI_OK) {
+#ifdef RAI_PRINT_BACKEND_ERRORS
+            printf("ERR: %s\n", err.detail);
+#endif
+            int ret = RedisModule_ReplyWithError(ctx, err.detail);
+            RAI_ClearError(&err);
+            if (*buffer) {
+                RedisModule_Free(buffer);
+            }
+            return ret;
+        }
+    }
+
+    if (!meta && blob) {
+        RAI_ReplyWithChunks(ctx, buffer, len);
+        RedisModule_Free(buffer);
+        RedisModule_CloseKey(key);
+        return REDISMODULE_OK;
+    }
+
+    const int outentries = blob ? 16 : 14;
+
+    RedisModule_ReplyWithArray(ctx, outentries);
+
+    RedisModule_ReplyWithCString(ctx, "backend");
+    const char *backendstr = RAI_BackendName(mto->backend);
+    RedisModule_ReplyWithCString(ctx, backendstr);
+
+    RedisModule_ReplyWithCString(ctx, "device");
+    RedisModule_ReplyWithCString(ctx, mto->devicestr);
+
+    RedisModule_ReplyWithCString(ctx, "tag");
+    RedisModule_ReplyWithCString(ctx, mto->tag ? mto->tag : "");
+
+    RedisModule_ReplyWithCString(ctx, "batchsize");
+    RedisModule_ReplyWithLongLong(ctx, (long)mto->opts.batchsize);
+
+    RedisModule_ReplyWithCString(ctx, "minbatchsize");
+    RedisModule_ReplyWithLongLong(ctx, (long)mto->opts.minbatchsize);
+
+    RedisModule_ReplyWithCString(ctx, "inputs");
+    const size_t ninputs = array_len(mto->inputs);
+    RedisModule_ReplyWithArray(ctx, (long)ninputs);
+
+    for (size_t i = 0; i < ninputs; i++) {
+        RedisModule_ReplyWithCString(ctx, mto->inputs[i]);
+    }
+
+    RedisModule_ReplyWithCString(ctx, "outputs");
+    const size_t noutputs = array_len(mto->outputs);
+    RedisModule_ReplyWithArray(ctx, (long)noutputs);
+
+    for (size_t i = 0; i < noutputs; i++) {
+        RedisModule_ReplyWithCString(ctx, mto->outputs[i]);
+    }
+
+    if (meta && blob) {
+        RedisModule_ReplyWithCString(ctx, "blob");
+        RAI_ReplyWithChunks(ctx, buffer, len);
+        RedisModule_Free(buffer);
+    }
+
+    RedisModule_CloseKey(key);
+
+    return REDISMODULE_OK;
+}
+
+/**
+ * AI.MODELDEL model_key
+ */
 int RedisAI_ModelDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc != 2) return RedisModule_WrongArity(ctx);
+    if (argc != 2)
+        return RedisModule_WrongArity(ctx);
 
-  RAI_Model *mto;
-  RedisModuleKey *key;
-  const int status = RAI_GetModelFromKeyspace(ctx, argv[1], &key, &mto, REDISMODULE_READ|REDISMODULE_WRITE);
-  if(status==REDISMODULE_ERR){
-      return REDISMODULE_ERR;
-  }
+    RAI_Model *mto;
+    RedisModuleKey *key;
+    const int status =
+        RAI_GetModelFromKeyspace(ctx, argv[1], &key, &mto, REDISMODULE_READ | REDISMODULE_WRITE);
+    if (status == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
 
-  RedisModule_DeleteKey(key);
-  RedisModule_CloseKey(key);
-  RedisModule_ReplicateVerbatim(ctx);
+    RedisModule_DeleteKey(key);
+    RedisModule_CloseKey(key);
+    RedisModule_ReplicateVerbatim(ctx);
 
-  return RedisModule_ReplyWithSimpleString(ctx, "OK");
-}
-
-/** 
-* AI._MODELSCAN
-*/
-int RedisAI_ModelScan_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc != 1) return RedisModule_WrongArity(ctx);
-
-  RedisModule_Log(ctx, "warning", "MODELSCAN is experimental and might be removed in future versions");
-
-  long long nkeys;
-  RedisModuleString** keys;
-  const char** tags;
-  RAI_ListStatsEntries(RAI_MODEL, &nkeys, &keys, &tags);
-
-  RedisModule_ReplyWithArray(ctx, nkeys);
-
-  for (long long i=0; i<nkeys; i++) {
-    RedisModule_ReplyWithArray(ctx, 2);
-    RedisModule_ReplyWithString(ctx, keys[i]);
-    RedisModule_ReplyWithCString(ctx, tags[i]);
-  }
-
-  RedisModule_Free(keys);
-  RedisModule_Free(tags);
-
-  return REDISMODULE_OK;
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 
 /**
- * AI.MODELRUN model_key [TIMEOUT t] INPUTS <input_key> [input_key ...] OUTPUTS <output_key> [output_key ...]
+ * AI._MODELSCAN
+ */
+int RedisAI_ModelScan_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 1)
+        return RedisModule_WrongArity(ctx);
+
+    RedisModule_Log(ctx, "warning",
+                    "MODELSCAN is experimental and might be removed in future versions");
+
+    long long nkeys;
+    RedisModuleString **keys;
+    const char **tags;
+    RAI_ListStatsEntries(RAI_MODEL, &nkeys, &keys, &tags);
+
+    RedisModule_ReplyWithArray(ctx, nkeys);
+
+    for (long long i = 0; i < nkeys; i++) {
+        RedisModule_ReplyWithArray(ctx, 2);
+        RedisModule_ReplyWithString(ctx, keys[i]);
+        RedisModule_ReplyWithCString(ctx, tags[i]);
+    }
+
+    RedisModule_Free(keys);
+    RedisModule_Free(tags);
+
+    return REDISMODULE_OK;
+}
+
+/**
+ * AI.MODELRUN model_key [TIMEOUT t] INPUTS <input_key> [input_key ...] OUTPUTS
+ * <output_key> [output_key ...]
  *
  * The request is queued and evaded asynchronously from a separate thread. The
  * client blocks until the computation finishes.
  */
-int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                  int argc) {
-  if (RedisModule_IsKeysPositionRequest(ctx)) {
-    return RedisAI_ModelRun_IsKeysPositionRequest_ReportKeys(ctx, argv, argc);
-  }
+int RedisAI_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (RedisModule_IsKeysPositionRequest(ctx)) {
+        return RedisAI_ModelRun_IsKeysPositionRequest_ReportKeys(ctx, argv, argc);
+    }
 
-  if (argc < 3) return RedisModule_WrongArity(ctx);
+    if (argc < 3)
+        return RedisModule_WrongArity(ctx);
 
-  return RedisAI_DagRunSyntaxParser(ctx, argv, argc, REDISAI_DAG_WRITE_MODE);
+    return RedisAI_DagRunSyntaxParser(ctx, argv, argc, REDISAI_DAG_WRITE_MODE);
 }
 
-/** 
-* AI.SCRIPTRUN <key> <function> INPUTS <input_key> [input_key ...] OUTPUTS <output_key> [output_key ...]
-*/
+/**
+ * AI.SCRIPTRUN <key> <function> INPUTS <input_key> [input_key ...] OUTPUTS
+ * <output_key> [output_key ...]
+ */
 int RedisAI_ScriptRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (RedisModule_IsKeysPositionRequest(ctx)) {
-    return RedisAI_ScriptRun_IsKeysPositionRequest_ReportKeys(ctx, argv, argc);
-  }
+    if (RedisModule_IsKeysPositionRequest(ctx)) {
+        return RedisAI_ScriptRun_IsKeysPositionRequest_ReportKeys(ctx, argv, argc);
+    }
 
-  if (argc < 6) return RedisModule_WrongArity(ctx);
+    if (argc < 6)
+        return RedisModule_WrongArity(ctx);
 
-  return RedisAI_DagRunSyntaxParser(ctx, argv, argc, REDISAI_DAG_WRITE_MODE);
+    return RedisAI_DagRunSyntaxParser(ctx, argv, argc, REDISAI_DAG_WRITE_MODE);
 }
 
 /**
  * AI.SCRIPTGET script_key [META] [SOURCE]
  */
 int RedisAI_ScriptGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc < 2 || argc > 4) return RedisModule_WrongArity(ctx);
+    if (argc < 2 || argc > 4)
+        return RedisModule_WrongArity(ctx);
 
-  RAI_Script *sto;
-  RedisModuleKey *key;
-  const int status = RAI_GetScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_READ);
-  if(status==REDISMODULE_ERR){
-      return REDISMODULE_ERR;
-  }
-
-  int meta = 0;
-  int source = 0;
-  for (int i=2; i<argc; i++) {
-    const char *optstr = RedisModule_StringPtrLen(argv[i], NULL);
-    if (!strcasecmp(optstr, "META")) {
-      meta = 1;
+    RAI_Script *sto;
+    RedisModuleKey *key;
+    const int status = RAI_GetScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_READ);
+    if (status == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
     }
-    else if (!strcasecmp(optstr, "SOURCE")) {
-      source = 1;
+
+    int meta = 0;
+    int source = 0;
+    for (int i = 2; i < argc; i++) {
+        const char *optstr = RedisModule_StringPtrLen(argv[i], NULL);
+        if (!strcasecmp(optstr, "META")) {
+            meta = 1;
+        } else if (!strcasecmp(optstr, "SOURCE")) {
+            source = 1;
+        }
     }
-  }
 
-  if (!meta && !source) {
-    RedisModule_CloseKey(key);
-    return RedisModule_ReplyWithError(ctx, "ERR no META or SOURCE specified");
-  }
+    if (!meta && !source) {
+        RedisModule_CloseKey(key);
+        return RedisModule_ReplyWithError(ctx, "ERR no META or SOURCE specified");
+    }
 
-  if (!meta && source) {
-    RedisModule_ReplyWithCString(ctx, sto->scriptdef);
+    if (!meta && source) {
+        RedisModule_ReplyWithCString(ctx, sto->scriptdef);
+        RedisModule_CloseKey(key);
+        return REDISMODULE_OK;
+    }
+
+    int outentries = source ? 6 : 4;
+
+    RedisModule_ReplyWithArray(ctx, outentries);
+    RedisModule_ReplyWithCString(ctx, "device");
+    RedisModule_ReplyWithCString(ctx, sto->devicestr);
+    RedisModule_ReplyWithCString(ctx, "tag");
+    RedisModule_ReplyWithCString(ctx, sto->tag);
+    if (source) {
+        RedisModule_ReplyWithCString(ctx, "source");
+        RedisModule_ReplyWithCString(ctx, sto->scriptdef);
+    }
     RedisModule_CloseKey(key);
     return REDISMODULE_OK;
-  }
-
-  int outentries = source ? 6 : 4;
-
-  RedisModule_ReplyWithArray(ctx, outentries);
-  RedisModule_ReplyWithCString(ctx, "device");
-  RedisModule_ReplyWithCString(ctx, sto->devicestr);
-  RedisModule_ReplyWithCString(ctx, "tag");
-  RedisModule_ReplyWithCString(ctx, sto->tag);
-  if (source) {
-    RedisModule_ReplyWithCString(ctx, "source");
-    RedisModule_ReplyWithCString(ctx, sto->scriptdef);
-  }
-  RedisModule_CloseKey(key);
-  return REDISMODULE_OK;
 }
 
 /**
  * AI.SCRIPTDEL script_key
  */
 int RedisAI_ScriptDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc != 2) return RedisModule_WrongArity(ctx);
+    if (argc != 2)
+        return RedisModule_WrongArity(ctx);
 
-  RAI_Script *sto;
-  RedisModuleKey *key;
-  const int status = RAI_GetScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_WRITE);
-  if(status==REDISMODULE_ERR){
-      return REDISMODULE_ERR;
-  }
-
-  RedisModule_DeleteKey(key);
-  RedisModule_CloseKey(key);
-
-  RedisModule_ReplicateVerbatim(ctx);
-  
-  return RedisModule_ReplyWithSimpleString(ctx, "OK");
-}
-
-/** 
-* AI.SCRIPTSET script_key device [TAG tag] SOURCE script_source
-*/
-int RedisAI_ScriptSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  RedisModule_AutoMemory(ctx);
-
-  if (argc != 5 && argc != 7) return RedisModule_WrongArity(ctx);
-
-  ArgsCursor ac;
-  ArgsCursor_InitRString(&ac, argv+1, argc-1);
-
-  RedisModuleString* keystr;
-  AC_GetRString(&ac, &keystr, 0);
-
-  const char* devicestr;
-  AC_GetString(&ac, &devicestr, NULL, 0); 
-
-  const char* tag = "";
-  if (AC_AdvanceIfMatch(&ac, "TAG")) {
-    AC_GetString(&ac, &tag, NULL, 0);
-  }
-
-  if (AC_IsAtEnd(&ac)) {
-    return RedisModule_ReplyWithError(ctx, "ERR Insufficient arguments, missing script SOURCE");
-  }
-
-  size_t scriptlen;
-  const char *scriptdef = NULL;
-
-  if (AC_AdvanceIfMatch(&ac, "SOURCE")) {
-    AC_GetString(&ac, &scriptdef, &scriptlen, 0); 
-  }
-
-  if (scriptdef == NULL) {
-    return RedisModule_ReplyWithError(ctx, "ERR Insufficient arguments, missing script SOURCE");
-  }
-
-  RAI_Script *script = NULL;
-
-  RAI_Error err = {0};
-  script = RAI_ScriptCreate(devicestr, tag, scriptdef, &err);
-
-  if (err.code == RAI_EBACKENDNOTLOADED) {
-    RedisModule_Log(ctx, "warning", "Backend TORCH not loaded, will try loading default backend");
-    int ret = RAI_LoadDefaultBackend(ctx, RAI_BACKEND_TORCH);
-    if (ret == REDISMODULE_ERR) {
-      RedisModule_Log(ctx, "error", "Could not load TORCH default backend");
-      int ret = RedisModule_ReplyWithError(ctx, "ERR Could not load backend");
-      RAI_ClearError(&err);
-      return ret;
+    RAI_Script *sto;
+    RedisModuleKey *key;
+    const int status = RAI_GetScriptFromKeyspace(ctx, argv[1], &key, &sto, REDISMODULE_WRITE);
+    if (status == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
     }
-    RAI_ClearError(&err);
-    script = RAI_ScriptCreate(devicestr, tag, scriptdef, &err);
-  }
 
-  if (err.code != RAI_OK){
-    #ifdef RAI_PRINT_BACKEND_ERRORS
-    printf("ERR: %s\n", err.detail);
-    #endif
-    int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
-    RAI_ClearError(&err);
-    return ret;
-  }
-
-  RunQueueInfo *run_queue_info = NULL;
-  // If the queue does not exist, initialize it
-  if (ensureRunQueue(devicestr,&run_queue_info) == REDISMODULE_ERR) {
-    RAI_ScriptFree(script, &err);
-    if (err.code != RAI_OK) {
-      #ifdef RAI_PRINT_BACKEND_ERRORS
-      printf("ERR: %s\n", err.detail);
-      #endif
-      int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
-      RAI_ClearError(&err);
-      return ret;
-    }
-    return RedisModule_ReplyWithError(ctx, "ERR Could not initialize queue on requested device");
-  }
-
-  RedisModuleKey *key = RedisModule_OpenKey(ctx, keystr,
-      REDISMODULE_READ|REDISMODULE_WRITE);
-  int type = RedisModule_KeyType(key);
-  if (type != REDISMODULE_KEYTYPE_EMPTY &&
-      !(type == REDISMODULE_KEYTYPE_MODULE &&
-        RedisModule_ModuleTypeGetType(key) == RedisAI_ScriptType)) {
+    RedisModule_DeleteKey(key);
     RedisModule_CloseKey(key);
-    return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-  }
 
-  RedisModule_ModuleTypeSetValue(key, RedisAI_ScriptType, script);
+    RedisModule_ReplicateVerbatim(ctx);
 
-  script->infokey = RAI_AddStatsEntry(ctx, keystr, RAI_SCRIPT, RAI_BACKEND_TORCH, devicestr, tag);
-
-  RedisModule_CloseKey(key);
-
-  RedisModule_ReplyWithSimpleString(ctx, "OK");
-
-  RedisModule_ReplicateVerbatim(ctx);
-
-  return REDISMODULE_OK;
-}
-
-/** 
-* AI._SCRIPTSCAN
-*/
-int RedisAI_ScriptScan_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc != 1) return RedisModule_WrongArity(ctx);
-
-  RedisModule_Log(ctx, "warning", "SCRIPTSCAN is experimental and might be removed in future versions");
-
-  long long nkeys;
-  RedisModuleString** keys;
-  const char** tags;
-  RAI_ListStatsEntries(RAI_SCRIPT, &nkeys, &keys, &tags);
-
-  RedisModule_ReplyWithArray(ctx, nkeys);
-
-  for (long long i=0; i<nkeys; i++) {
-    RedisModule_ReplyWithArray(ctx, 2);
-    RedisModule_ReplyWithString(ctx, keys[i]);
-    RedisModule_ReplyWithCString(ctx, tags[i]);
-  }
-
-  RedisModule_Free(keys);
-  RedisModule_Free(tags);
-
-  return REDISMODULE_OK;
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 
 /**
-* AI.INFO <model_or_script_key> [RESETSTAT]
-*/
-int RedisAI_Info_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc != 2 && argc != 3) return RedisModule_WrongArity(ctx);
-  const char *runkey = RedisModule_StringPtrLen(argv[1], NULL);
-  struct RedisAI_RunStats *rstats = NULL;
-  if (RAI_GetRunStats(runkey, &rstats) == REDISMODULE_ERR) {
-    return RedisModule_ReplyWithError(ctx, "ERR cannot find run info for key");
-  }
+ * AI.SCRIPTSET script_key device [TAG tag] SOURCE script_source
+ */
+int RedisAI_ScriptSet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
 
-  if(argc==3){
-    const char *subcommand = RedisModule_StringPtrLen(argv[2], NULL);
-    if (!strcasecmp(subcommand, "RESETSTAT")) {
-      RAI_ResetRunStats(rstats);
-      RedisModule_ReplyWithSimpleString(ctx, "OK");
-      return REDISMODULE_OK;
+    if (argc != 5 && argc != 7)
+        return RedisModule_WrongArity(ctx);
+
+    ArgsCursor ac;
+    ArgsCursor_InitRString(&ac, argv + 1, argc - 1);
+
+    RedisModuleString *keystr;
+    AC_GetRString(&ac, &keystr, 0);
+
+    const char *devicestr;
+    AC_GetString(&ac, &devicestr, NULL, 0);
+
+    const char *tag = "";
+    if (AC_AdvanceIfMatch(&ac, "TAG")) {
+        AC_GetString(&ac, &tag, NULL, 0);
     }
-  }
 
-  RedisModule_ReplyWithArray(ctx, 18);
+    if (AC_IsAtEnd(&ac)) {
+        return RedisModule_ReplyWithError(ctx, "ERR Insufficient arguments, missing script SOURCE");
+    }
 
-  RedisModule_ReplyWithCString(ctx, "key");
-  RedisModule_ReplyWithString(ctx, rstats->key);
-  RedisModule_ReplyWithCString(ctx, "type");
-  if (rstats->type == 0) {
-    RedisModule_ReplyWithCString(ctx, "MODEL");
-  }
-  else {
-    RedisModule_ReplyWithCString(ctx, "SCRIPT");
-  }
-  RedisModule_ReplyWithCString(ctx, "backend");
-  RedisModule_ReplyWithCString(ctx, RAI_BackendName(rstats->backend));
-  RedisModule_ReplyWithCString(ctx, "device");
-  RedisModule_ReplyWithCString(ctx, rstats->devicestr);
-  RedisModule_ReplyWithCString(ctx, "tag");
-  RedisModule_ReplyWithCString(ctx, rstats->tag);
-  RedisModule_ReplyWithCString(ctx, "duration");
-  RedisModule_ReplyWithLongLong(ctx, rstats->duration_us);
-  RedisModule_ReplyWithCString(ctx, "samples");
-  if (rstats->type == 0) {
-    RedisModule_ReplyWithLongLong(ctx, rstats->samples);
-  }
-  else {
-    RedisModule_ReplyWithLongLong(ctx, -1);
-  }
-  RedisModule_ReplyWithCString(ctx, "calls");
-  RedisModule_ReplyWithLongLong(ctx, rstats->calls);
-  RedisModule_ReplyWithCString(ctx, "errors");
-  RedisModule_ReplyWithLongLong(ctx, rstats->nerrors);
+    size_t scriptlen;
+    const char *scriptdef = NULL;
 
-  return REDISMODULE_OK;
+    if (AC_AdvanceIfMatch(&ac, "SOURCE")) {
+        AC_GetString(&ac, &scriptdef, &scriptlen, 0);
+    }
+
+    if (scriptdef == NULL) {
+        return RedisModule_ReplyWithError(ctx, "ERR Insufficient arguments, missing script SOURCE");
+    }
+
+    RAI_Script *script = NULL;
+
+    RAI_Error err = {0};
+    script = RAI_ScriptCreate(devicestr, tag, scriptdef, &err);
+
+    if (err.code == RAI_EBACKENDNOTLOADED) {
+        RedisModule_Log(ctx, "warning",
+                        "Backend TORCH not loaded, will try loading default backend");
+        int ret = RAI_LoadDefaultBackend(ctx, RAI_BACKEND_TORCH);
+        if (ret == REDISMODULE_ERR) {
+            RedisModule_Log(ctx, "error", "Could not load TORCH default backend");
+            int ret = RedisModule_ReplyWithError(ctx, "ERR Could not load backend");
+            RAI_ClearError(&err);
+            return ret;
+        }
+        RAI_ClearError(&err);
+        script = RAI_ScriptCreate(devicestr, tag, scriptdef, &err);
+    }
+
+    if (err.code != RAI_OK) {
+#ifdef RAI_PRINT_BACKEND_ERRORS
+        printf("ERR: %s\n", err.detail);
+#endif
+        int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
+        RAI_ClearError(&err);
+        return ret;
+    }
+
+    RunQueueInfo *run_queue_info = NULL;
+    // If the queue does not exist, initialize it
+    if (ensureRunQueue(devicestr, &run_queue_info) == REDISMODULE_ERR) {
+        RAI_ScriptFree(script, &err);
+        if (err.code != RAI_OK) {
+#ifdef RAI_PRINT_BACKEND_ERRORS
+            printf("ERR: %s\n", err.detail);
+#endif
+            int ret = RedisModule_ReplyWithError(ctx, err.detail_oneline);
+            RAI_ClearError(&err);
+            return ret;
+        }
+        return RedisModule_ReplyWithError(ctx,
+                                          "ERR Could not initialize queue on requested device");
+    }
+
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, keystr, REDISMODULE_READ | REDISMODULE_WRITE);
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_EMPTY &&
+        !(type == REDISMODULE_KEYTYPE_MODULE &&
+          RedisModule_ModuleTypeGetType(key) == RedisAI_ScriptType)) {
+        RedisModule_CloseKey(key);
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+    }
+
+    RedisModule_ModuleTypeSetValue(key, RedisAI_ScriptType, script);
+
+    script->infokey = RAI_AddStatsEntry(ctx, keystr, RAI_SCRIPT, RAI_BACKEND_TORCH, devicestr, tag);
+
+    RedisModule_CloseKey(key);
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+
+    RedisModule_ReplicateVerbatim(ctx);
+
+    return REDISMODULE_OK;
 }
 
-/** 
-* AI.CONFIG [BACKENDSPATH <default_location_of_backend_libraries> | 
+/**
+ * AI._SCRIPTSCAN
+ */
+int RedisAI_ScriptScan_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 1)
+        return RedisModule_WrongArity(ctx);
+
+    RedisModule_Log(ctx, "warning",
+                    "SCRIPTSCAN is experimental and might be removed in future versions");
+
+    long long nkeys;
+    RedisModuleString **keys;
+    const char **tags;
+    RAI_ListStatsEntries(RAI_SCRIPT, &nkeys, &keys, &tags);
+
+    RedisModule_ReplyWithArray(ctx, nkeys);
+
+    for (long long i = 0; i < nkeys; i++) {
+        RedisModule_ReplyWithArray(ctx, 2);
+        RedisModule_ReplyWithString(ctx, keys[i]);
+        RedisModule_ReplyWithCString(ctx, tags[i]);
+    }
+
+    RedisModule_Free(keys);
+    RedisModule_Free(tags);
+
+    return REDISMODULE_OK;
+}
+
+/**
+ * AI.INFO <model_or_script_key> [RESETSTAT]
+ */
+int RedisAI_Info_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 2 && argc != 3)
+        return RedisModule_WrongArity(ctx);
+    const char *runkey = RedisModule_StringPtrLen(argv[1], NULL);
+    struct RedisAI_RunStats *rstats = NULL;
+    if (RAI_GetRunStats(runkey, &rstats) == REDISMODULE_ERR) {
+        return RedisModule_ReplyWithError(ctx, "ERR cannot find run info for key");
+    }
+
+    if (argc == 3) {
+        const char *subcommand = RedisModule_StringPtrLen(argv[2], NULL);
+        if (!strcasecmp(subcommand, "RESETSTAT")) {
+            RAI_ResetRunStats(rstats);
+            RedisModule_ReplyWithSimpleString(ctx, "OK");
+            return REDISMODULE_OK;
+        }
+    }
+
+    RedisModule_ReplyWithArray(ctx, 18);
+
+    RedisModule_ReplyWithCString(ctx, "key");
+    RedisModule_ReplyWithString(ctx, rstats->key);
+    RedisModule_ReplyWithCString(ctx, "type");
+    if (rstats->type == 0) {
+        RedisModule_ReplyWithCString(ctx, "MODEL");
+    } else {
+        RedisModule_ReplyWithCString(ctx, "SCRIPT");
+    }
+    RedisModule_ReplyWithCString(ctx, "backend");
+    RedisModule_ReplyWithCString(ctx, RAI_BackendName(rstats->backend));
+    RedisModule_ReplyWithCString(ctx, "device");
+    RedisModule_ReplyWithCString(ctx, rstats->devicestr);
+    RedisModule_ReplyWithCString(ctx, "tag");
+    RedisModule_ReplyWithCString(ctx, rstats->tag);
+    RedisModule_ReplyWithCString(ctx, "duration");
+    RedisModule_ReplyWithLongLong(ctx, rstats->duration_us);
+    RedisModule_ReplyWithCString(ctx, "samples");
+    if (rstats->type == 0) {
+        RedisModule_ReplyWithLongLong(ctx, rstats->samples);
+    } else {
+        RedisModule_ReplyWithLongLong(ctx, -1);
+    }
+    RedisModule_ReplyWithCString(ctx, "calls");
+    RedisModule_ReplyWithLongLong(ctx, rstats->calls);
+    RedisModule_ReplyWithCString(ctx, "errors");
+    RedisModule_ReplyWithLongLong(ctx, rstats->nerrors);
+
+    return REDISMODULE_OK;
+}
+
+/**
+* AI.CONFIG [BACKENDSPATH <default_location_of_backend_libraries> |
              LOADBACKEND <backend_identifier> <location_of_backend_library> |
              CHUNKLEN <len>]
 */
 int RedisAI_Config_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc < 2) return RedisModule_WrongArity(ctx);
+    if (argc < 2)
+        return RedisModule_WrongArity(ctx);
 
-  const char *subcommand = RedisModule_StringPtrLen(argv[1], NULL);
-  if (!strcasecmp(subcommand, "LOADBACKEND")) {
-    return RedisAI_Config_LoadBackend(ctx, argv + 1, argc - 1);
-  }
-
-  if (!strcasecmp(subcommand, "BACKENDSPATH")) {
-    if (argc > 2) {
-      return RedisAI_Config_BackendsPath(
-          ctx, RedisModule_StringPtrLen(argv[2], NULL));
-    } else {
-      return RedisModule_ReplyWithError(
-          ctx, "ERR BACKENDSPATH: missing path argument");
+    const char *subcommand = RedisModule_StringPtrLen(argv[1], NULL);
+    if (!strcasecmp(subcommand, "LOADBACKEND")) {
+        return RedisAI_Config_LoadBackend(ctx, argv + 1, argc - 1);
     }
-  }
 
-  if (!strcasecmp(subcommand, "MODEL_CHUNK_SIZE")) {
-    if (argc > 2) {
-      RedisAI_Config_ModelChunkSize(argv[2]);
-      return RedisModule_ReplyWithSimpleString(ctx, "OK");
-    } else {
-      return RedisModule_ReplyWithError(
-          ctx, "ERR MODEL_CHUNK_SIZE: missing chunk size");
+    if (!strcasecmp(subcommand, "BACKENDSPATH")) {
+        if (argc > 2) {
+            return RedisAI_Config_BackendsPath(ctx, RedisModule_StringPtrLen(argv[2], NULL));
+        } else {
+            return RedisModule_ReplyWithError(ctx, "ERR BACKENDSPATH: missing path argument");
+        }
     }
-  }
 
-  return RedisModule_ReplyWithError(ctx, "ERR unsupported subcommand");
+    if (!strcasecmp(subcommand, "MODEL_CHUNK_SIZE")) {
+        if (argc > 2) {
+            RedisAI_Config_ModelChunkSize(argv[2]);
+            return RedisModule_ReplyWithSimpleString(ctx, "OK");
+        } else {
+            return RedisModule_ReplyWithError(ctx, "ERR MODEL_CHUNK_SIZE: missing chunk size");
+        }
+    }
+
+    return RedisModule_ReplyWithError(ctx, "ERR unsupported subcommand");
 }
 
 /**
- * AI.DAGRUN [LOAD <nkeys> key1 key2... ] [PERSIST <nkeys> key1 key2... ] [TIMEOUT t] |>
- * [COMMAND1] |> [COMMAND2] |> [COMMANDN]
+ * AI.DAGRUN [LOAD <nkeys> key1 key2... ] [PERSIST <nkeys> key1 key2... ]
+ * [TIMEOUT t] |> [COMMAND1] |> [COMMAND2] |> [COMMANDN]
  *
  * The request is queued and evaded asynchronously from a separate thread. The
  * client blocks until the computation finishes.
  */
-int RedisAI_DagRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                int argc) {
-  if (RedisModule_IsKeysPositionRequest(ctx)) {
-     return RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(ctx, argv, argc);
-  }
-  return RedisAI_DagRunSyntaxParser(ctx, argv, argc, REDISAI_DAG_WRITE_MODE);
+int RedisAI_DagRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (RedisModule_IsKeysPositionRequest(ctx)) {
+        return RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(ctx, argv, argc);
+    }
+    return RedisAI_DagRunSyntaxParser(ctx, argv, argc, REDISAI_DAG_WRITE_MODE);
 }
 
 /**
- * AI.DAGRUN_RO [LOAD <nkeys> key1 key2... ] [TIMEOUT t] |> [COMMAND1] |> [COMMAND2] |> [COMMANDN]
+ * AI.DAGRUN_RO [LOAD <nkeys> key1 key2... ] [TIMEOUT t] |> [COMMAND1] |>
+ * [COMMAND2] |> [COMMANDN]
  *
  * Read-only (no PERSIST) DAG execution.
  * The request is queued and evaded asynchronously from a separate thread. The
  * client blocks until the computation finishes.
  */
-int RedisAI_DagRunRO_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                  int argc) {
-  if (RedisModule_IsKeysPositionRequest(ctx)) {
-     return RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(ctx, argv, argc);
-  }
-  return RedisAI_DagRunSyntaxParser(ctx, argv, argc, REDISAI_DAG_READONLY_MODE);
+int RedisAI_DagRunRO_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (RedisModule_IsKeysPositionRequest(ctx)) {
+        return RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(ctx, argv, argc);
+    }
+    return RedisAI_DagRunSyntaxParser(ctx, argv, argc, REDISAI_DAG_READONLY_MODE);
 }
 
 #define EXECUTION_PLAN_FREE_MSG 100
 
-#define REGISTER_API(name, ctx) \
-  if (RedisModule_ExportSharedAPI) {\
-    if (RedisModule_ExportSharedAPI(ctx, "RedisAI_" #name, RAI_ ## name) != REDISMODULE_OK) {\
-      RedisModule_Log(ctx, "warning", "Could not register RedisAI_%s", #name);\
-      return REDISMODULE_ERR;\
-    }\
-  }
+#define REGISTER_API(name, ctx)                                                                    \
+    if (RedisModule_ExportSharedAPI) {                                                             \
+        if (RedisModule_ExportSharedAPI(ctx, "RedisAI_" #name, RAI_##name) != REDISMODULE_OK) {    \
+            RedisModule_Log(ctx, "warning", "Could not register RedisAI_%s", #name);               \
+            return REDISMODULE_ERR;                                                                \
+        }                                                                                          \
+    }
 
-static int RAI_GetLLAPIVersion(){
-  return REDISAI_LLAPI_VERSION;
-}
+static int RAI_GetLLAPIVersion() { return REDISAI_LLAPI_VERSION; }
 
-static int RedisAI_RegisterApi(RedisModuleCtx* ctx) {
+static int RedisAI_RegisterApi(RedisModuleCtx *ctx) {
 
-  if (!RedisModule_ExportSharedAPI) {
-    RedisModule_Log(ctx, "warning", "Redis version does not support SharedAPI; running without exposing C API to other modules");
-  }
+    if (!RedisModule_ExportSharedAPI) {
+        RedisModule_Log(ctx, "warning",
+                        "Redis version does not support SharedAPI; running without "
+                        "exposing C API to other modules");
+    }
 
-  REGISTER_API(GetLLAPIVersion, ctx);
+    REGISTER_API(GetLLAPIVersion, ctx);
 
-  REGISTER_API(InitError, ctx);
-  REGISTER_API(ClearError, ctx);
-  REGISTER_API(FreeError, ctx);
-  REGISTER_API(GetError, ctx);
-  REGISTER_API(GetErrorOneLine, ctx);
-  REGISTER_API(GetErrorCode, ctx);
+    REGISTER_API(InitError, ctx);
+    REGISTER_API(ClearError, ctx);
+    REGISTER_API(FreeError, ctx);
+    REGISTER_API(GetError, ctx);
+    REGISTER_API(GetErrorOneLine, ctx);
+    REGISTER_API(GetErrorCode, ctx);
 
-  REGISTER_API(TensorCreate, ctx);
-  REGISTER_API(TensorCreateByConcatenatingTensors, ctx);
-  REGISTER_API(TensorCreateBySlicingTensor, ctx);
-  REGISTER_API(TensorLength, ctx);
-  REGISTER_API(TensorDataSize, ctx);
-  REGISTER_API(TensorFree, ctx);
-  REGISTER_API(TensorSetData, ctx);
-  REGISTER_API(TensorSetValueFromLongLong, ctx);
-  REGISTER_API(TensorSetValueFromDouble, ctx);
-  REGISTER_API(TensorGetValueAsDouble, ctx);
-  REGISTER_API(TensorGetValueAsLongLong, ctx);
-  REGISTER_API(TensorGetShallowCopy, ctx);
-  REGISTER_API(TensorNumDims, ctx);
-  REGISTER_API(TensorDim, ctx);
-  REGISTER_API(TensorByteSize, ctx);
-  REGISTER_API(TensorData, ctx);
-  REGISTER_API(TensorRedisType, ctx);
+    REGISTER_API(TensorCreate, ctx);
+    REGISTER_API(TensorCreateByConcatenatingTensors, ctx);
+    REGISTER_API(TensorCreateBySlicingTensor, ctx);
+    REGISTER_API(TensorLength, ctx);
+    REGISTER_API(TensorDataSize, ctx);
+    REGISTER_API(TensorFree, ctx);
+    REGISTER_API(TensorSetData, ctx);
+    REGISTER_API(TensorSetValueFromLongLong, ctx);
+    REGISTER_API(TensorSetValueFromDouble, ctx);
+    REGISTER_API(TensorGetValueAsDouble, ctx);
+    REGISTER_API(TensorGetValueAsLongLong, ctx);
+    REGISTER_API(TensorGetShallowCopy, ctx);
+    REGISTER_API(TensorNumDims, ctx);
+    REGISTER_API(TensorDim, ctx);
+    REGISTER_API(TensorByteSize, ctx);
+    REGISTER_API(TensorData, ctx);
+    REGISTER_API(TensorRedisType, ctx);
 
-  REGISTER_API(ModelCreate, ctx);
-  REGISTER_API(ModelFree, ctx);
-  REGISTER_API(ModelRunCtxCreate, ctx);
-  REGISTER_API(ModelRunCtxAddInput, ctx);
-  REGISTER_API(ModelRunCtxAddOutput, ctx);
-  REGISTER_API(ModelRunCtxNumOutputs, ctx);
-  REGISTER_API(ModelRunCtxOutputTensor, ctx);
-  REGISTER_API(ModelRunCtxFree, ctx);
-  REGISTER_API(ModelRun, ctx);
-  REGISTER_API(ModelSerialize, ctx);
-  REGISTER_API(ModelGetShallowCopy, ctx);
-  REGISTER_API(ModelRedisType, ctx);
+    REGISTER_API(ModelCreate, ctx);
+    REGISTER_API(ModelFree, ctx);
+    REGISTER_API(ModelRunCtxCreate, ctx);
+    REGISTER_API(ModelRunCtxAddInput, ctx);
+    REGISTER_API(ModelRunCtxAddOutput, ctx);
+    REGISTER_API(ModelRunCtxNumOutputs, ctx);
+    REGISTER_API(ModelRunCtxOutputTensor, ctx);
+    REGISTER_API(ModelRunCtxFree, ctx);
+    REGISTER_API(ModelRun, ctx);
+    REGISTER_API(ModelSerialize, ctx);
+    REGISTER_API(ModelGetShallowCopy, ctx);
+    REGISTER_API(ModelRedisType, ctx);
 
-  REGISTER_API(ScriptCreate, ctx);
-  REGISTER_API(ScriptFree, ctx);
-  REGISTER_API(ScriptRunCtxCreate, ctx);
-  REGISTER_API(ScriptRunCtxAddInput, ctx);
-  REGISTER_API(ScriptRunCtxAddInputList, ctx);
-  REGISTER_API(ScriptRunCtxAddOutput, ctx);
-  REGISTER_API(ScriptRunCtxNumOutputs, ctx);
-  REGISTER_API(ScriptRunCtxOutputTensor, ctx);
-  REGISTER_API(ScriptRunCtxFree, ctx);
-  REGISTER_API(ScriptRun, ctx);
-  REGISTER_API(ScriptGetShallowCopy, ctx);
-  REGISTER_API(ScriptRedisType, ctx);
+    REGISTER_API(ScriptCreate, ctx);
+    REGISTER_API(ScriptFree, ctx);
+    REGISTER_API(ScriptRunCtxCreate, ctx);
+    REGISTER_API(ScriptRunCtxAddInput, ctx);
+    REGISTER_API(ScriptRunCtxAddInputList, ctx);
+    REGISTER_API(ScriptRunCtxAddOutput, ctx);
+    REGISTER_API(ScriptRunCtxNumOutputs, ctx);
+    REGISTER_API(ScriptRunCtxOutputTensor, ctx);
+    REGISTER_API(ScriptRunCtxFree, ctx);
+    REGISTER_API(ScriptRun, ctx);
+    REGISTER_API(ScriptGetShallowCopy, ctx);
+    REGISTER_API(ScriptRedisType, ctx);
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
 void RAI_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
@@ -984,10 +990,14 @@ void RAI_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
     // Return resource usage statistics for all of its
     // terminated child processes
     getrusage(RUSAGE_CHILDREN, &c_ru);
-    sds self_used_cpu_sys = sdscatprintf(sdsempty(),"%ld.%06ld",(long)self_ru.ru_stime.tv_sec,(long)self_ru.ru_stime.tv_usec);
-    sds self_used_cpu_user = sdscatprintf(sdsempty(),"%ld.%06ld",(long)self_ru.ru_utime.tv_sec, (long)self_ru.ru_utime.tv_usec);
-    sds children_used_cpu_sys = sdscatprintf(sdsempty(),"%ld.%06ld",(long)c_ru.ru_stime.tv_sec,(long)c_ru.ru_stime.tv_usec);
-    sds children_used_cpu_user = sdscatprintf(sdsempty(),"%ld.%06ld",(long)c_ru.ru_utime.tv_sec, (long)c_ru.ru_utime.tv_usec);
+    sds self_used_cpu_sys = sdscatprintf(sdsempty(), "%ld.%06ld", (long)self_ru.ru_stime.tv_sec,
+                                         (long)self_ru.ru_stime.tv_usec);
+    sds self_used_cpu_user = sdscatprintf(sdsempty(), "%ld.%06ld", (long)self_ru.ru_utime.tv_sec,
+                                          (long)self_ru.ru_utime.tv_usec);
+    sds children_used_cpu_sys = sdscatprintf(sdsempty(), "%ld.%06ld", (long)c_ru.ru_stime.tv_sec,
+                                             (long)c_ru.ru_stime.tv_usec);
+    sds children_used_cpu_user = sdscatprintf(sdsempty(), "%ld.%06ld", (long)c_ru.ru_utime.tv_sec,
+                                              (long)c_ru.ru_utime.tv_usec);
     RedisModule_InfoAddSection(ctx, "cpu");
     RedisModule_InfoAddFieldCString(ctx, "self_used_cpu_sys", self_used_cpu_sys);
     RedisModule_InfoAddFieldCString(ctx, "self_used_cpu_user", self_used_cpu_user);
@@ -997,169 +1007,174 @@ void RAI_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
     AI_dictIterator *iter = AI_dictGetSafeIterator(run_queues);
     AI_dictEntry *entry = AI_dictNext(iter);
     while (entry) {
-      char *queue_name = (char *)AI_dictGetKey(entry);
-      RunQueueInfo *run_queue_info = (RunQueueInfo *)AI_dictGetVal(entry);
-      if(run_queue_info){
-        for (int i = 0; i < perqueueThreadPoolSize; i++) {
-          pthread_t current_bg_threads = run_queue_info->threads[i];
-          struct timespec ts;
-          clockid_t cid;
-          sds queue_used_cpu_total = sdscatprintf(sdsempty(),"queue_%s_bthread_#%d_used_cpu_total",queue_name,i+1);
-          sds bthread_used_cpu_total = sdsempty();
-          #if (!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || defined(_DARWIN_C_SOURCE) || defined(__cplusplus)
-          const int status = -1;
-          #else
-          const int status = pthread_getcpuclockid(current_bg_threads,&cid);
-          #endif
-          if (status != 0){
-            bthread_used_cpu_total = sdscatprintf(bthread_used_cpu_total,"N/A");
-          } else {
-            if (clock_gettime(cid, &ts) == -1){
-              bthread_used_cpu_total = sdscatprintf(bthread_used_cpu_total,"N/A");
-            } else {
-                bthread_used_cpu_total = sdscatprintf(bthread_used_cpu_total,"%ld.%06ld",(long)ts.tv_sec, (long)(ts.tv_nsec / 1000000));
+        char *queue_name = (char *)AI_dictGetKey(entry);
+        RunQueueInfo *run_queue_info = (RunQueueInfo *)AI_dictGetVal(entry);
+        if (run_queue_info) {
+            for (int i = 0; i < perqueueThreadPoolSize; i++) {
+                pthread_t current_bg_threads = run_queue_info->threads[i];
+                struct timespec ts;
+                clockid_t cid;
+                sds queue_used_cpu_total = sdscatprintf(
+                    sdsempty(), "queue_%s_bthread_#%d_used_cpu_total", queue_name, i + 1);
+                sds bthread_used_cpu_total = sdsempty();
+#if (!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || defined(_DARWIN_C_SOURCE) ||         \
+    defined(__cplusplus)
+                const int status = -1;
+#else
+                const int status = pthread_getcpuclockid(current_bg_threads, &cid);
+#endif
+                if (status != 0) {
+                    bthread_used_cpu_total = sdscatprintf(bthread_used_cpu_total, "N/A");
+                } else {
+                    if (clock_gettime(cid, &ts) == -1) {
+                        bthread_used_cpu_total = sdscatprintf(bthread_used_cpu_total, "N/A");
+                    } else {
+                        bthread_used_cpu_total =
+                            sdscatprintf(bthread_used_cpu_total, "%ld.%06ld", (long)ts.tv_sec,
+                                         (long)(ts.tv_nsec / 1000000));
+                    }
+                }
+                RedisModule_InfoAddFieldCString(ctx, queue_used_cpu_total, bthread_used_cpu_total);
             }
-          }
-          RedisModule_InfoAddFieldCString(ctx, queue_used_cpu_total, bthread_used_cpu_total);
         }
-      }
-      entry = AI_dictNext(iter);
+        entry = AI_dictNext(iter);
     }
     AI_dictReleaseIterator(iter);
 }
 
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
-  if (RedisModule_Init(ctx, "ai", RAI_ENC_VER, REDISMODULE_APIVER_1)
-      == REDISMODULE_ERR) return REDISMODULE_ERR;
+    if (RedisModule_Init(ctx, "ai", RAI_ENC_VER, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  getRedisVersion();
-  RedisModule_Log(ctx, "notice", "Redis version found by RedisAI: %d.%d.%d - %s",
-                      redisMajorVersion, redisMinorVersion, redisPatchVersion,
-                      IsEnterprise() ? "enterprise" : "oss");
-  if (IsEnterprise()) {
-      RedisModule_Log(ctx, "notice", "Redis Enterprise version found by RedisAI: %d.%d.%d-%d",
-                      rlecMajorVersion, rlecMinorVersion, rlecPatchVersion, rlecBuild);
-  }
+    getRedisVersion();
+    RedisModule_Log(ctx, "notice", "Redis version found by RedisAI: %d.%d.%d - %s",
+                    redisMajorVersion, redisMinorVersion, redisPatchVersion,
+                    IsEnterprise() ? "enterprise" : "oss");
+    if (IsEnterprise()) {
+        RedisModule_Log(ctx, "notice", "Redis Enterprise version found by RedisAI: %d.%d.%d-%d",
+                        rlecMajorVersion, rlecMinorVersion, rlecPatchVersion, rlecBuild);
+    }
 
-  if (redisMajorVersion < 5 ||
-      (redisMajorVersion == 5 && redisMinorVersion == 0 && redisPatchVersion < 7)) {
-    RedisModule_Log(ctx, "warning", "RedisAI requires Redis version equal or greater than 5.0.7");
-    return REDISMODULE_ERR;
-  }
+    if (redisMajorVersion < 5 ||
+        (redisMajorVersion == 5 && redisMinorVersion == 0 && redisPatchVersion < 7)) {
+        RedisModule_Log(ctx, "warning",
+                        "RedisAI requires Redis version equal or greater than 5.0.7");
+        return REDISMODULE_ERR;
+    }
 
-  if (redisMajorVersion >= 6){
-    if (RedisModule_RegisterInfoFunc(ctx, RAI_moduleInfoFunc) == REDISMODULE_ERR) return REDISMODULE_ERR;
-  }
+    if (redisMajorVersion >= 6) {
+        if (RedisModule_RegisterInfoFunc(ctx, RAI_moduleInfoFunc) == REDISMODULE_ERR)
+            return REDISMODULE_ERR;
+    }
 
-  RedisModule_Log(ctx, "notice", "RedisAI version %d, git_sha=%s",
-                  RAI_ENC_VER, REDISAI_GIT_SHA);
- 
-  int flags = RedisModule_GetContextFlags(ctx);
+    RedisModule_Log(ctx, "notice", "RedisAI version %d, git_sha=%s", RAI_ENC_VER, REDISAI_GIT_SHA);
 
-  if(RedisAI_RegisterApi(ctx) != REDISMODULE_OK){
-    RedisModule_Log(ctx, "warning", "could not register RedisAI api\r\n");
-    return REDISMODULE_ERR;
-  }
+    int flags = RedisModule_GetContextFlags(ctx);
 
-  if(!RAI_TensorInit(ctx)){
-    RedisModule_Log(ctx, "warning", "can not initialize tensor dt\r\n");
-    return REDISMODULE_ERR;
-  }
+    if (RedisAI_RegisterApi(ctx) != REDISMODULE_OK) {
+        RedisModule_Log(ctx, "warning", "could not register RedisAI api\r\n");
+        return REDISMODULE_ERR;
+    }
 
-  if(!RAI_ModelInit(ctx)){
-    RedisModule_Log(ctx, "warning", "can not initialize model dt\r\n");
-    return REDISMODULE_ERR;
-  }
+    if (!RAI_TensorInit(ctx)) {
+        RedisModule_Log(ctx, "warning", "can not initialize tensor dt\r\n");
+        return REDISMODULE_ERR;
+    }
 
-  if(!RAI_ScriptInit(ctx)){
-    RedisModule_Log(ctx, "warning", "can not initialize script dt\r\n");
-    return REDISMODULE_ERR;
-  }
+    if (!RAI_ModelInit(ctx)) {
+        RedisModule_Log(ctx, "warning", "can not initialize model dt\r\n");
+        return REDISMODULE_ERR;
+    }
 
-  if (RedisModule_CreateCommand(ctx, "ai.tensorset", RedisAI_TensorSet_RedisCommand, "write deny-oom", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (!RAI_ScriptInit(ctx)) {
+        RedisModule_Log(ctx, "warning", "can not initialize script dt\r\n");
+        return REDISMODULE_ERR;
+    }
 
-  if (RedisModule_CreateCommand(ctx, "ai.tensorget", RedisAI_TensorGet_RedisCommand, "readonly", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.tensorset", RedisAI_TensorSet_RedisCommand,
+                                  "write deny-oom", 1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.modelset", RedisAI_ModelSet_RedisCommand, "write deny-oom", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.tensorget", RedisAI_TensorGet_RedisCommand, "readonly",
+                                  1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.modelget", RedisAI_ModelGet_RedisCommand, "readonly", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.modelset", RedisAI_ModelSet_RedisCommand,
+                                  "write deny-oom", 1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.modeldel", RedisAI_ModelDel_RedisCommand, "write", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.modelget", RedisAI_ModelGet_RedisCommand, "readonly", 1,
+                                  1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.modelrun", RedisAI_ModelRun_RedisCommand, "write deny-oom getkeys-api", 3, 3, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.modeldel", RedisAI_ModelDel_RedisCommand, "write", 1, 1,
+                                  1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai._modelscan", RedisAI_ModelScan_RedisCommand, "readonly", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.modelrun", RedisAI_ModelRun_RedisCommand,
+                                  "write deny-oom getkeys-api", 3, 3, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.scriptset", RedisAI_ScriptSet_RedisCommand, "write deny-oom", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai._modelscan", RedisAI_ModelScan_RedisCommand, "readonly",
+                                  1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.scriptget", RedisAI_ScriptGet_RedisCommand, "readonly", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.scriptset", RedisAI_ScriptSet_RedisCommand,
+                                  "write deny-oom", 1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.scriptdel", RedisAI_ScriptDel_RedisCommand, "write", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.scriptget", RedisAI_ScriptGet_RedisCommand, "readonly",
+                                  1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.scriptrun", RedisAI_ScriptRun_RedisCommand, "write deny-oom getkeys-api", 4, 4, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.scriptdel", RedisAI_ScriptDel_RedisCommand, "write", 1,
+                                  1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai._scriptscan", RedisAI_ScriptScan_RedisCommand, "readonly", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.scriptrun", RedisAI_ScriptRun_RedisCommand,
+                                  "write deny-oom getkeys-api", 4, 4, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.info", RedisAI_Info_RedisCommand, "readonly", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai._scriptscan", RedisAI_ScriptScan_RedisCommand,
+                                  "readonly", 1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.config", RedisAI_Config_RedisCommand, "write", 1, 1, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.info", RedisAI_Info_RedisCommand, "readonly", 1, 1, 1) ==
+        REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.dagrun", RedisAI_DagRun_RedisCommand, "write deny-oom getkeys-api", 3, 3, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.config", RedisAI_Config_RedisCommand, "write", 1, 1,
+                                  1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  if (RedisModule_CreateCommand(ctx, "ai.dagrun_ro", RedisAI_DagRunRO_RedisCommand, "readonly getkeys-api", 3, 3, 1)
-      == REDISMODULE_ERR)
-    return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "ai.dagrun", RedisAI_DagRun_RedisCommand,
+                                  "write deny-oom getkeys-api", 3, 3, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  // Default configs
-  RAI_BackendsPath = NULL;
-  perqueueThreadPoolSize = REDISAI_DEFAULT_THREADS_PER_QUEUE;
-  setBackendsInterOpParallelism(REDISAI_DEFAULT_INTER_OP_PARALLELISM);
-  setBackendsIntraOpParallelism(REDISAI_DEFAULT_INTRA_OP_PARALLELISM);
-  setModelChunkSize(REDISAI_DEFAULT_MODEL_CHUNK_SIZE);
-  
-  RAI_loadTimeConfig(ctx,argv,argc);
+    if (RedisModule_CreateCommand(ctx, "ai.dagrun_ro", RedisAI_DagRunRO_RedisCommand,
+                                  "readonly getkeys-api", 3, 3, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-  run_queues = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
-  RunQueueInfo *run_queue_info = NULL;
-  if (ensureRunQueue("CPU",&run_queue_info) != REDISMODULE_OK){
-    RedisModule_Log(ctx, "warning", "Queue not initialized for device CPU" );
-    return REDISMODULE_ERR;
-  }
+    // Default configs
+    RAI_BackendsPath = NULL;
+    perqueueThreadPoolSize = REDISAI_DEFAULT_THREADS_PER_QUEUE;
+    setBackendsInterOpParallelism(REDISAI_DEFAULT_INTER_OP_PARALLELISM);
+    setBackendsIntraOpParallelism(REDISAI_DEFAULT_INTRA_OP_PARALLELISM);
+    setModelChunkSize(REDISAI_DEFAULT_MODEL_CHUNK_SIZE);
 
-  run_stats = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
-  
-  return REDISMODULE_OK;
+    RAI_loadTimeConfig(ctx, argv, argc);
+
+    run_queues = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
+    RunQueueInfo *run_queue_info = NULL;
+    if (ensureRunQueue("CPU", &run_queue_info) != REDISMODULE_OK) {
+        RedisModule_Log(ctx, "warning", "Queue not initialized for device CPU");
+        return REDISMODULE_ERR;
+    }
+
+    run_stats = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
+
+    return REDISMODULE_OK;
 }
 
 extern AI_dictType AI_dictTypeHeapStrings;

--- a/src/redisai.h
+++ b/src/redisai.h
@@ -1,12 +1,12 @@
 #ifndef SRC_REDISAI_H_
 #define SRC_REDISAI_H_
 
-#include <stdbool.h>
+#include "background_workers.h"
+#include "model_struct.h"
 #include "redismodule.h"
 #include "util/dict.h"
-#include "model_struct.h"
-#include "background_workers.h"
 #include "version.h"
+#include <stdbool.h>
 
 #define MODULE_API_FUNC(x) (*x)
 
@@ -20,168 +20,178 @@ typedef struct RAI_ScriptRunCtx RAI_ScriptRunCtx;
 typedef struct RAI_Error RAI_Error;
 #endif
 
-#define REDISAI_BACKEND_TENSORFLOW 0
-#define REDISAI_BACKEND_TFLITE 1
-#define REDISAI_BACKEND_TORCH 2
+#define REDISAI_BACKEND_TENSORFLOW  0
+#define REDISAI_BACKEND_TFLITE      1
+#define REDISAI_BACKEND_TORCH       2
 #define REDISAI_BACKEND_ONNXRUNTIME 3
 
 #define REDISAI_DEVICE_CPU 0
 #define REDISAI_DEVICE_GPU 1
 
-#define RedisAI_ErrorCode int
-#define RedisAI_ErrorCode_OK 0
-#define RedisAI_ErrorCode_EMODELIMPORT 1
-#define RedisAI_ErrorCode_EMODELCONFIGURE 2
-#define RedisAI_ErrorCode_EMODELCREATE 3
-#define RedisAI_ErrorCode_EMODELRUN 4
-#define RedisAI_ErrorCode_EMODELSERIALIZE 5
-#define RedisAI_ErrorCode_EMODELFREE 6
-#define RedisAI_ErrorCode_ESCRIPTIMPORT 7
-#define RedisAI_ErrorCode_ESCRIPTCONFIGURE 8
-#define RedisAI_ErrorCode_ESCRIPTCREATE 9
-#define RedisAI_ErrorCode_ESCRIPTRUN 10
+#define RedisAI_ErrorCode                     int
+#define RedisAI_ErrorCode_OK                  0
+#define RedisAI_ErrorCode_EMODELIMPORT        1
+#define RedisAI_ErrorCode_EMODELCONFIGURE     2
+#define RedisAI_ErrorCode_EMODELCREATE        3
+#define RedisAI_ErrorCode_EMODELRUN           4
+#define RedisAI_ErrorCode_EMODELSERIALIZE     5
+#define RedisAI_ErrorCode_EMODELFREE          6
+#define RedisAI_ErrorCode_ESCRIPTIMPORT       7
+#define RedisAI_ErrorCode_ESCRIPTCONFIGURE    8
+#define RedisAI_ErrorCode_ESCRIPTCREATE       9
+#define RedisAI_ErrorCode_ESCRIPTRUN          10
 #define RedisAI_ErrorCode_EUNSUPPORTEDBACKEND 11
-#define RedisAI_ErrorCode_EBACKENDNOTLOADED 12
-#define RedisAI_ErrorCode_ESCRIPTFREE 13
-#define RedisAI_ErrorCode_ETENSORSET 14
-#define RedisAI_ErrorCode_ETENSORGET 15
-#define RedisAI_ErrorCode_EDAGRUN 17
+#define RedisAI_ErrorCode_EBACKENDNOTLOADED   12
+#define RedisAI_ErrorCode_ESCRIPTFREE         13
+#define RedisAI_ErrorCode_ETENSORSET          14
+#define RedisAI_ErrorCode_ETENSORGET          15
+#define RedisAI_ErrorCode_EDAGRUN             17
 
-enum RedisAI_DataFmt {
-  REDISAI_DATA_BLOB = 0,
-  REDISAI_DATA_VALUES,
-  REDISAI_DATA_NONE
-};
+enum RedisAI_DataFmt { REDISAI_DATA_BLOB = 0, REDISAI_DATA_VALUES, REDISAI_DATA_NONE };
 
 int MODULE_API_FUNC(RedisAI_InitError)(RAI_Error **err);
 void MODULE_API_FUNC(RedisAI_ClearError)(RAI_Error *err);
 void MODULE_API_FUNC(RedisAI_FreeError)(RAI_Error *err);
-const char* MODULE_API_FUNC(RedisAI_GetError)(RAI_Error *err);
-const char* MODULE_API_FUNC(RedisAI_GetErrorOneLine)(RAI_Error *err);
+const char *MODULE_API_FUNC(RedisAI_GetError)(RAI_Error *err);
+const char *MODULE_API_FUNC(RedisAI_GetErrorOneLine)(RAI_Error *err);
 RedisAI_ErrorCode MODULE_API_FUNC(RedisAI_GetErrorCode)(RAI_Error *err);
 
-RAI_Tensor* MODULE_API_FUNC(RedisAI_TensorCreate)(const char* dataTypeStr, long long* dims, int ndims);
-RAI_Tensor* MODULE_API_FUNC(RedisAI_TensorCreateByConcatenatingTensors)(RAI_Tensor** ts, long long n);
-RAI_Tensor* MODULE_API_FUNC(RedisAI_TensorCreateBySlicingTensor)(RAI_Tensor* t, long long offset, long long len);
-size_t MODULE_API_FUNC(RedisAI_TensorLength)(RAI_Tensor* t);
-size_t MODULE_API_FUNC(RedisAI_TensorDataSize)(RAI_Tensor* t);
-size_t MODULE_API_FUNC(RedisAI_TensorDataType)(RAI_Tensor* t);
-void MODULE_API_FUNC(RedisAI_TensorFree)(RAI_Tensor* t);
-int MODULE_API_FUNC(RedisAI_TensorSetData)(RAI_Tensor* tensor, const char* data, size_t len);
-int MODULE_API_FUNC(RedisAI_TensorSetValueFromLongLong)(RAI_Tensor* tensor, long long i, long long val);
-int MODULE_API_FUNC(RedisAI_TensorSetValueFromDouble)(RAI_Tensor* tensor, long long i, double val);
-int MODULE_API_FUNC(RedisAI_TensorGetValueAsDouble)(RAI_Tensor* t, long long i, double* val);
-int MODULE_API_FUNC(RedisAI_TensorGetValueAsLongLong)(RAI_Tensor* t, long long i, long long* val);
-RAI_Tensor* MODULE_API_FUNC(RedisAI_TensorGetShallowCopy)(RAI_Tensor* t);
-int MODULE_API_FUNC(RedisAI_TensorNumDims)(RAI_Tensor* t);
-long long MODULE_API_FUNC(RedisAI_TensorDim)(RAI_Tensor* t, int dim);
-size_t MODULE_API_FUNC(RedisAI_TensorByteSize)(RAI_Tensor* t);
-char* MODULE_API_FUNC(RedisAI_TensorData)(RAI_Tensor* t);
-RedisModuleType* MODULE_API_FUNC(RedisAI_TensorRedisType)(void);
+RAI_Tensor *MODULE_API_FUNC(RedisAI_TensorCreate)(const char *dataTypeStr, long long *dims,
+                                                  int ndims);
+RAI_Tensor *MODULE_API_FUNC(RedisAI_TensorCreateByConcatenatingTensors)(RAI_Tensor **ts,
+                                                                        long long n);
+RAI_Tensor *MODULE_API_FUNC(RedisAI_TensorCreateBySlicingTensor)(RAI_Tensor *t, long long offset,
+                                                                 long long len);
+size_t MODULE_API_FUNC(RedisAI_TensorLength)(RAI_Tensor *t);
+size_t MODULE_API_FUNC(RedisAI_TensorDataSize)(RAI_Tensor *t);
+size_t MODULE_API_FUNC(RedisAI_TensorDataType)(RAI_Tensor *t);
+void MODULE_API_FUNC(RedisAI_TensorFree)(RAI_Tensor *t);
+int MODULE_API_FUNC(RedisAI_TensorSetData)(RAI_Tensor *tensor, const char *data, size_t len);
+int MODULE_API_FUNC(RedisAI_TensorSetValueFromLongLong)(RAI_Tensor *tensor, long long i,
+                                                        long long val);
+int MODULE_API_FUNC(RedisAI_TensorSetValueFromDouble)(RAI_Tensor *tensor, long long i, double val);
+int MODULE_API_FUNC(RedisAI_TensorGetValueAsDouble)(RAI_Tensor *t, long long i, double *val);
+int MODULE_API_FUNC(RedisAI_TensorGetValueAsLongLong)(RAI_Tensor *t, long long i, long long *val);
+RAI_Tensor *MODULE_API_FUNC(RedisAI_TensorGetShallowCopy)(RAI_Tensor *t);
+int MODULE_API_FUNC(RedisAI_TensorNumDims)(RAI_Tensor *t);
+long long MODULE_API_FUNC(RedisAI_TensorDim)(RAI_Tensor *t, int dim);
+size_t MODULE_API_FUNC(RedisAI_TensorByteSize)(RAI_Tensor *t);
+char *MODULE_API_FUNC(RedisAI_TensorData)(RAI_Tensor *t);
+RedisModuleType *MODULE_API_FUNC(RedisAI_TensorRedisType)(void);
 
-RAI_Model* MODULE_API_FUNC(RedisAI_ModelCreate)(int backend, char* devicestr, char* tag, RAI_ModelOpts opts,
-                                                size_t ninputs, const char **inputs,
-                                                size_t noutputs, const char **outputs,
-                                                const char *modeldef, size_t modellen, RAI_Error* err);
-void MODULE_API_FUNC(RedisAI_ModelFree)(RAI_Model* model, RAI_Error* err);
-RAI_ModelRunCtx* MODULE_API_FUNC(RedisAI_ModelRunCtxCreate)(RAI_Model* model);
-int MODULE_API_FUNC(RedisAI_ModelRunCtxAddInput)(RAI_ModelRunCtx* mctx, const char* inputName, RAI_Tensor* inputTensor);
-int MODULE_API_FUNC(RedisAI_ModelRunCtxAddOutput)(RAI_ModelRunCtx* mctx, const char* outputName);
-size_t MODULE_API_FUNC(RedisAI_ModelRunCtxNumOutputs)(RAI_ModelRunCtx* mctx);
-RAI_Tensor* MODULE_API_FUNC(RedisAI_ModelRunCtxOutputTensor)(RAI_ModelRunCtx* mctx, size_t index);
-void MODULE_API_FUNC(RedisAI_ModelRunCtxFree)(RAI_ModelRunCtx* mctx);
-int MODULE_API_FUNC(RedisAI_ModelRun)(RAI_ModelRunCtx** mctx, long long n, RAI_Error* err);
-RAI_Model* MODULE_API_FUNC(RedisAI_ModelGetShallowCopy)(RAI_Model* model);
-int MODULE_API_FUNC(RedisAI_ModelSerialize)(RAI_Model *model, char **buffer, size_t *len, RAI_Error *err);
-RedisModuleType* MODULE_API_FUNC(RedisAI_ModelRedisType)(void);
+RAI_Model *MODULE_API_FUNC(RedisAI_ModelCreate)(int backend, char *devicestr, char *tag,
+                                                RAI_ModelOpts opts, size_t ninputs,
+                                                const char **inputs, size_t noutputs,
+                                                const char **outputs, const char *modeldef,
+                                                size_t modellen, RAI_Error *err);
+void MODULE_API_FUNC(RedisAI_ModelFree)(RAI_Model *model, RAI_Error *err);
+RAI_ModelRunCtx *MODULE_API_FUNC(RedisAI_ModelRunCtxCreate)(RAI_Model *model);
+int MODULE_API_FUNC(RedisAI_ModelRunCtxAddInput)(RAI_ModelRunCtx *mctx, const char *inputName,
+                                                 RAI_Tensor *inputTensor);
+int MODULE_API_FUNC(RedisAI_ModelRunCtxAddOutput)(RAI_ModelRunCtx *mctx, const char *outputName);
+size_t MODULE_API_FUNC(RedisAI_ModelRunCtxNumOutputs)(RAI_ModelRunCtx *mctx);
+RAI_Tensor *MODULE_API_FUNC(RedisAI_ModelRunCtxOutputTensor)(RAI_ModelRunCtx *mctx, size_t index);
+void MODULE_API_FUNC(RedisAI_ModelRunCtxFree)(RAI_ModelRunCtx *mctx);
+int MODULE_API_FUNC(RedisAI_ModelRun)(RAI_ModelRunCtx **mctx, long long n, RAI_Error *err);
+RAI_Model *MODULE_API_FUNC(RedisAI_ModelGetShallowCopy)(RAI_Model *model);
+int MODULE_API_FUNC(RedisAI_ModelSerialize)(RAI_Model *model, char **buffer, size_t *len,
+                                            RAI_Error *err);
+RedisModuleType *MODULE_API_FUNC(RedisAI_ModelRedisType)(void);
 
-RAI_Script* MODULE_API_FUNC(RedisAI_ScriptCreate)(char* devicestr, char* tag, const char* scriptdef, RAI_Error* err);
-void MODULE_API_FUNC(RedisAI_ScriptFree)(RAI_Script* script, RAI_Error* err);
-RAI_ScriptRunCtx* MODULE_API_FUNC(RedisAI_ScriptRunCtxCreate)(RAI_Script* script, const char *fnname);
-int MODULE_API_FUNC(RedisAI_ScriptRunCtxAddInput)(RAI_ScriptRunCtx* sctx, RAI_Tensor* inputTensor, RAI_Error* err);
-int MODULE_API_FUNC(RedisAI_ScriptRunCtxAddInputList)(RAI_ScriptRunCtx* sctx, RAI_Tensor** inputTensors, size_t len, RAI_Error* err);
-int MODULE_API_FUNC(RedisAI_ScriptRunCtxAddOutput)(RAI_ScriptRunCtx* sctx);
-size_t MODULE_API_FUNC(RedisAI_ScriptRunCtxNumOutputs)(RAI_ScriptRunCtx* sctx);
-RAI_Tensor* MODULE_API_FUNC(RedisAI_ScriptRunCtxOutputTensor)(RAI_ScriptRunCtx* sctx, size_t index);
-void MODULE_API_FUNC(RedisAI_ScriptRunCtxFree)(RAI_ScriptRunCtx* sctx);
-int MODULE_API_FUNC(RedisAI_ScriptRun)(RAI_ScriptRunCtx* sctx, RAI_Error* err);
-RAI_Script* MODULE_API_FUNC(RedisAI_ScriptGetShallowCopy)(RAI_Script* script);
-RedisModuleType* MODULE_API_FUNC(RedisAI_ScriptRedisType)(void);
+RAI_Script *MODULE_API_FUNC(RedisAI_ScriptCreate)(char *devicestr, char *tag, const char *scriptdef,
+                                                  RAI_Error *err);
+void MODULE_API_FUNC(RedisAI_ScriptFree)(RAI_Script *script, RAI_Error *err);
+RAI_ScriptRunCtx *MODULE_API_FUNC(RedisAI_ScriptRunCtxCreate)(RAI_Script *script,
+                                                              const char *fnname);
+int MODULE_API_FUNC(RedisAI_ScriptRunCtxAddInput)(RAI_ScriptRunCtx *sctx, RAI_Tensor *inputTensor,
+                                                  RAI_Error *err);
+int MODULE_API_FUNC(RedisAI_ScriptRunCtxAddInputList)(RAI_ScriptRunCtx *sctx,
+                                                      RAI_Tensor **inputTensors, size_t len,
+                                                      RAI_Error *err);
+int MODULE_API_FUNC(RedisAI_ScriptRunCtxAddOutput)(RAI_ScriptRunCtx *sctx);
+size_t MODULE_API_FUNC(RedisAI_ScriptRunCtxNumOutputs)(RAI_ScriptRunCtx *sctx);
+RAI_Tensor *MODULE_API_FUNC(RedisAI_ScriptRunCtxOutputTensor)(RAI_ScriptRunCtx *sctx, size_t index);
+void MODULE_API_FUNC(RedisAI_ScriptRunCtxFree)(RAI_ScriptRunCtx *sctx);
+int MODULE_API_FUNC(RedisAI_ScriptRun)(RAI_ScriptRunCtx *sctx, RAI_Error *err);
+RAI_Script *MODULE_API_FUNC(RedisAI_ScriptGetShallowCopy)(RAI_Script *script);
+RedisModuleType *MODULE_API_FUNC(RedisAI_ScriptRedisType)(void);
 
 int MODULE_API_FUNC(RedisAI_GetLLAPIVersion)();
 
-#define REDISAI_MODULE_INIT_FUNCTION(ctx, name) \
-  RedisAI_ ## name = RedisModule_GetSharedAPI(ctx, "RedisAI_" #name);\
-  if(!RedisAI_ ## name){\
-    RedisModule_Log(ctx, "warning", "could not initialize RedisAI_" #name "\r\n");\
-    return REDISMODULE_ERR; \
-  }
+#define REDISAI_MODULE_INIT_FUNCTION(ctx, name)                                                    \
+    RedisAI_##name = RedisModule_GetSharedAPI(ctx, "RedisAI_" #name);                              \
+    if (!RedisAI_##name) {                                                                         \
+        RedisModule_Log(ctx, "warning", "could not initialize RedisAI_" #name "\r\n");             \
+        return REDISMODULE_ERR;                                                                    \
+    }
 
-static int RedisAI_Initialize(RedisModuleCtx* ctx){
+static int RedisAI_Initialize(RedisModuleCtx *ctx) {
 
-  if(!RedisModule_GetSharedAPI){
-    RedisModule_Log(ctx, "warning", "redis version is not compatible with module shared api, use redis 5.0.4 or above.");
-    return REDISMODULE_ERR;
-  }
+    if (!RedisModule_GetSharedAPI) {
+        RedisModule_Log(ctx, "warning",
+                        "redis version is not compatible with module shared api, "
+                        "use redis 5.0.4 or above.");
+        return REDISMODULE_ERR;
+    }
 
-  REDISAI_MODULE_INIT_FUNCTION(ctx, InitError);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ClearError);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, FreeError);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, GetError);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, GetErrorOneLine);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, GetErrorCode);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, InitError);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ClearError);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, FreeError);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, GetError);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, GetErrorOneLine);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, GetErrorCode);
 
-  REDISAI_MODULE_INIT_FUNCTION(ctx, GetLLAPIVersion);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, GetLLAPIVersion);
 
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorCreate);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorCreateByConcatenatingTensors);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorCreateBySlicingTensor);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorLength);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorDataSize);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorFree);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorSetData);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorSetValueFromLongLong);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorSetValueFromDouble);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorGetValueAsDouble);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorGetValueAsLongLong);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorGetShallowCopy);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorNumDims);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorDim);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorByteSize);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorData);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, TensorRedisType);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorCreate);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorCreateByConcatenatingTensors);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorCreateBySlicingTensor);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorLength);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorDataSize);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorFree);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorSetData);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorSetValueFromLongLong);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorSetValueFromDouble);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorGetValueAsDouble);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorGetValueAsLongLong);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorGetShallowCopy);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorNumDims);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorDim);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorByteSize);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorData);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, TensorRedisType);
 
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelCreate);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelFree);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxCreate);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxAddInput);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxAddOutput);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxNumOutputs);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxOutputTensor);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxFree);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRun);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelGetShallowCopy);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelSerialize);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRedisType);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelCreate);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelFree);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxCreate);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxAddInput);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxAddOutput);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxNumOutputs);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxOutputTensor);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRunCtxFree);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRun);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelGetShallowCopy);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelSerialize);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ModelRedisType);
 
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptCreate);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptFree);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxCreate);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxAddInput);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxAddInputList);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxAddOutput);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxNumOutputs);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxOutputTensor);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxFree);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRun);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptGetShallowCopy);
-  REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRedisType);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptCreate);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptFree);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxCreate);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxAddInput);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxAddInputList);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxAddOutput);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxNumOutputs);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxOutputTensor);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunCtxFree);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRun);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptGetShallowCopy);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRedisType);
 
-  if(RedisAI_GetLLAPIVersion() < REDISAI_LLAPI_VERSION){
-    return REDISMODULE_ERR;
-  }
+    if (RedisAI_GetLLAPIVersion() < REDISAI_LLAPI_VERSION) {
+        return REDISMODULE_ERR;
+    }
 
-  return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }
 
 #endif /* SRC_REDISAI_H_ */

--- a/src/redisai_memory.h
+++ b/src/redisai_memory.h
@@ -13,19 +13,17 @@
 #include <string.h>
 
 #ifdef VALGRIND
-#define RA_ALLOC malloc
-#define RA_CALLOC calloc
+#define RA_ALLOC   malloc
+#define RA_CALLOC  calloc
 #define RA_REALLOC realloc
-#define RA_FREE free
-#define RA_STRDUP strdup
+#define RA_FREE    free
+#define RA_STRDUP  strdup
 #else
-#define RA_ALLOC RedisModule_Alloc
-#define RA_CALLOC RedisModule_Calloc
+#define RA_ALLOC   RedisModule_Alloc
+#define RA_CALLOC  RedisModule_Calloc
 #define RA_REALLOC RedisModule_Realloc
-#define RA_FREE RedisModule_Free
-#define RA_STRDUP RedisModule_Strdup
+#define RA_FREE    RedisModule_Free
+#define RA_STRDUP  RedisModule_Strdup
 #endif
-
-
 
 #endif /* SRC_REDISAI_MEMORY_H_ */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1,51 +1,53 @@
 #ifndef REDISMODULE_H
 #define REDISMODULE_H
 
-#include <sys/types.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <sys/types.h>
 
 /* ---------------- Defines common between core and modules --------------- */
 
 /* Error status return values. */
-#define REDISMODULE_OK 0
+#define REDISMODULE_OK  0
 #define REDISMODULE_ERR 1
 
 /* API versions. */
 #define REDISMODULE_APIVER_1 1
 
-/* Version of the RedisModuleTypeMethods structure. Once the RedisModuleTypeMethods
- * structure is changed, this version number needs to be changed synchronistically. */
+/* Version of the RedisModuleTypeMethods structure. Once the
+ * RedisModuleTypeMethods
+ * structure is changed, this version number needs to be changed
+ * synchronistically. */
 #define REDISMODULE_TYPE_METHOD_VERSION 3
 
 /* API flags and constants */
-#define REDISMODULE_READ (1<<0)
-#define REDISMODULE_WRITE (1<<1)
+#define REDISMODULE_READ  (1 << 0)
+#define REDISMODULE_WRITE (1 << 1)
 
 /* RedisModule_OpenKey extra flags for the 'mode' argument.
  * Avoid touching the LRU/LFU of the key when opened. */
-#define REDISMODULE_OPEN_KEY_NOTOUCH (1<<16)
+#define REDISMODULE_OPEN_KEY_NOTOUCH (1 << 16)
 
 #define REDISMODULE_LIST_HEAD 0
 #define REDISMODULE_LIST_TAIL 1
 
 /* Key types. */
-#define REDISMODULE_KEYTYPE_EMPTY 0
+#define REDISMODULE_KEYTYPE_EMPTY  0
 #define REDISMODULE_KEYTYPE_STRING 1
-#define REDISMODULE_KEYTYPE_LIST 2
-#define REDISMODULE_KEYTYPE_HASH 3
-#define REDISMODULE_KEYTYPE_SET 4
-#define REDISMODULE_KEYTYPE_ZSET 5
+#define REDISMODULE_KEYTYPE_LIST   2
+#define REDISMODULE_KEYTYPE_HASH   3
+#define REDISMODULE_KEYTYPE_SET    4
+#define REDISMODULE_KEYTYPE_ZSET   5
 #define REDISMODULE_KEYTYPE_MODULE 6
 #define REDISMODULE_KEYTYPE_STREAM 7
 
 /* Reply types. */
 #define REDISMODULE_REPLY_UNKNOWN -1
-#define REDISMODULE_REPLY_STRING 0
-#define REDISMODULE_REPLY_ERROR 1
+#define REDISMODULE_REPLY_STRING  0
+#define REDISMODULE_REPLY_ERROR   1
 #define REDISMODULE_REPLY_INTEGER 2
-#define REDISMODULE_REPLY_ARRAY 3
-#define REDISMODULE_REPLY_NULL 4
+#define REDISMODULE_REPLY_ARRAY   3
+#define REDISMODULE_REPLY_NULL    4
 
 /* Postponed array length. */
 #define REDISMODULE_POSTPONED_ARRAY_LEN -1
@@ -54,133 +56,141 @@
 #define REDISMODULE_NO_EXPIRE -1
 
 /* Sorted set API flags. */
-#define REDISMODULE_ZADD_XX      (1<<0)
-#define REDISMODULE_ZADD_NX      (1<<1)
-#define REDISMODULE_ZADD_ADDED   (1<<2)
-#define REDISMODULE_ZADD_UPDATED (1<<3)
-#define REDISMODULE_ZADD_NOP     (1<<4)
-#define REDISMODULE_ZADD_GT      (1<<5)
-#define REDISMODULE_ZADD_LT      (1<<6)
+#define REDISMODULE_ZADD_XX      (1 << 0)
+#define REDISMODULE_ZADD_NX      (1 << 1)
+#define REDISMODULE_ZADD_ADDED   (1 << 2)
+#define REDISMODULE_ZADD_UPDATED (1 << 3)
+#define REDISMODULE_ZADD_NOP     (1 << 4)
+#define REDISMODULE_ZADD_GT      (1 << 5)
+#define REDISMODULE_ZADD_LT      (1 << 6)
 
 /* Hash API flags. */
-#define REDISMODULE_HASH_NONE       0
-#define REDISMODULE_HASH_NX         (1<<0)
-#define REDISMODULE_HASH_XX         (1<<1)
-#define REDISMODULE_HASH_CFIELDS    (1<<2)
-#define REDISMODULE_HASH_EXISTS     (1<<3)
+#define REDISMODULE_HASH_NONE    0
+#define REDISMODULE_HASH_NX      (1 << 0)
+#define REDISMODULE_HASH_XX      (1 << 1)
+#define REDISMODULE_HASH_CFIELDS (1 << 2)
+#define REDISMODULE_HASH_EXISTS  (1 << 3)
 
 /* Context Flags: Info about the current context returned by
  * RM_GetContextFlags(). */
 
 /* The command is running in the context of a Lua script */
-#define REDISMODULE_CTX_FLAGS_LUA (1<<0)
+#define REDISMODULE_CTX_FLAGS_LUA (1 << 0)
 /* The command is running inside a Redis transaction */
-#define REDISMODULE_CTX_FLAGS_MULTI (1<<1)
+#define REDISMODULE_CTX_FLAGS_MULTI (1 << 1)
 /* The instance is a master */
-#define REDISMODULE_CTX_FLAGS_MASTER (1<<2)
+#define REDISMODULE_CTX_FLAGS_MASTER (1 << 2)
 /* The instance is a slave */
-#define REDISMODULE_CTX_FLAGS_SLAVE (1<<3)
+#define REDISMODULE_CTX_FLAGS_SLAVE (1 << 3)
 /* The instance is read-only (usually meaning it's a slave as well) */
-#define REDISMODULE_CTX_FLAGS_READONLY (1<<4)
+#define REDISMODULE_CTX_FLAGS_READONLY (1 << 4)
 /* The instance is running in cluster mode */
-#define REDISMODULE_CTX_FLAGS_CLUSTER (1<<5)
+#define REDISMODULE_CTX_FLAGS_CLUSTER (1 << 5)
 /* The instance has AOF enabled */
-#define REDISMODULE_CTX_FLAGS_AOF (1<<6)
+#define REDISMODULE_CTX_FLAGS_AOF (1 << 6)
 /* The instance has RDB enabled */
-#define REDISMODULE_CTX_FLAGS_RDB (1<<7)
+#define REDISMODULE_CTX_FLAGS_RDB (1 << 7)
 /* The instance has Maxmemory set */
-#define REDISMODULE_CTX_FLAGS_MAXMEMORY (1<<8)
+#define REDISMODULE_CTX_FLAGS_MAXMEMORY (1 << 8)
 /* Maxmemory is set and has an eviction policy that may delete keys */
-#define REDISMODULE_CTX_FLAGS_EVICT (1<<9)
+#define REDISMODULE_CTX_FLAGS_EVICT (1 << 9)
 /* Redis is out of memory according to the maxmemory flag. */
-#define REDISMODULE_CTX_FLAGS_OOM (1<<10)
+#define REDISMODULE_CTX_FLAGS_OOM (1 << 10)
 /* Less than 25% of memory available according to maxmemory. */
-#define REDISMODULE_CTX_FLAGS_OOM_WARNING (1<<11)
+#define REDISMODULE_CTX_FLAGS_OOM_WARNING (1 << 11)
 /* The command was sent over the replication link. */
-#define REDISMODULE_CTX_FLAGS_REPLICATED (1<<12)
+#define REDISMODULE_CTX_FLAGS_REPLICATED (1 << 12)
 /* Redis is currently loading either from AOF or RDB. */
-#define REDISMODULE_CTX_FLAGS_LOADING (1<<13)
+#define REDISMODULE_CTX_FLAGS_LOADING (1 << 13)
 /* The replica has no link with its master, note that
  * there is the inverse flag as well:
  *
  *  REDISMODULE_CTX_FLAGS_REPLICA_IS_ONLINE
  *
  * The two flags are exclusive, one or the other can be set. */
-#define REDISMODULE_CTX_FLAGS_REPLICA_IS_STALE (1<<14)
+#define REDISMODULE_CTX_FLAGS_REPLICA_IS_STALE (1 << 14)
 /* The replica is trying to connect with the master.
  * (REPL_STATE_CONNECT and REPL_STATE_CONNECTING states) */
-#define REDISMODULE_CTX_FLAGS_REPLICA_IS_CONNECTING (1<<15)
+#define REDISMODULE_CTX_FLAGS_REPLICA_IS_CONNECTING (1 << 15)
 /* THe replica is receiving an RDB file from its master. */
-#define REDISMODULE_CTX_FLAGS_REPLICA_IS_TRANSFERRING (1<<16)
+#define REDISMODULE_CTX_FLAGS_REPLICA_IS_TRANSFERRING (1 << 16)
 /* The replica is online, receiving updates from its master. */
-#define REDISMODULE_CTX_FLAGS_REPLICA_IS_ONLINE (1<<17)
+#define REDISMODULE_CTX_FLAGS_REPLICA_IS_ONLINE (1 << 17)
 /* There is currently some background process active. */
-#define REDISMODULE_CTX_FLAGS_ACTIVE_CHILD (1<<18)
+#define REDISMODULE_CTX_FLAGS_ACTIVE_CHILD (1 << 18)
 /* The next EXEC will fail due to dirty CAS (touched keys). */
-#define REDISMODULE_CTX_FLAGS_MULTI_DIRTY (1<<19)
+#define REDISMODULE_CTX_FLAGS_MULTI_DIRTY (1 << 19)
 /* Redis is currently running inside background child process. */
-#define REDISMODULE_CTX_FLAGS_IS_CHILD (1<<20)
+#define REDISMODULE_CTX_FLAGS_IS_CHILD (1 << 20)
 /* The current client does not allow blocking, either called from
  * within multi, lua, or from another module using RM_Call */
-#define REDISMODULE_CTX_FLAGS_DENY_BLOCKING (1<<21)
+#define REDISMODULE_CTX_FLAGS_DENY_BLOCKING (1 << 21)
 
 /* Next context flag, must be updated when adding new flags above!
 This flag should not be used directly by the module.
  * Use RedisModule_GetContextFlagsAll instead. */
-#define _REDISMODULE_CTX_FLAGS_NEXT (1<<22)
+#define _REDISMODULE_CTX_FLAGS_NEXT (1 << 22)
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes.
  * NOTE: These have to be in sync with NOTIFY_* in server.h */
-#define REDISMODULE_NOTIFY_KEYSPACE (1<<0)    /* K */
-#define REDISMODULE_NOTIFY_KEYEVENT (1<<1)    /* E */
-#define REDISMODULE_NOTIFY_GENERIC (1<<2)     /* g */
-#define REDISMODULE_NOTIFY_STRING (1<<3)      /* $ */
-#define REDISMODULE_NOTIFY_LIST (1<<4)        /* l */
-#define REDISMODULE_NOTIFY_SET (1<<5)         /* s */
-#define REDISMODULE_NOTIFY_HASH (1<<6)        /* h */
-#define REDISMODULE_NOTIFY_ZSET (1<<7)        /* z */
-#define REDISMODULE_NOTIFY_EXPIRED (1<<8)     /* x */
-#define REDISMODULE_NOTIFY_EVICTED (1<<9)     /* e */
-#define REDISMODULE_NOTIFY_STREAM (1<<10)     /* t */
-#define REDISMODULE_NOTIFY_KEY_MISS (1<<11)   /* m (Note: This one is excluded from REDISMODULE_NOTIFY_ALL on purpose) */
-#define REDISMODULE_NOTIFY_LOADED (1<<12)     /* module only key space notification, indicate a key loaded from rdb */
+#define REDISMODULE_NOTIFY_KEYSPACE (1 << 0)  /* K */
+#define REDISMODULE_NOTIFY_KEYEVENT (1 << 1)  /* E */
+#define REDISMODULE_NOTIFY_GENERIC  (1 << 2)  /* g */
+#define REDISMODULE_NOTIFY_STRING   (1 << 3)  /* $ */
+#define REDISMODULE_NOTIFY_LIST     (1 << 4)  /* l */
+#define REDISMODULE_NOTIFY_SET      (1 << 5)  /* s */
+#define REDISMODULE_NOTIFY_HASH     (1 << 6)  /* h */
+#define REDISMODULE_NOTIFY_ZSET     (1 << 7)  /* z */
+#define REDISMODULE_NOTIFY_EXPIRED  (1 << 8)  /* x */
+#define REDISMODULE_NOTIFY_EVICTED  (1 << 9)  /* e */
+#define REDISMODULE_NOTIFY_STREAM   (1 << 10) /* t */
+#define REDISMODULE_NOTIFY_KEY_MISS                                                                \
+    (1 << 11) /* m (Note: This one is excluded from REDISMODULE_NOTIFY_ALL on                      \
+                 purpose) */
+#define REDISMODULE_NOTIFY_LOADED                                                                  \
+    (1 << 12) /* module only key space notification, indicate a key loaded from                    \
+                 rdb */
 
 /* Next notification flag, must be updated when adding new flags above!
 This flag should not be used directly by the module.
  * Use RedisModule_GetKeyspaceNotificationFlagsAll instead. */
-#define _REDISMODULE_NOTIFY_NEXT (1<<13)
+#define _REDISMODULE_NOTIFY_NEXT (1 << 13)
 
-#define REDISMODULE_NOTIFY_ALL (REDISMODULE_NOTIFY_GENERIC | REDISMODULE_NOTIFY_STRING | REDISMODULE_NOTIFY_LIST | REDISMODULE_NOTIFY_SET | REDISMODULE_NOTIFY_HASH | REDISMODULE_NOTIFY_ZSET | REDISMODULE_NOTIFY_EXPIRED | REDISMODULE_NOTIFY_EVICTED | REDISMODULE_NOTIFY_STREAM)      /* A */
+#define REDISMODULE_NOTIFY_ALL                                                                     \
+    (REDISMODULE_NOTIFY_GENERIC | REDISMODULE_NOTIFY_STRING | REDISMODULE_NOTIFY_LIST |            \
+     REDISMODULE_NOTIFY_SET | REDISMODULE_NOTIFY_HASH | REDISMODULE_NOTIFY_ZSET |                  \
+     REDISMODULE_NOTIFY_EXPIRED | REDISMODULE_NOTIFY_EVICTED | REDISMODULE_NOTIFY_STREAM) /* A */
 
 /* A special pointer that we can use between the core and the module to signal
  * field deletion, and that is impossible to be a valid pointer. */
-#define REDISMODULE_HASH_DELETE ((RedisModuleString*)(long)1)
+#define REDISMODULE_HASH_DELETE ((RedisModuleString *)(long)1)
 
 /* Error messages. */
-#define REDISMODULE_ERRORMSG_WRONGTYPE "WRONGTYPE Operation against a key holding the wrong kind of value"
+#define REDISMODULE_ERRORMSG_WRONGTYPE                                                             \
+    "WRONGTYPE Operation against a key holding the wrong kind of value"
 
-#define REDISMODULE_POSITIVE_INFINITE (1.0/0.0)
-#define REDISMODULE_NEGATIVE_INFINITE (-1.0/0.0)
+#define REDISMODULE_POSITIVE_INFINITE (1.0 / 0.0)
+#define REDISMODULE_NEGATIVE_INFINITE (-1.0 / 0.0)
 
 /* Cluster API defines. */
-#define REDISMODULE_NODE_ID_LEN 40
-#define REDISMODULE_NODE_MYSELF     (1<<0)
-#define REDISMODULE_NODE_MASTER     (1<<1)
-#define REDISMODULE_NODE_SLAVE      (1<<2)
-#define REDISMODULE_NODE_PFAIL      (1<<3)
-#define REDISMODULE_NODE_FAIL       (1<<4)
-#define REDISMODULE_NODE_NOFAILOVER (1<<5)
+#define REDISMODULE_NODE_ID_LEN     40
+#define REDISMODULE_NODE_MYSELF     (1 << 0)
+#define REDISMODULE_NODE_MASTER     (1 << 1)
+#define REDISMODULE_NODE_SLAVE      (1 << 2)
+#define REDISMODULE_NODE_PFAIL      (1 << 3)
+#define REDISMODULE_NODE_FAIL       (1 << 4)
+#define REDISMODULE_NODE_NOFAILOVER (1 << 5)
 
-#define REDISMODULE_CLUSTER_FLAG_NONE 0
-#define REDISMODULE_CLUSTER_FLAG_NO_FAILOVER (1<<1)
-#define REDISMODULE_CLUSTER_FLAG_NO_REDIRECTION (1<<2)
+#define REDISMODULE_CLUSTER_FLAG_NONE           0
+#define REDISMODULE_CLUSTER_FLAG_NO_FAILOVER    (1 << 1)
+#define REDISMODULE_CLUSTER_FLAG_NO_REDIRECTION (1 << 2)
 
-#define REDISMODULE_NOT_USED(V) ((void) V)
+#define REDISMODULE_NOT_USED(V) ((void)V)
 
 /* Bit flags for aux_save_triggers and the aux_load and aux_save callbacks */
-#define REDISMODULE_AUX_BEFORE_RDB (1<<0)
-#define REDISMODULE_AUX_AFTER_RDB (1<<1)
+#define REDISMODULE_AUX_BEFORE_RDB (1 << 0)
+#define REDISMODULE_AUX_AFTER_RDB  (1 << 1)
 
 /* This type represents a timer handle, and is returned when a timer is
  * registered and used in order to invalidate a timer. It's just a 64 bit
@@ -191,147 +201,112 @@ typedef uint64_t RedisModuleTimerID;
 /* CommandFilter Flags */
 
 /* Do filter RedisModule_Call() commands initiated by module itself. */
-#define REDISMODULE_CMDFILTER_NOSELF    (1<<0)
+#define REDISMODULE_CMDFILTER_NOSELF (1 << 0)
 
-/* Declare that the module can handle errors with RedisModule_SetModuleOptions. */
-#define REDISMODULE_OPTIONS_HANDLE_IO_ERRORS    (1<<0)
+/* Declare that the module can handle errors with RedisModule_SetModuleOptions.
+ */
+#define REDISMODULE_OPTIONS_HANDLE_IO_ERRORS (1 << 0)
 /* When set, Redis will not call RedisModule_SignalModifiedKey(), implicitly in
  * RedisModule_CloseKey, and the module needs to do that when manually when keys
  * are modified from the user's sperspective, to invalidate WATCH. */
-#define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1<<1)
+#define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1 << 1)
 
 /* Server events definitions.
  * Those flags should not be used directly by the module, instead
  * the module should use RedisModuleEvent_* variables */
 #define REDISMODULE_EVENT_REPLICATION_ROLE_CHANGED 0
-#define REDISMODULE_EVENT_PERSISTENCE 1
-#define REDISMODULE_EVENT_FLUSHDB 2
-#define REDISMODULE_EVENT_LOADING 3
-#define REDISMODULE_EVENT_CLIENT_CHANGE 4
-#define REDISMODULE_EVENT_SHUTDOWN 5
-#define REDISMODULE_EVENT_REPLICA_CHANGE 6
-#define REDISMODULE_EVENT_MASTER_LINK_CHANGE 7
-#define REDISMODULE_EVENT_CRON_LOOP 8
-#define REDISMODULE_EVENT_MODULE_CHANGE 9
-#define REDISMODULE_EVENT_LOADING_PROGRESS 10
-#define REDISMODULE_EVENT_SWAPDB 11
+#define REDISMODULE_EVENT_PERSISTENCE              1
+#define REDISMODULE_EVENT_FLUSHDB                  2
+#define REDISMODULE_EVENT_LOADING                  3
+#define REDISMODULE_EVENT_CLIENT_CHANGE            4
+#define REDISMODULE_EVENT_SHUTDOWN                 5
+#define REDISMODULE_EVENT_REPLICA_CHANGE           6
+#define REDISMODULE_EVENT_MASTER_LINK_CHANGE       7
+#define REDISMODULE_EVENT_CRON_LOOP                8
+#define REDISMODULE_EVENT_MODULE_CHANGE            9
+#define REDISMODULE_EVENT_LOADING_PROGRESS         10
+#define REDISMODULE_EVENT_SWAPDB                   11
 
 /* Next event flag, should be updated if a new event added. */
 #define _REDISMODULE_EVENT_NEXT 12
 
 typedef struct RedisModuleEvent {
-	uint64_t id;        /* REDISMODULE_EVENT_... defines. */
-	uint64_t dataver;   /* Version of the structure we pass as 'data'. */
+    uint64_t id;      /* REDISMODULE_EVENT_... defines. */
+    uint64_t dataver; /* Version of the structure we pass as 'data'. */
 } RedisModuleEvent;
 
 struct RedisModuleCtx;
-typedef void (*RedisModuleEventCallback)(struct RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data);
+typedef void (*RedisModuleEventCallback)(struct RedisModuleCtx *ctx, RedisModuleEvent eid,
+                                         uint64_t subevent, void *data);
 
 static const RedisModuleEvent
-  RedisModuleEvent_ReplicationRoleChanged = {
-  REDISMODULE_EVENT_REPLICATION_ROLE_CHANGED,
-  1
-},
-  RedisModuleEvent_Persistence = {
-  REDISMODULE_EVENT_PERSISTENCE,
-  1
-},
-  RedisModuleEvent_FlushDB = {
-  REDISMODULE_EVENT_FLUSHDB,
-  1
-},
-  RedisModuleEvent_Loading = {
-  REDISMODULE_EVENT_LOADING,
-  1
-},
-  RedisModuleEvent_ClientChange = {
-  REDISMODULE_EVENT_CLIENT_CHANGE,
-  1
-},
-  RedisModuleEvent_Shutdown = {
-  REDISMODULE_EVENT_SHUTDOWN,
-  1
-},
-  RedisModuleEvent_ReplicaChange = {
-  REDISMODULE_EVENT_REPLICA_CHANGE,
-  1
-},
-  RedisModuleEvent_CronLoop = {
-  REDISMODULE_EVENT_CRON_LOOP,
-  1
-},
-  RedisModuleEvent_MasterLinkChange = {
-  REDISMODULE_EVENT_MASTER_LINK_CHANGE,
-  1
-},
-  RedisModuleEvent_ModuleChange = {
-  REDISMODULE_EVENT_MODULE_CHANGE,
-  1
-},
-  RedisModuleEvent_LoadingProgress = {
-  REDISMODULE_EVENT_LOADING_PROGRESS,
-  1
-},
-  RedisModuleEvent_SwapDB = {
-  REDISMODULE_EVENT_SWAPDB,
-  1
-};
+    RedisModuleEvent_ReplicationRoleChanged = {REDISMODULE_EVENT_REPLICATION_ROLE_CHANGED, 1},
+    RedisModuleEvent_Persistence = {REDISMODULE_EVENT_PERSISTENCE, 1},
+    RedisModuleEvent_FlushDB = {REDISMODULE_EVENT_FLUSHDB, 1},
+    RedisModuleEvent_Loading = {REDISMODULE_EVENT_LOADING, 1},
+    RedisModuleEvent_ClientChange = {REDISMODULE_EVENT_CLIENT_CHANGE, 1},
+    RedisModuleEvent_Shutdown = {REDISMODULE_EVENT_SHUTDOWN, 1},
+    RedisModuleEvent_ReplicaChange = {REDISMODULE_EVENT_REPLICA_CHANGE, 1},
+    RedisModuleEvent_CronLoop = {REDISMODULE_EVENT_CRON_LOOP, 1},
+    RedisModuleEvent_MasterLinkChange = {REDISMODULE_EVENT_MASTER_LINK_CHANGE, 1},
+    RedisModuleEvent_ModuleChange = {REDISMODULE_EVENT_MODULE_CHANGE, 1},
+    RedisModuleEvent_LoadingProgress = {REDISMODULE_EVENT_LOADING_PROGRESS, 1},
+    RedisModuleEvent_SwapDB = {REDISMODULE_EVENT_SWAPDB, 1};
 
 /* Those are values that are used for the 'subevent' callback argument. */
-#define REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START 0
-#define REDISMODULE_SUBEVENT_PERSISTENCE_AOF_START 1
+#define REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START      0
+#define REDISMODULE_SUBEVENT_PERSISTENCE_AOF_START      1
 #define REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_RDB_START 2
-#define REDISMODULE_SUBEVENT_PERSISTENCE_ENDED 3
-#define REDISMODULE_SUBEVENT_PERSISTENCE_FAILED 4
-#define _REDISMODULE_SUBEVENT_PERSISTENCE_NEXT 5
+#define REDISMODULE_SUBEVENT_PERSISTENCE_ENDED          3
+#define REDISMODULE_SUBEVENT_PERSISTENCE_FAILED         4
+#define _REDISMODULE_SUBEVENT_PERSISTENCE_NEXT          5
 
-#define REDISMODULE_SUBEVENT_LOADING_RDB_START 0
-#define REDISMODULE_SUBEVENT_LOADING_AOF_START 1
+#define REDISMODULE_SUBEVENT_LOADING_RDB_START  0
+#define REDISMODULE_SUBEVENT_LOADING_AOF_START  1
 #define REDISMODULE_SUBEVENT_LOADING_REPL_START 2
-#define REDISMODULE_SUBEVENT_LOADING_ENDED 3
-#define REDISMODULE_SUBEVENT_LOADING_FAILED 4
-#define _REDISMODULE_SUBEVENT_LOADING_NEXT 5
+#define REDISMODULE_SUBEVENT_LOADING_ENDED      3
+#define REDISMODULE_SUBEVENT_LOADING_FAILED     4
+#define _REDISMODULE_SUBEVENT_LOADING_NEXT      5
 
-#define REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED 0
+#define REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED    0
 #define REDISMODULE_SUBEVENT_CLIENT_CHANGE_DISCONNECTED 1
-#define _REDISMODULE_SUBEVENT_CLIENT_CHANGE_NEXT 2
+#define _REDISMODULE_SUBEVENT_CLIENT_CHANGE_NEXT        2
 
-#define REDISMODULE_SUBEVENT_MASTER_LINK_UP 0
+#define REDISMODULE_SUBEVENT_MASTER_LINK_UP   0
 #define REDISMODULE_SUBEVENT_MASTER_LINK_DOWN 1
-#define _REDISMODULE_SUBEVENT_MASTER_NEXT 2
+#define _REDISMODULE_SUBEVENT_MASTER_NEXT     2
 
-#define REDISMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE 0
+#define REDISMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE  0
 #define REDISMODULE_SUBEVENT_REPLICA_CHANGE_OFFLINE 1
-#define _REDISMODULE_SUBEVENT_REPLICA_CHANGE_NEXT 2
+#define _REDISMODULE_SUBEVENT_REPLICA_CHANGE_NEXT   2
 
-#define REDISMODULE_EVENT_REPLROLECHANGED_NOW_MASTER 0
+#define REDISMODULE_EVENT_REPLROLECHANGED_NOW_MASTER  0
 #define REDISMODULE_EVENT_REPLROLECHANGED_NOW_REPLICA 1
-#define _REDISMODULE_EVENT_REPLROLECHANGED_NEXT 2
+#define _REDISMODULE_EVENT_REPLROLECHANGED_NEXT       2
 
 #define REDISMODULE_SUBEVENT_FLUSHDB_START 0
-#define REDISMODULE_SUBEVENT_FLUSHDB_END 1
+#define REDISMODULE_SUBEVENT_FLUSHDB_END   1
 #define _REDISMODULE_SUBEVENT_FLUSHDB_NEXT 2
 
-#define REDISMODULE_SUBEVENT_MODULE_LOADED 0
+#define REDISMODULE_SUBEVENT_MODULE_LOADED   0
 #define REDISMODULE_SUBEVENT_MODULE_UNLOADED 1
-#define _REDISMODULE_SUBEVENT_MODULE_NEXT 2
+#define _REDISMODULE_SUBEVENT_MODULE_NEXT    2
 
-
-#define REDISMODULE_SUBEVENT_LOADING_PROGRESS_RDB 0
-#define REDISMODULE_SUBEVENT_LOADING_PROGRESS_AOF 1
+#define REDISMODULE_SUBEVENT_LOADING_PROGRESS_RDB   0
+#define REDISMODULE_SUBEVENT_LOADING_PROGRESS_AOF   1
 #define _REDISMODULE_SUBEVENT_LOADING_PROGRESS_NEXT 2
 
-#define _REDISMODULE_SUBEVENT_SHUTDOWN_NEXT 0
+#define _REDISMODULE_SUBEVENT_SHUTDOWN_NEXT  0
 #define _REDISMODULE_SUBEVENT_CRON_LOOP_NEXT 0
-#define _REDISMODULE_SUBEVENT_SWAPDB_NEXT 0
+#define _REDISMODULE_SUBEVENT_SWAPDB_NEXT    0
 
 /* RedisModuleClientInfo flags. */
-#define REDISMODULE_CLIENTINFO_FLAG_SSL (1<<0)
-#define REDISMODULE_CLIENTINFO_FLAG_PUBSUB (1<<1)
-#define REDISMODULE_CLIENTINFO_FLAG_BLOCKED (1<<2)
-#define REDISMODULE_CLIENTINFO_FLAG_TRACKING (1<<3)
-#define REDISMODULE_CLIENTINFO_FLAG_UNIXSOCKET (1<<4)
-#define REDISMODULE_CLIENTINFO_FLAG_MULTI (1<<5)
+#define REDISMODULE_CLIENTINFO_FLAG_SSL        (1 << 0)
+#define REDISMODULE_CLIENTINFO_FLAG_PUBSUB     (1 << 1)
+#define REDISMODULE_CLIENTINFO_FLAG_BLOCKED    (1 << 2)
+#define REDISMODULE_CLIENTINFO_FLAG_TRACKING   (1 << 3)
+#define REDISMODULE_CLIENTINFO_FLAG_UNIXSOCKET (1 << 4)
+#define REDISMODULE_CLIENTINFO_FLAG_MULTI      (1 << 5)
 
 /* Here we take all the structures that the module pass to the core
  * and the other way around. Notably the list here contains the structures
@@ -350,83 +325,83 @@ static const RedisModuleEvent
 
 #define REDISMODULE_CLIENTINFO_VERSION 1
 typedef struct RedisModuleClientInfo {
-	uint64_t version;       /* Version of this structure for ABI compat. */
-	uint64_t flags;         /* REDISMODULE_CLIENTINFO_FLAG_* */
-	uint64_t id;            /* Client ID. */
-	char addr[46];          /* IPv4 or IPv6 address. */
-	uint16_t port;          /* TCP port. */
-	uint16_t db;            /* Selected DB. */
+    uint64_t version; /* Version of this structure for ABI compat. */
+    uint64_t flags;   /* REDISMODULE_CLIENTINFO_FLAG_* */
+    uint64_t id;      /* Client ID. */
+    char addr[46];    /* IPv4 or IPv6 address. */
+    uint16_t port;    /* TCP port. */
+    uint16_t db;      /* Selected DB. */
 } RedisModuleClientInfoV1;
 
 #define RedisModuleClientInfo RedisModuleClientInfoV1
 
 #define REDISMODULE_REPLICATIONINFO_VERSION 1
 typedef struct RedisModuleReplicationInfo {
-	uint64_t version;       /* Not used since this structure is never passed
-                               from the module to the core right now. Here
-                               for future compatibility. */
-	int master;             /* true if master, false if replica */
-	char *masterhost;       /* master instance hostname for NOW_REPLICA */
-	int masterport;         /* master instance port for NOW_REPLICA */
-	char *replid1;          /* Main replication ID */
-	char *replid2;          /* Secondary replication ID */
-	uint64_t repl1_offset;  /* Main replication offset */
-	uint64_t repl2_offset;  /* Offset of replid2 validity */
+    uint64_t version;      /* Not used since this structure is never passed
+                          from the module to the core right now. Here
+                          for future compatibility. */
+    int master;            /* true if master, false if replica */
+    char *masterhost;      /* master instance hostname for NOW_REPLICA */
+    int masterport;        /* master instance port for NOW_REPLICA */
+    char *replid1;         /* Main replication ID */
+    char *replid2;         /* Secondary replication ID */
+    uint64_t repl1_offset; /* Main replication offset */
+    uint64_t repl2_offset; /* Offset of replid2 validity */
 } RedisModuleReplicationInfoV1;
 
 #define RedisModuleReplicationInfo RedisModuleReplicationInfoV1
 
 #define REDISMODULE_FLUSHINFO_VERSION 1
 typedef struct RedisModuleFlushInfo {
-	uint64_t version;       /* Not used since this structure is never passed
-                               from the module to the core right now. Here
-                               for future compatibility. */
-	int32_t sync;           /* Synchronous or threaded flush?. */
-	int32_t dbnum;          /* Flushed database number, -1 for ALL. */
+    uint64_t version; /* Not used since this structure is never passed
+                     from the module to the core right now. Here
+                     for future compatibility. */
+    int32_t sync;     /* Synchronous or threaded flush?. */
+    int32_t dbnum;    /* Flushed database number, -1 for ALL. */
 } RedisModuleFlushInfoV1;
 
 #define RedisModuleFlushInfo RedisModuleFlushInfoV1
 
 #define REDISMODULE_MODULE_CHANGE_VERSION 1
 typedef struct RedisModuleModuleChange {
-	uint64_t version;       /* Not used since this structure is never passed
-                               from the module to the core right now. Here
-                               for future compatibility. */
-	const char* module_name;/* Name of module loaded or unloaded. */
-	int32_t module_version; /* Module version. */
+    uint64_t version;        /* Not used since this structure is never passed
+                            from the module to the core right now. Here
+                            for future compatibility. */
+    const char *module_name; /* Name of module loaded or unloaded. */
+    int32_t module_version;  /* Module version. */
 } RedisModuleModuleChangeV1;
 
 #define RedisModuleModuleChange RedisModuleModuleChangeV1
 
 #define REDISMODULE_CRON_LOOP_VERSION 1
 typedef struct RedisModuleCronLoopInfo {
-	uint64_t version;       /* Not used since this structure is never passed
-                               from the module to the core right now. Here
-                               for future compatibility. */
-	int32_t hz;             /* Approximate number of events per second. */
+    uint64_t version; /* Not used since this structure is never passed
+                     from the module to the core right now. Here
+                     for future compatibility. */
+    int32_t hz;       /* Approximate number of events per second. */
 } RedisModuleCronLoopV1;
 
 #define RedisModuleCronLoop RedisModuleCronLoopV1
 
 #define REDISMODULE_LOADING_PROGRESS_VERSION 1
 typedef struct RedisModuleLoadingProgressInfo {
-	uint64_t version;       /* Not used since this structure is never passed
-                               from the module to the core right now. Here
-                               for future compatibility. */
-	int32_t hz;             /* Approximate number of events per second. */
-	int32_t progress;       /* Approximate progress between 0 and 1024, or -1
-                             * if unknown. */
+    uint64_t version; /* Not used since this structure is never passed
+                     from the module to the core right now. Here
+                     for future compatibility. */
+    int32_t hz;       /* Approximate number of events per second. */
+    int32_t progress; /* Approximate progress between 0 and 1024, or -1
+                       * if unknown. */
 } RedisModuleLoadingProgressV1;
 
 #define RedisModuleLoadingProgress RedisModuleLoadingProgressV1
 
 #define REDISMODULE_SWAPDBINFO_VERSION 1
 typedef struct RedisModuleSwapDbInfo {
-	uint64_t version;       /* Not used since this structure is never passed
-                               from the module to the core right now. Here
-                               for future compatibility. */
-	int32_t dbnum_first;    /* Swap Db first dbnum */
-	int32_t dbnum_second;   /* Swap Db second dbnum */
+    uint64_t version;     /* Not used since this structure is never passed
+                         from the module to the core right now. Here
+                         for future compatibility. */
+    int32_t dbnum_first;  /* Swap Db first dbnum */
+    int32_t dbnum_second; /* Swap Db second dbnum */
 } RedisModuleSwapDbInfoV1;
 
 #define RedisModuleSwapDbInfo RedisModuleSwapDbInfoV1
@@ -439,27 +414,27 @@ typedef long long mstime_t;
 
 /* Macro definitions specific to individual compilers */
 #ifndef REDISMODULE_ATTR_UNUSED
-#    ifdef __GNUC__
-#        define REDISMODULE_ATTR_UNUSED __attribute__((unused))
-#    else
-#        define REDISMODULE_ATTR_UNUSED
-#    endif
+#ifdef __GNUC__
+#define REDISMODULE_ATTR_UNUSED __attribute__((unused))
+#else
+#define REDISMODULE_ATTR_UNUSED
+#endif
 #endif
 
 #ifndef REDISMODULE_ATTR_PRINTF
-#    ifdef __GNUC__
-#        define REDISMODULE_ATTR_PRINTF(idx,cnt) __attribute__((format(printf,idx,cnt)))
-#    else
-#        define REDISMODULE_ATTR_PRINTF(idx,cnt)
-#    endif
+#ifdef __GNUC__
+#define REDISMODULE_ATTR_PRINTF(idx, cnt) __attribute__((format(printf, idx, cnt)))
+#else
+#define REDISMODULE_ATTR_PRINTF(idx, cnt)
+#endif
 #endif
 
 #ifndef REDISMODULE_ATTR_COMMON
-#    if defined(__GNUC__) && !defined(__clang__)
-#        define REDISMODULE_ATTR_COMMON __attribute__((__common__))
-#    else
-#        define REDISMODULE_ATTR_COMMON
-#    endif
+#if defined(__GNUC__) && !defined(__clang__)
+#define REDISMODULE_ATTR_COMMON __attribute__((__common__))
+#else
+#define REDISMODULE_ATTR_COMMON
+#endif
 #endif
 
 /* Incomplete structures for compiler checks but opaque access. */
@@ -483,7 +458,8 @@ typedef struct RedisModuleUser RedisModuleUser;
 
 typedef int (*RedisModuleCmdFunc)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 typedef void (*RedisModuleDisconnectFunc)(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc);
-typedef int (*RedisModuleNotificationFunc)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key);
+typedef int (*RedisModuleNotificationFunc)(RedisModuleCtx *ctx, int type, const char *event,
+                                           RedisModuleString *key);
 typedef void *(*RedisModuleTypeLoadFunc)(RedisModuleIO *rdb, int encver);
 typedef void (*RedisModuleTypeSaveFunc)(RedisModuleIO *rdb, void *value);
 typedef int (*RedisModuleTypeAuxLoadFunc)(RedisModuleIO *rdb, int encver, int when);
@@ -494,32 +470,36 @@ typedef void (*RedisModuleTypeDigestFunc)(RedisModuleDigest *digest, void *value
 typedef void (*RedisModuleTypeFreeFunc)(void *value);
 typedef size_t (*RedisModuleTypeFreeEffortFunc)(RedisModuleString *key, const void *value);
 typedef void (*RedisModuleTypeUnlinkFunc)(RedisModuleString *key, const void *value);
-typedef void (*RedisModuleClusterMessageReceiver)(RedisModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len);
+typedef void (*RedisModuleClusterMessageReceiver)(RedisModuleCtx *ctx, const char *sender_id,
+                                                  uint8_t type, const unsigned char *payload,
+                                                  uint32_t len);
 typedef void (*RedisModuleTimerProc)(RedisModuleCtx *ctx, void *data);
-typedef void (*RedisModuleCommandFilterFunc) (RedisModuleCommandFilterCtx *filter);
-typedef void (*RedisModuleForkDoneHandler) (int exitcode, int bysignal, void *user_data);
+typedef void (*RedisModuleCommandFilterFunc)(RedisModuleCommandFilterCtx *filter);
+typedef void (*RedisModuleForkDoneHandler)(int exitcode, int bysignal, void *user_data);
 typedef void (*RedisModuleInfoFunc)(RedisModuleInfoCtx *ctx, int for_crash_report);
-typedef void (*RedisModuleScanCB)(RedisModuleCtx *ctx, RedisModuleString *keyname, RedisModuleKey *key, void *privdata);
-typedef void (*RedisModuleScanKeyCB)(RedisModuleKey *key, RedisModuleString *field, RedisModuleString *value, void *privdata);
-typedef void (*RedisModuleUserChangedFunc) (uint64_t client_id, void *privdata);
+typedef void (*RedisModuleScanCB)(RedisModuleCtx *ctx, RedisModuleString *keyname,
+                                  RedisModuleKey *key, void *privdata);
+typedef void (*RedisModuleScanKeyCB)(RedisModuleKey *key, RedisModuleString *field,
+                                     RedisModuleString *value, void *privdata);
+typedef void (*RedisModuleUserChangedFunc)(uint64_t client_id, void *privdata);
 
 typedef struct RedisModuleTypeMethods {
-	uint64_t version;
-	RedisModuleTypeLoadFunc rdb_load;
-	RedisModuleTypeSaveFunc rdb_save;
-	RedisModuleTypeRewriteFunc aof_rewrite;
-	RedisModuleTypeMemUsageFunc mem_usage;
-	RedisModuleTypeDigestFunc digest;
-	RedisModuleTypeFreeFunc free;
-	RedisModuleTypeAuxLoadFunc aux_load;
-	RedisModuleTypeAuxSaveFunc aux_save;
-	int aux_save_triggers;
-	RedisModuleTypeFreeEffortFunc free_effort;
-	RedisModuleTypeUnlinkFunc unlink;
+    uint64_t version;
+    RedisModuleTypeLoadFunc rdb_load;
+    RedisModuleTypeSaveFunc rdb_save;
+    RedisModuleTypeRewriteFunc aof_rewrite;
+    RedisModuleTypeMemUsageFunc mem_usage;
+    RedisModuleTypeDigestFunc digest;
+    RedisModuleTypeFreeFunc free;
+    RedisModuleTypeAuxLoadFunc aux_load;
+    RedisModuleTypeAuxSaveFunc aux_save;
+    int aux_save_triggers;
+    RedisModuleTypeFreeEffortFunc free_effort;
+    RedisModuleTypeUnlinkFunc unlink;
 } RedisModuleTypeMethods;
 
-#define REDISMODULE_GET_API(name) \
-    RedisModule_GetApi("RedisModule_" #name, ((void **)&RedisModule_ ## name))
+#define REDISMODULE_GET_API(name)                                                                  \
+    RedisModule_GetApi("RedisModule_" #name, ((void **)&RedisModule_##name))
 
 /* Default API declaration prefix (not 'extern' for backwards compatibility) */
 #ifndef REDISMODULE_API
@@ -531,83 +511,137 @@ typedef struct RedisModuleTypeMethods {
 #define REDISMODULE_ATTR REDISMODULE_ATTR_COMMON
 #endif
 
-REDISMODULE_API void * (*RedisModule_Alloc)(size_t bytes) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_Realloc)(void *ptr, size_t bytes) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_Alloc)(size_t bytes)REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_Realloc)(void *ptr, size_t bytes)REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_Free)(void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_Calloc)(size_t nmemb, size_t size) REDISMODULE_ATTR;
-REDISMODULE_API char * (*RedisModule_Strdup)(const char *str) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_Calloc)(size_t nmemb, size_t size)REDISMODULE_ATTR;
+REDISMODULE_API char *(*RedisModule_Strdup)(const char *str)REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetApi)(const char *, void *) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, int ver, int apiver) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char *name,
+                                                 RedisModuleCmdFunc cmdfunc, const char *strflags,
+                                                 int firstkey, int lastkey,
+                                                 int keystep) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, int ver,
+                                                     int apiver) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsModuleNameBusy)(const char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_WrongArity)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithLongLong)(RedisModuleCtx *ctx, long long ll) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithLongLong)(RedisModuleCtx *ctx,
+                                                     long long ll) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetSelectedDb)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SelectDb)(RedisModuleCtx *ctx, int newid) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_OpenKey)(RedisModuleCtx *ctx, RedisModuleString *keyname, int mode) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_OpenKey)(RedisModuleCtx *ctx, RedisModuleString *keyname,
+                                             int mode)REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_CloseKey)(RedisModuleKey *kp) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_KeyType)(RedisModuleKey *kp) REDISMODULE_ATTR;
-REDISMODULE_API size_t (*RedisModule_ValueLength)(RedisModuleKey *kp) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ListPush)(RedisModuleKey *kp, int where, RedisModuleString *ele) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_ListPop)(RedisModuleKey *key, int where) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCallReply * (*RedisModule_Call)(RedisModuleCtx *ctx, const char *cmdname, const char *fmt, ...) REDISMODULE_ATTR;
-REDISMODULE_API const char * (*RedisModule_CallReplyProto)(RedisModuleCallReply *reply, size_t *len) REDISMODULE_ATTR;
+REDISMODULE_API
+size_t (*RedisModule_ValueLength)(RedisModuleKey *kp) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ListPush)(RedisModuleKey *kp, int where,
+                                            RedisModuleString *ele) REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleString *(*RedisModule_ListPop)(RedisModuleKey *key, int where)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleCallReply *(*RedisModule_Call)(RedisModuleCtx *ctx, const char *cmdname,
+                                                          const char *fmt, ...)REDISMODULE_ATTR;
+REDISMODULE_API const char *(*RedisModule_CallReplyProto)(RedisModuleCallReply *reply,
+                                                          size_t *len)REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeCallReply)(RedisModuleCallReply *reply) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CallReplyType)(RedisModuleCallReply *reply) REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_CallReplyInteger)(RedisModuleCallReply *reply) REDISMODULE_ATTR;
+REDISMODULE_API long long (*RedisModule_CallReplyInteger)(RedisModuleCallReply *reply)
+    REDISMODULE_ATTR;
 REDISMODULE_API size_t (*RedisModule_CallReplyLength)(RedisModuleCallReply *reply) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCallReply * (*RedisModule_CallReplyArrayElement)(RedisModuleCallReply *reply, size_t idx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_CreateString)(RedisModuleCtx *ctx, const char *ptr, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_CreateStringFromLongLong)(RedisModuleCtx *ctx, long long ll) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_CreateStringFromDouble)(RedisModuleCtx *ctx, double d) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_CreateStringFromLongDouble)(RedisModuleCtx *ctx, long double ld, int humanfriendly) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_CreateStringFromString)(RedisModuleCtx *ctx, const RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_CreateStringPrintf)(RedisModuleCtx *ctx, const char *fmt, ...) REDISMODULE_ATTR_PRINTF(2,3) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API const char * (*RedisModule_StringPtrLen)(const RedisModuleString *str, size_t *len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithError)(RedisModuleCtx *ctx, const char *err) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithSimpleString)(RedisModuleCtx *ctx, const char *msg) REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleCallReply *(*RedisModule_CallReplyArrayElement)(RedisModuleCallReply *reply,
+                                                           size_t idx)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_CreateString)(RedisModuleCtx *ctx, const char *ptr,
+                                                               size_t len)REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleString *(*RedisModule_CreateStringFromLongLong)(RedisModuleCtx *ctx,
+                                                           long long ll)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromDouble)(RedisModuleCtx *ctx,
+                                                                         double d)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromLongDouble)(
+    RedisModuleCtx *ctx, long double ld, int humanfriendly)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromString)(
+    RedisModuleCtx *ctx, const RedisModuleString *str)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringPrintf)(
+    RedisModuleCtx *ctx, const char *fmt, ...)REDISMODULE_ATTR_PRINTF(2, 3) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_FreeString)(RedisModuleCtx *ctx,
+                                               RedisModuleString *str) REDISMODULE_ATTR;
+REDISMODULE_API const char *(*RedisModule_StringPtrLen)(const RedisModuleString *str,
+                                                        size_t *len)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithError)(RedisModuleCtx *ctx,
+                                                  const char *err) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithSimpleString)(RedisModuleCtx *ctx,
+                                                         const char *msg) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithArray)(RedisModuleCtx *ctx, long len) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithNullArray)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithEmptyArray)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ReplySetArrayLength)(RedisModuleCtx *ctx, long len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithStringBuffer)(RedisModuleCtx *ctx, const char *buf, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithCString)(RedisModuleCtx *ctx, const char *buf) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_ReplySetArrayLength)(RedisModuleCtx *ctx,
+                                                        long len) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithStringBuffer)(RedisModuleCtx *ctx, const char *buf,
+                                                         size_t len) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithCString)(RedisModuleCtx *ctx,
+                                                    const char *buf) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithString)(RedisModuleCtx *ctx,
+                                                   RedisModuleString *str) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithEmptyString)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithVerbatimString)(RedisModuleCtx *ctx, const char *buf, size_t len) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithVerbatimString)(RedisModuleCtx *ctx, const char *buf,
+                                                           size_t len) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithNull)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx, double d) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithLongDouble)(RedisModuleCtx *ctx, long double d) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithCallReply)(RedisModuleCtx *ctx, RedisModuleCallReply *reply) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringToLongLong)(const RedisModuleString *str, long long *ll) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringToDouble)(const RedisModuleString *str, double *d) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringToLongDouble)(const RedisModuleString *str, long double *d) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithLongDouble)(RedisModuleCtx *ctx,
+                                                       long double d) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithCallReply)(RedisModuleCtx *ctx,
+                                                      RedisModuleCallReply *reply) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StringToLongLong)(const RedisModuleString *str,
+                                                    long long *ll) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StringToDouble)(const RedisModuleString *str,
+                                                  double *d) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StringToLongDouble)(const RedisModuleString *str,
+                                                      long double *d) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_AutoMemory)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_Replicate)(RedisModuleCtx *ctx, const char *cmdname, const char *fmt, ...) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_Replicate)(RedisModuleCtx *ctx, const char *cmdname,
+                                             const char *fmt, ...) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplicateVerbatim)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API const char * (*RedisModule_CallReplyStringPtr)(RedisModuleCallReply *reply, size_t *len) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_CreateStringFromCallReply)(RedisModuleCallReply *reply) REDISMODULE_ATTR;
+REDISMODULE_API const char *(*RedisModule_CallReplyStringPtr)(RedisModuleCallReply *reply,
+                                                              size_t *len)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromCallReply)(
+    RedisModuleCallReply *reply)REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_DeleteKey)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_UnlinkKey)(RedisModuleKey *key) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringSet)(RedisModuleKey *key, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API char * (*RedisModule_StringDMA)(RedisModuleKey *key, size_t *len, int mode) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringTruncate)(RedisModuleKey *key, size_t newlen) REDISMODULE_ATTR;
-REDISMODULE_API mstime_t (*RedisModule_GetExpire)(RedisModuleKey *key) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StringSet)(RedisModuleKey *key,
+                                             RedisModuleString *str) REDISMODULE_ATTR;
+REDISMODULE_API char *(*RedisModule_StringDMA)(RedisModuleKey *key, size_t *len,
+                                               int mode)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StringTruncate)(RedisModuleKey *key,
+                                                  size_t newlen) REDISMODULE_ATTR;
+REDISMODULE_API
+mstime_t (*RedisModule_GetExpire)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetExpire)(RedisModuleKey *key, mstime_t expire) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ResetDataset)(int restart_aof, int async) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_DbSize)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_RandomKey)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetAdd)(RedisModuleKey *key, double score, RedisModuleString *ele, int *flagsptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetIncrby)(RedisModuleKey *key, double score, RedisModuleString *ele, int *flagsptr, double *newscore) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetScore)(RedisModuleKey *key, RedisModuleString *ele, double *score) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetRem)(RedisModuleKey *key, RedisModuleString *ele, int *deleted) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_RandomKey)(RedisModuleCtx *ctx)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ZsetAdd)(RedisModuleKey *key, double score,
+                                           RedisModuleString *ele, int *flagsptr) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ZsetIncrby)(RedisModuleKey *key, double score,
+                                              RedisModuleString *ele, int *flagsptr,
+                                              double *newscore) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ZsetScore)(RedisModuleKey *key, RedisModuleString *ele,
+                                             double *score) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ZsetRem)(RedisModuleKey *key, RedisModuleString *ele,
+                                           int *deleted) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ZsetRangeStop)(RedisModuleKey *key) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetFirstInScoreRange)(RedisModuleKey *key, double min, double max, int minex, int maxex) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetLastInScoreRange)(RedisModuleKey *key, double min, double max, int minex, int maxex) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetFirstInLexRange)(RedisModuleKey *key, RedisModuleString *min, RedisModuleString *max) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetLastInLexRange)(RedisModuleKey *key, RedisModuleString *min, RedisModuleString *max) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_ZsetRangeCurrentElement)(RedisModuleKey *key, double *score) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ZsetFirstInScoreRange)(RedisModuleKey *key, double min,
+                                                         double max, int minex,
+                                                         int maxex) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ZsetLastInScoreRange)(RedisModuleKey *key, double min, double max,
+                                                        int minex, int maxex) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ZsetFirstInLexRange)(RedisModuleKey *key, RedisModuleString *min,
+                                                       RedisModuleString *max) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ZsetLastInLexRange)(RedisModuleKey *key, RedisModuleString *min,
+                                                      RedisModuleString *max) REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleString *(*RedisModule_ZsetRangeCurrentElement)(RedisModuleKey *key,
+                                                          double *score)REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ZsetRangeNext)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ZsetRangePrev)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ZsetRangeEndReached)(RedisModuleKey *key) REDISMODULE_ATTR;
@@ -617,420 +651,557 @@ REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) RE
 REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetClientInfoById)(void *ci, uint64_t id) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_PublishMessage)(RedisModuleCtx *ctx, RedisModuleString *channel, RedisModuleString *message) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_PublishMessage)(RedisModuleCtx *ctx, RedisModuleString *channel,
+                                                  RedisModuleString *message) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetContextFlags)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_AvoidReplicaTraffic)() REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_PoolAlloc)(RedisModuleCtx *ctx, size_t bytes) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleType * (*RedisModule_CreateDataType)(RedisModuleCtx *ctx, const char *name, int encver, RedisModuleTypeMethods *typemethods) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ModuleTypeSetValue)(RedisModuleKey *key, RedisModuleType *mt, void *value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ModuleTypeReplaceValue)(RedisModuleKey *key, RedisModuleType *mt, void *new_value, void **old_value) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleType * (*RedisModule_ModuleTypeGetType)(RedisModuleKey *key) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_ModuleTypeGetValue)(RedisModuleKey *key) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_PoolAlloc)(RedisModuleCtx *ctx, size_t bytes)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleType *(*RedisModule_CreateDataType)(
+    RedisModuleCtx *ctx, const char *name, int encver,
+    RedisModuleTypeMethods *typemethods)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ModuleTypeSetValue)(RedisModuleKey *key, RedisModuleType *mt,
+                                                      void *value) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ModuleTypeReplaceValue)(RedisModuleKey *key, RedisModuleType *mt,
+                                                          void *new_value,
+                                                          void **old_value) REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleType *(*RedisModule_ModuleTypeGetType)(RedisModuleKey *key)REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_ModuleTypeGetValue)(RedisModuleKey *key)REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsIOError)(RedisModuleIO *io) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetModuleOptions)(RedisModuleCtx *ctx, int options) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SignalModifiedKey)(RedisModuleCtx *ctx, RedisModuleString *keyname) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveUnsigned)(RedisModuleIO *io, uint64_t value) REDISMODULE_ATTR;
-REDISMODULE_API uint64_t (*RedisModule_LoadUnsigned)(RedisModuleIO *io) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SetModuleOptions)(RedisModuleCtx *ctx,
+                                                     int options) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SignalModifiedKey)(RedisModuleCtx *ctx,
+                                                     RedisModuleString *keyname) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SaveUnsigned)(RedisModuleIO *io,
+                                                 uint64_t value) REDISMODULE_ATTR;
+REDISMODULE_API
+uint64_t (*RedisModule_LoadUnsigned)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SaveSigned)(RedisModuleIO *io, int64_t value) REDISMODULE_ATTR;
-REDISMODULE_API int64_t (*RedisModule_LoadSigned)(RedisModuleIO *io) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_EmitAOF)(RedisModuleIO *io, const char *cmdname, const char *fmt, ...) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveString)(RedisModuleIO *io, RedisModuleString *s) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveStringBuffer)(RedisModuleIO *io, const char *str, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_LoadString)(RedisModuleIO *io) REDISMODULE_ATTR;
-REDISMODULE_API char * (*RedisModule_LoadStringBuffer)(RedisModuleIO *io, size_t *lenptr) REDISMODULE_ATTR;
+REDISMODULE_API
+int64_t (*RedisModule_LoadSigned)(RedisModuleIO *io) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_EmitAOF)(RedisModuleIO *io, const char *cmdname, const char *fmt,
+                                            ...) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SaveString)(RedisModuleIO *io,
+                                               RedisModuleString *s) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SaveStringBuffer)(RedisModuleIO *io, const char *str,
+                                                     size_t len) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_LoadString)(RedisModuleIO *io)REDISMODULE_ATTR;
+REDISMODULE_API char *(*RedisModule_LoadStringBuffer)(RedisModuleIO *io,
+                                                      size_t *lenptr)REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SaveDouble)(RedisModuleIO *io, double value) REDISMODULE_ATTR;
 REDISMODULE_API double (*RedisModule_LoadDouble)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SaveFloat)(RedisModuleIO *io, float value) REDISMODULE_ATTR;
 REDISMODULE_API float (*RedisModule_LoadFloat)(RedisModuleIO *io) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveLongDouble)(RedisModuleIO *io, long double value) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SaveLongDouble)(RedisModuleIO *io,
+                                                   long double value) REDISMODULE_ATTR;
 REDISMODULE_API long double (*RedisModule_LoadLongDouble)(RedisModuleIO *io) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_LoadDataTypeFromString)(const RedisModuleString *str, const RedisModuleType *mt) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_SaveDataTypeToString)(RedisModuleCtx *ctx, void *data, const RedisModuleType *mt) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_Log)(RedisModuleCtx *ctx, const char *level, const char *fmt, ...) REDISMODULE_ATTR REDISMODULE_ATTR_PRINTF(3,4);
-REDISMODULE_API void (*RedisModule_LogIOError)(RedisModuleIO *io, const char *levelstr, const char *fmt, ...) REDISMODULE_ATTR REDISMODULE_ATTR_PRINTF(3,4);
-REDISMODULE_API void (*RedisModule__Assert)(const char *estr, const char *file, int line) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_LatencyAddSample)(const char *event, mstime_t latency) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringAppendBuffer)(RedisModuleCtx *ctx, RedisModuleString *str, const char *buf, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_RetainString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_HoldString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringCompare)(RedisModuleString *a, RedisModuleString *b) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCtx * (*RedisModule_GetContextFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromModuleKey)(RedisModuleKey *key) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_LoadDataTypeFromString)(
+    const RedisModuleString *str, const RedisModuleType *mt)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_SaveDataTypeToString)(
+    RedisModuleCtx *ctx, void *data, const RedisModuleType *mt)REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_Log)(RedisModuleCtx *ctx, const char *level, const char *fmt,
+                                        ...) REDISMODULE_ATTR REDISMODULE_ATTR_PRINTF(3, 4);
+REDISMODULE_API void (*RedisModule_LogIOError)(RedisModuleIO *io, const char *levelstr,
+                                               const char *fmt, ...) REDISMODULE_ATTR
+    REDISMODULE_ATTR_PRINTF(3, 4);
+REDISMODULE_API void (*RedisModule__Assert)(const char *estr, const char *file,
+                                            int line) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_LatencyAddSample)(const char *event,
+                                                     mstime_t latency) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StringAppendBuffer)(RedisModuleCtx *ctx, RedisModuleString *str,
+                                                      const char *buf, size_t len) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_RetainString)(RedisModuleCtx *ctx,
+                                                 RedisModuleString *str) REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleString *(*RedisModule_HoldString)(RedisModuleCtx *ctx,
+                                             RedisModuleString *str)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StringCompare)(RedisModuleString *a,
+                                                 RedisModuleString *b) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleCtx *(*RedisModule_GetContextFromIO)(RedisModuleIO *io)REDISMODULE_ATTR;
+REDISMODULE_API const
+    RedisModuleString *(*RedisModule_GetKeyNameFromIO)(RedisModuleIO *io)REDISMODULE_ATTR;
+REDISMODULE_API const
+    RedisModuleString *(*RedisModule_GetKeyNameFromModuleKey)(RedisModuleKey *key)REDISMODULE_ATTR;
 REDISMODULE_API long long (*RedisModule_Milliseconds)(void) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_DigestAddStringBuffer)(RedisModuleDigest *md, unsigned char *ele, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_DigestAddLongLong)(RedisModuleDigest *md, long long ele) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_DigestAddStringBuffer)(RedisModuleDigest *md, unsigned char *ele,
+                                                          size_t len) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_DigestAddLongLong)(RedisModuleDigest *md,
+                                                      long long ele) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DigestEndSequence)(RedisModuleDigest *md) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleDict * (*RedisModule_CreateDict)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeDict)(RedisModuleCtx *ctx, RedisModuleDict *d) REDISMODULE_ATTR;
-REDISMODULE_API uint64_t (*RedisModule_DictSize)(RedisModuleDict *d) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictSetC)(RedisModuleDict *d, void *key, size_t keylen, void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictReplaceC)(RedisModuleDict *d, void *key, size_t keylen, void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictSet)(RedisModuleDict *d, RedisModuleString *key, void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictReplace)(RedisModuleDict *d, RedisModuleString *key, void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_DictGetC)(RedisModuleDict *d, void *key, size_t keylen, int *nokey) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_DictGet)(RedisModuleDict *d, RedisModuleString *key, int *nokey) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictDelC)(RedisModuleDict *d, void *key, size_t keylen, void *oldval) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictDel)(RedisModuleDict *d, RedisModuleString *key, void *oldval) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleDictIter * (*RedisModule_DictIteratorStartC)(RedisModuleDict *d, const char *op, void *key, size_t keylen) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleDictIter * (*RedisModule_DictIteratorStart)(RedisModuleDict *d, const char *op, RedisModuleString *key) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleDict *(*RedisModule_CreateDict)(RedisModuleCtx *ctx)REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_FreeDict)(RedisModuleCtx *ctx,
+                                             RedisModuleDict *d) REDISMODULE_ATTR;
+REDISMODULE_API
+uint64_t (*RedisModule_DictSize)(RedisModuleDict *d) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictSetC)(RedisModuleDict *d, void *key, size_t keylen,
+                                            void *ptr) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictReplaceC)(RedisModuleDict *d, void *key, size_t keylen,
+                                                void *ptr) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictSet)(RedisModuleDict *d, RedisModuleString *key,
+                                           void *ptr) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictReplace)(RedisModuleDict *d, RedisModuleString *key,
+                                               void *ptr) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_DictGetC)(RedisModuleDict *d, void *key, size_t keylen,
+                                              int *nokey)REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_DictGet)(RedisModuleDict *d, RedisModuleString *key,
+                                             int *nokey)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictDelC)(RedisModuleDict *d, void *key, size_t keylen,
+                                            void *oldval) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictDel)(RedisModuleDict *d, RedisModuleString *key,
+                                           void *oldval) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleDictIter *(*RedisModule_DictIteratorStartC)(
+    RedisModuleDict *d, const char *op, void *key, size_t keylen)REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleDictIter *(*RedisModule_DictIteratorStart)(RedisModuleDict *d, const char *op,
+                                                      RedisModuleString *key)REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DictIteratorStop)(RedisModuleDictIter *di) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictIteratorReseekC)(RedisModuleDictIter *di, const char *op, void *key, size_t keylen) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictIteratorReseek)(RedisModuleDictIter *di, const char *op, RedisModuleString *key) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_DictNextC)(RedisModuleDictIter *di, size_t *keylen, void **dataptr) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_DictPrevC)(RedisModuleDictIter *di, size_t *keylen, void **dataptr) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_DictNext)(RedisModuleCtx *ctx, RedisModuleDictIter *di, void **dataptr) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_DictPrev)(RedisModuleCtx *ctx, RedisModuleDictIter *di, void **dataptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictCompareC)(RedisModuleDictIter *di, const char *op, void *key, size_t keylen) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictCompare)(RedisModuleDictIter *di, const char *op, RedisModuleString *key) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RegisterInfoFunc)(RedisModuleCtx *ctx, RedisModuleInfoFunc cb) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddSection)(RedisModuleInfoCtx *ctx, char *name) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoBeginDictField)(RedisModuleInfoCtx *ctx, char *name) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictIteratorReseekC)(RedisModuleDictIter *di, const char *op,
+                                                       void *key, size_t keylen) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictIteratorReseek)(RedisModuleDictIter *di, const char *op,
+                                                      RedisModuleString *key) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_DictNextC)(RedisModuleDictIter *di, size_t *keylen,
+                                               void **dataptr)REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_DictPrevC)(RedisModuleDictIter *di, size_t *keylen,
+                                               void **dataptr)REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleString *(*RedisModule_DictNext)(RedisModuleCtx *ctx, RedisModuleDictIter *di,
+                                           void **dataptr)REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleString *(*RedisModule_DictPrev)(RedisModuleCtx *ctx, RedisModuleDictIter *di,
+                                           void **dataptr)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictCompareC)(RedisModuleDictIter *di, const char *op, void *key,
+                                                size_t keylen) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DictCompare)(RedisModuleDictIter *di, const char *op,
+                                               RedisModuleString *key) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RegisterInfoFunc)(RedisModuleCtx *ctx,
+                                                    RedisModuleInfoFunc cb) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_InfoAddSection)(RedisModuleInfoCtx *ctx,
+                                                  char *name) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_InfoBeginDictField)(RedisModuleInfoCtx *ctx,
+                                                      char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_InfoEndDictField)(RedisModuleInfoCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldString)(RedisModuleInfoCtx *ctx, char *field, RedisModuleString *value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldCString)(RedisModuleInfoCtx *ctx, char *field, char *value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldDouble)(RedisModuleInfoCtx *ctx, char *field, double value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldLongLong)(RedisModuleInfoCtx *ctx, char *field, long long value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldULongLong)(RedisModuleInfoCtx *ctx, char *field, unsigned long long value) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleServerInfoData * (*RedisModule_GetServerInfo)(RedisModuleCtx *ctx, const char *section) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeServerInfo)(RedisModuleCtx *ctx, RedisModuleServerInfoData *data) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_ServerInfoGetField)(RedisModuleCtx *ctx, RedisModuleServerInfoData *data, const char* field) REDISMODULE_ATTR;
-REDISMODULE_API const char * (*RedisModule_ServerInfoGetFieldC)(RedisModuleServerInfoData *data, const char* field) REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_ServerInfoGetFieldSigned)(RedisModuleServerInfoData *data, const char* field, int *out_err) REDISMODULE_ATTR;
-REDISMODULE_API unsigned long long (*RedisModule_ServerInfoGetFieldUnsigned)(RedisModuleServerInfoData *data, const char* field, int *out_err) REDISMODULE_ATTR;
-REDISMODULE_API double (*RedisModule_ServerInfoGetFieldDouble)(RedisModuleServerInfoData *data, const char* field, int *out_err) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SubscribeToServerEvent)(RedisModuleCtx *ctx, RedisModuleEvent event, RedisModuleEventCallback callback) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_InfoAddFieldString)(RedisModuleInfoCtx *ctx, char *field,
+                                                      RedisModuleString *value) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_InfoAddFieldCString)(RedisModuleInfoCtx *ctx, char *field,
+                                                       char *value) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_InfoAddFieldDouble)(RedisModuleInfoCtx *ctx, char *field,
+                                                      double value) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_InfoAddFieldLongLong)(RedisModuleInfoCtx *ctx, char *field,
+                                                        long long value) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_InfoAddFieldULongLong)(RedisModuleInfoCtx *ctx, char *field,
+                                                         unsigned long long value) REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleServerInfoData *(*RedisModule_GetServerInfo)(RedisModuleCtx *ctx,
+                                                        const char *section)REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_FreeServerInfo)(
+    RedisModuleCtx *ctx, RedisModuleServerInfoData *data) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_ServerInfoGetField)(
+    RedisModuleCtx *ctx, RedisModuleServerInfoData *data, const char *field)REDISMODULE_ATTR;
+REDISMODULE_API const char *(*RedisModule_ServerInfoGetFieldC)(RedisModuleServerInfoData *data,
+                                                               const char *field)REDISMODULE_ATTR;
+REDISMODULE_API long long (*RedisModule_ServerInfoGetFieldSigned)(RedisModuleServerInfoData *data,
+                                                                  const char *field,
+                                                                  int *out_err) REDISMODULE_ATTR;
+REDISMODULE_API unsigned long long (*RedisModule_ServerInfoGetFieldUnsigned)(
+    RedisModuleServerInfoData *data, const char *field, int *out_err) REDISMODULE_ATTR;
+REDISMODULE_API double (*RedisModule_ServerInfoGetFieldDouble)(RedisModuleServerInfoData *data,
+                                                               const char *field,
+                                                               int *out_err) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SubscribeToServerEvent)(
+    RedisModuleCtx *ctx, RedisModuleEvent event,
+    RedisModuleEventCallback callback) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetLRU)(RedisModuleKey *key, mstime_t lru_idle) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetLRU)(RedisModuleKey *key, mstime_t *lru_idle) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetLFU)(RedisModuleKey *key, long long lfu_freq) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetLFU)(RedisModuleKey *key, long long *lfu_freq) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleBlockedClient * (*RedisModule_BlockClientOnKeys)(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*), long long timeout_ms, RedisModuleString **keys, int numkeys, void *privdata) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SignalKeyAsReady)(RedisModuleCtx *ctx, RedisModuleString *key) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_GetBlockedClientReadyKey)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleScanCursor * (*RedisModule_ScanCursorCreate)() REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ScanCursorRestart)(RedisModuleScanCursor *cursor) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ScanCursorDestroy)(RedisModuleScanCursor *cursor) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_Scan)(RedisModuleCtx *ctx, RedisModuleScanCursor *cursor, RedisModuleScanCB fn, void *privdata) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ScanKey)(RedisModuleKey *key, RedisModuleScanCursor *cursor, RedisModuleScanKeyCB fn, void *privdata) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_GetLFU)(RedisModuleKey *key,
+                                          long long *lfu_freq) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleBlockedClient *(*RedisModule_BlockClientOnKeys)(
+    RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback,
+    void (*free_privdata)(RedisModuleCtx *, void *), long long timeout_ms, RedisModuleString **keys,
+    int numkeys, void *privdata)REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SignalKeyAsReady)(RedisModuleCtx *ctx,
+                                                     RedisModuleString *key) REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleString *(*RedisModule_GetBlockedClientReadyKey)(RedisModuleCtx *ctx)REDISMODULE_ATTR;
+REDISMODULE_API
+RedisModuleScanCursor *(*RedisModule_ScanCursorCreate)() REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_ScanCursorRestart)(RedisModuleScanCursor *cursor)
+    REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_ScanCursorDestroy)(RedisModuleScanCursor *cursor)
+    REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_Scan)(RedisModuleCtx *ctx, RedisModuleScanCursor *cursor,
+                                        RedisModuleScanCB fn, void *privdata) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ScanKey)(RedisModuleKey *key, RedisModuleScanCursor *cursor,
+                                           RedisModuleScanKeyCB fn,
+                                           void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetContextFlagsAll)() REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetKeyspaceNotificationFlagsAll)() REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_IsSubEventSupported)(RedisModuleEvent event, uint64_t subevent) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_IsSubEventSupported)(RedisModuleEvent event,
+                                                       uint64_t subevent) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetServerVersion)() REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetTypeMethodVersion)() REDISMODULE_ATTR;
 
 /* Experimental APIs */
 #ifdef REDISMODULE_EXPERIMENTAL_API
 #define REDISMODULE_EXPERIMENTAL_API_VERSION 3
-REDISMODULE_API RedisModuleBlockedClient * (*RedisModule_BlockClient)(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*), long long timeout_ms) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_UnblockClient)(RedisModuleBlockedClient *bc, void *privdata) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleBlockedClient *(*RedisModule_BlockClient)(
+    RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback,
+    void (*free_privdata)(RedisModuleCtx *, void *), long long timeout_ms)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_UnblockClient)(RedisModuleBlockedClient *bc,
+                                                 void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsBlockedReplyRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsBlockedTimeoutRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_GetBlockedClientPrivateData)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleBlockedClient * (*RedisModule_GetBlockedClientHandle)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_GetBlockedClientPrivateData)(RedisModuleCtx *ctx)
+    REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleBlockedClient *(*RedisModule_GetBlockedClientHandle)(RedisModuleCtx *ctx)
+    REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_AbortBlock)(RedisModuleBlockedClient *bc) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCtx * (*RedisModule_GetThreadSafeContext)(RedisModuleBlockedClient *bc) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCtx * (*RedisModule_GetDetachedThreadSafeContext)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleCtx *(*RedisModule_GetThreadSafeContext)(RedisModuleBlockedClient *bc)
+    REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleCtx *(*RedisModule_GetDetachedThreadSafeContext)(RedisModuleCtx *ctx)
+    REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeThreadSafeContext)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ThreadSafeContextLock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ThreadSafeContextTryLock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ThreadSafeContextUnlock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SubscribeToKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_NotifyKeyspaceEvent)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SubscribeToKeyspaceEvents)(
+    RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_NotifyKeyspaceEvent)(RedisModuleCtx *ctx, int type,
+                                                       const char *event,
+                                                       RedisModuleString *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetNotifyKeyspaceEvents)() REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_BlockedClientDisconnected)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_RegisterClusterMessageReceiver)(RedisModuleCtx *ctx, uint8_t type, RedisModuleClusterMessageReceiver callback) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SendClusterMessage)(RedisModuleCtx *ctx, char *target_id, uint8_t type, unsigned char *msg, uint32_t len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetClusterNodeInfo)(RedisModuleCtx *ctx, const char *id, char *ip, char *master_id, int *port, int *flags) REDISMODULE_ATTR;
-REDISMODULE_API char ** (*RedisModule_GetClusterNodesList)(RedisModuleCtx *ctx, size_t *numnodes) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_RegisterClusterMessageReceiver)(
+    RedisModuleCtx *ctx, uint8_t type, RedisModuleClusterMessageReceiver callback) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SendClusterMessage)(RedisModuleCtx *ctx, char *target_id,
+                                                      uint8_t type, unsigned char *msg,
+                                                      uint32_t len) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_GetClusterNodeInfo)(RedisModuleCtx *ctx, const char *id, char *ip,
+                                                      char *master_id, int *port,
+                                                      int *flags) REDISMODULE_ATTR;
+REDISMODULE_API char **(*RedisModule_GetClusterNodesList)(RedisModuleCtx *ctx,
+                                                          size_t *numnodes)REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeClusterNodesList)(char **ids) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleTimerID (*RedisModule_CreateTimer)(RedisModuleCtx *ctx, mstime_t period, RedisModuleTimerProc callback, void *data) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StopTimer)(RedisModuleCtx *ctx, RedisModuleTimerID id, void **data) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetTimerInfo)(RedisModuleCtx *ctx, RedisModuleTimerID id, uint64_t *remaining, void **data) REDISMODULE_ATTR;
-REDISMODULE_API const char * (*RedisModule_GetMyClusterID)(void) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleTimerID (*RedisModule_CreateTimer)(RedisModuleCtx *ctx, mstime_t period,
+                                                              RedisModuleTimerProc callback,
+                                                              void *data) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StopTimer)(RedisModuleCtx *ctx, RedisModuleTimerID id,
+                                             void **data) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_GetTimerInfo)(RedisModuleCtx *ctx, RedisModuleTimerID id,
+                                                uint64_t *remaining, void **data) REDISMODULE_ATTR;
+REDISMODULE_API const char *(*RedisModule_GetMyClusterID)(void)REDISMODULE_ATTR;
 REDISMODULE_API size_t (*RedisModule_GetClusterSize)(void) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_GetRandomBytes)(unsigned char *dst, size_t len) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_GetRandomHexChars)(char *dst, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetDisconnectCallback)(RedisModuleBlockedClient *bc, RedisModuleDisconnectFunc callback) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetClusterFlags)(RedisModuleCtx *ctx, uint64_t flags) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname, void *func) REDISMODULE_ATTR;
-REDISMODULE_API void * (*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx, const char *apiname) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCommandFilter * (*RedisModule_RegisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilterFunc cb, int flags) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_UnregisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilter *filter) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CommandFilterArgsCount)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString * (*RedisModule_CommandFilterArgGet)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SetDisconnectCallback)(
+    RedisModuleBlockedClient *bc, RedisModuleDisconnectFunc callback) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SetClusterFlags)(RedisModuleCtx *ctx,
+                                                    uint64_t flags) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname,
+                                                   void *func) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx,
+                                                  const char *apiname)REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleCommandFilter *(*RedisModule_RegisterCommandFilter)(
+    RedisModuleCtx *ctx, RedisModuleCommandFilterFunc cb, int flags)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_UnregisterCommandFilter)(
+    RedisModuleCtx *ctx, RedisModuleCommandFilter *filter) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CommandFilterArgsCount)(RedisModuleCommandFilterCtx *fctx)
+    REDISMODULE_ATTR;
+REDISMODULE_API const
+    RedisModuleString *(*RedisModule_CommandFilterArgGet)(RedisModuleCommandFilterCtx *fctx,
+                                                          int pos)REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilterCtx *fctx,
+                                                          int pos,
+                                                          RedisModuleString *arg) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx,
+                                                           int pos,
+                                                           RedisModuleString *arg) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx,
+                                                          int pos) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_Fork)(RedisModuleForkDoneHandler cb,
+                                        void *user_data) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_KillForkChild)(int child_pid) REDISMODULE_ATTR;
 REDISMODULE_API float (*RedisModule_GetUsedMemoryRatio)() REDISMODULE_ATTR;
-REDISMODULE_API size_t (*RedisModule_MallocSize)(void* ptr) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleUser * (*RedisModule_CreateModuleUser)(const char *name) REDISMODULE_ATTR;
+REDISMODULE_API size_t (*RedisModule_MallocSize)(void *ptr) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleUser *(*RedisModule_CreateModuleUser)(const char *name)REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeModuleUser)(RedisModuleUser *user) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetModuleUserACL)(RedisModuleUser *user, const char* acl) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_AuthenticateClientWithACLUser)(RedisModuleCtx *ctx, const char *name, size_t len, RedisModuleUserChangedFunc callback, void *privdata, uint64_t *client_id) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_AuthenticateClientWithUser)(RedisModuleCtx *ctx, RedisModuleUser *user, RedisModuleUserChangedFunc callback, void *privdata, uint64_t *client_id) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DeauthenticateAndCloseClient)(RedisModuleCtx *ctx, uint64_t client_id) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_GetClientCertificate)(RedisModuleCtx *ctx, uint64_t id) REDISMODULE_ATTR;
-REDISMODULE_API int *(*RedisModule_GetCommandKeys)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SetModuleUserACL)(RedisModuleUser *user,
+                                                    const char *acl) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_AuthenticateClientWithACLUser)(
+    RedisModuleCtx *ctx, const char *name, size_t len, RedisModuleUserChangedFunc callback,
+    void *privdata, uint64_t *client_id) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_AuthenticateClientWithUser)(RedisModuleCtx *ctx,
+                                                              RedisModuleUser *user,
+                                                              RedisModuleUserChangedFunc callback,
+                                                              void *privdata,
+                                                              uint64_t *client_id) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DeauthenticateAndCloseClient)(
+    RedisModuleCtx *ctx, uint64_t client_id) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_GetClientCertificate)(RedisModuleCtx *ctx,
+                                                                       uint64_t id)REDISMODULE_ATTR;
+REDISMODULE_API int *(*RedisModule_GetCommandKeys)(RedisModuleCtx *ctx, RedisModuleString **argv,
+                                                   int argc, int *num_keys)REDISMODULE_ATTR;
 #endif
 
 #define RedisModule_IsAOFClient(id) ((id) == CLIENT_ID_AOF)
 
 /* This is included inline inside each Redis module. */
-static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int apiver) REDISMODULE_ATTR_UNUSED;
+static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver,
+                            int apiver) REDISMODULE_ATTR_UNUSED;
 static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int apiver) {
-	void *getapifuncptr = ((void**)ctx)[0];
-	RedisModule_GetApi = (int (*)(const char *, void *)) (unsigned long)getapifuncptr;
-	REDISMODULE_GET_API(Alloc);
-	REDISMODULE_GET_API(Calloc);
-	REDISMODULE_GET_API(Free);
-	REDISMODULE_GET_API(Realloc);
-	REDISMODULE_GET_API(Strdup);
-	REDISMODULE_GET_API(CreateCommand);
-	REDISMODULE_GET_API(SetModuleAttribs);
-	REDISMODULE_GET_API(IsModuleNameBusy);
-	REDISMODULE_GET_API(WrongArity);
-	REDISMODULE_GET_API(ReplyWithLongLong);
-	REDISMODULE_GET_API(ReplyWithError);
-	REDISMODULE_GET_API(ReplyWithSimpleString);
-	REDISMODULE_GET_API(ReplyWithArray);
-	REDISMODULE_GET_API(ReplyWithNullArray);
-	REDISMODULE_GET_API(ReplyWithEmptyArray);
-	REDISMODULE_GET_API(ReplySetArrayLength);
-	REDISMODULE_GET_API(ReplyWithStringBuffer);
-	REDISMODULE_GET_API(ReplyWithCString);
-	REDISMODULE_GET_API(ReplyWithString);
-	REDISMODULE_GET_API(ReplyWithEmptyString);
-	REDISMODULE_GET_API(ReplyWithVerbatimString);
-	REDISMODULE_GET_API(ReplyWithNull);
-	REDISMODULE_GET_API(ReplyWithCallReply);
-	REDISMODULE_GET_API(ReplyWithDouble);
-	REDISMODULE_GET_API(ReplyWithLongDouble);
-	REDISMODULE_GET_API(GetSelectedDb);
-	REDISMODULE_GET_API(SelectDb);
-	REDISMODULE_GET_API(OpenKey);
-	REDISMODULE_GET_API(CloseKey);
-	REDISMODULE_GET_API(KeyType);
-	REDISMODULE_GET_API(ValueLength);
-	REDISMODULE_GET_API(ListPush);
-	REDISMODULE_GET_API(ListPop);
-	REDISMODULE_GET_API(StringToLongLong);
-	REDISMODULE_GET_API(StringToDouble);
-	REDISMODULE_GET_API(StringToLongDouble);
-	REDISMODULE_GET_API(Call);
-	REDISMODULE_GET_API(CallReplyProto);
-	REDISMODULE_GET_API(FreeCallReply);
-	REDISMODULE_GET_API(CallReplyInteger);
-	REDISMODULE_GET_API(CallReplyType);
-	REDISMODULE_GET_API(CallReplyLength);
-	REDISMODULE_GET_API(CallReplyArrayElement);
-	REDISMODULE_GET_API(CallReplyStringPtr);
-	REDISMODULE_GET_API(CreateStringFromCallReply);
-	REDISMODULE_GET_API(CreateString);
-	REDISMODULE_GET_API(CreateStringFromLongLong);
-	REDISMODULE_GET_API(CreateStringFromDouble);
-	REDISMODULE_GET_API(CreateStringFromLongDouble);
-	REDISMODULE_GET_API(CreateStringFromString);
-	REDISMODULE_GET_API(CreateStringPrintf);
-	REDISMODULE_GET_API(FreeString);
-	REDISMODULE_GET_API(StringPtrLen);
-	REDISMODULE_GET_API(AutoMemory);
-	REDISMODULE_GET_API(Replicate);
-	REDISMODULE_GET_API(ReplicateVerbatim);
-	REDISMODULE_GET_API(DeleteKey);
-	REDISMODULE_GET_API(UnlinkKey);
-	REDISMODULE_GET_API(StringSet);
-	REDISMODULE_GET_API(StringDMA);
-	REDISMODULE_GET_API(StringTruncate);
-	REDISMODULE_GET_API(GetExpire);
-	REDISMODULE_GET_API(SetExpire);
-	REDISMODULE_GET_API(ResetDataset);
-	REDISMODULE_GET_API(DbSize);
-	REDISMODULE_GET_API(RandomKey);
-	REDISMODULE_GET_API(ZsetAdd);
-	REDISMODULE_GET_API(ZsetIncrby);
-	REDISMODULE_GET_API(ZsetScore);
-	REDISMODULE_GET_API(ZsetRem);
-	REDISMODULE_GET_API(ZsetRangeStop);
-	REDISMODULE_GET_API(ZsetFirstInScoreRange);
-	REDISMODULE_GET_API(ZsetLastInScoreRange);
-	REDISMODULE_GET_API(ZsetFirstInLexRange);
-	REDISMODULE_GET_API(ZsetLastInLexRange);
-	REDISMODULE_GET_API(ZsetRangeCurrentElement);
-	REDISMODULE_GET_API(ZsetRangeNext);
-	REDISMODULE_GET_API(ZsetRangePrev);
-	REDISMODULE_GET_API(ZsetRangeEndReached);
-	REDISMODULE_GET_API(HashSet);
-	REDISMODULE_GET_API(HashGet);
-	REDISMODULE_GET_API(IsKeysPositionRequest);
-	REDISMODULE_GET_API(KeyAtPos);
-	REDISMODULE_GET_API(GetClientId);
-	REDISMODULE_GET_API(GetContextFlags);
-	REDISMODULE_GET_API(AvoidReplicaTraffic);
-	REDISMODULE_GET_API(PoolAlloc);
-	REDISMODULE_GET_API(CreateDataType);
-	REDISMODULE_GET_API(ModuleTypeSetValue);
-	REDISMODULE_GET_API(ModuleTypeReplaceValue);
-	REDISMODULE_GET_API(ModuleTypeGetType);
-	REDISMODULE_GET_API(ModuleTypeGetValue);
-	REDISMODULE_GET_API(IsIOError);
-	REDISMODULE_GET_API(SetModuleOptions);
-	REDISMODULE_GET_API(SignalModifiedKey);
-	REDISMODULE_GET_API(SaveUnsigned);
-	REDISMODULE_GET_API(LoadUnsigned);
-	REDISMODULE_GET_API(SaveSigned);
-	REDISMODULE_GET_API(LoadSigned);
-	REDISMODULE_GET_API(SaveString);
-	REDISMODULE_GET_API(SaveStringBuffer);
-	REDISMODULE_GET_API(LoadString);
-	REDISMODULE_GET_API(LoadStringBuffer);
-	REDISMODULE_GET_API(SaveDouble);
-	REDISMODULE_GET_API(LoadDouble);
-	REDISMODULE_GET_API(SaveFloat);
-	REDISMODULE_GET_API(LoadFloat);
-	REDISMODULE_GET_API(SaveLongDouble);
-	REDISMODULE_GET_API(LoadLongDouble);
-	REDISMODULE_GET_API(SaveDataTypeToString);
-	REDISMODULE_GET_API(LoadDataTypeFromString);
-	REDISMODULE_GET_API(EmitAOF);
-	REDISMODULE_GET_API(Log);
-	REDISMODULE_GET_API(LogIOError);
-	REDISMODULE_GET_API(_Assert);
-	REDISMODULE_GET_API(LatencyAddSample);
-	REDISMODULE_GET_API(StringAppendBuffer);
-	REDISMODULE_GET_API(RetainString);
-	REDISMODULE_GET_API(HoldString);
-	REDISMODULE_GET_API(StringCompare);
-	REDISMODULE_GET_API(GetContextFromIO);
-	REDISMODULE_GET_API(GetKeyNameFromIO);
-	REDISMODULE_GET_API(GetKeyNameFromModuleKey);
-	REDISMODULE_GET_API(Milliseconds);
-	REDISMODULE_GET_API(DigestAddStringBuffer);
-	REDISMODULE_GET_API(DigestAddLongLong);
-	REDISMODULE_GET_API(DigestEndSequence);
-	REDISMODULE_GET_API(CreateDict);
-	REDISMODULE_GET_API(FreeDict);
-	REDISMODULE_GET_API(DictSize);
-	REDISMODULE_GET_API(DictSetC);
-	REDISMODULE_GET_API(DictReplaceC);
-	REDISMODULE_GET_API(DictSet);
-	REDISMODULE_GET_API(DictReplace);
-	REDISMODULE_GET_API(DictGetC);
-	REDISMODULE_GET_API(DictGet);
-	REDISMODULE_GET_API(DictDelC);
-	REDISMODULE_GET_API(DictDel);
-	REDISMODULE_GET_API(DictIteratorStartC);
-	REDISMODULE_GET_API(DictIteratorStart);
-	REDISMODULE_GET_API(DictIteratorStop);
-	REDISMODULE_GET_API(DictIteratorReseekC);
-	REDISMODULE_GET_API(DictIteratorReseek);
-	REDISMODULE_GET_API(DictNextC);
-	REDISMODULE_GET_API(DictPrevC);
-	REDISMODULE_GET_API(DictNext);
-	REDISMODULE_GET_API(DictPrev);
-	REDISMODULE_GET_API(DictCompare);
-	REDISMODULE_GET_API(DictCompareC);
-	REDISMODULE_GET_API(RegisterInfoFunc);
-	REDISMODULE_GET_API(InfoAddSection);
-	REDISMODULE_GET_API(InfoBeginDictField);
-	REDISMODULE_GET_API(InfoEndDictField);
-	REDISMODULE_GET_API(InfoAddFieldString);
-	REDISMODULE_GET_API(InfoAddFieldCString);
-	REDISMODULE_GET_API(InfoAddFieldDouble);
-	REDISMODULE_GET_API(InfoAddFieldLongLong);
-	REDISMODULE_GET_API(InfoAddFieldULongLong);
-	REDISMODULE_GET_API(GetServerInfo);
-	REDISMODULE_GET_API(FreeServerInfo);
-	REDISMODULE_GET_API(ServerInfoGetField);
-	REDISMODULE_GET_API(ServerInfoGetFieldC);
-	REDISMODULE_GET_API(ServerInfoGetFieldSigned);
-	REDISMODULE_GET_API(ServerInfoGetFieldUnsigned);
-	REDISMODULE_GET_API(ServerInfoGetFieldDouble);
-	REDISMODULE_GET_API(GetClientInfoById);
-	REDISMODULE_GET_API(PublishMessage);
-	REDISMODULE_GET_API(SubscribeToServerEvent);
-	REDISMODULE_GET_API(SetLRU);
-	REDISMODULE_GET_API(GetLRU);
-	REDISMODULE_GET_API(SetLFU);
-	REDISMODULE_GET_API(GetLFU);
-	REDISMODULE_GET_API(BlockClientOnKeys);
-	REDISMODULE_GET_API(SignalKeyAsReady);
-	REDISMODULE_GET_API(GetBlockedClientReadyKey);
-	REDISMODULE_GET_API(ScanCursorCreate);
-	REDISMODULE_GET_API(ScanCursorRestart);
-	REDISMODULE_GET_API(ScanCursorDestroy);
-	REDISMODULE_GET_API(Scan);
-	REDISMODULE_GET_API(ScanKey);
-	REDISMODULE_GET_API(GetContextFlagsAll);
-	REDISMODULE_GET_API(GetKeyspaceNotificationFlagsAll);
-	REDISMODULE_GET_API(IsSubEventSupported);
-	REDISMODULE_GET_API(GetServerVersion);
-	REDISMODULE_GET_API(GetTypeMethodVersion);
+    void *getapifuncptr = ((void **)ctx)[0];
+    RedisModule_GetApi = (int (*)(const char *, void *))(unsigned long)getapifuncptr;
+    REDISMODULE_GET_API(Alloc);
+    REDISMODULE_GET_API(Calloc);
+    REDISMODULE_GET_API(Free);
+    REDISMODULE_GET_API(Realloc);
+    REDISMODULE_GET_API(Strdup);
+    REDISMODULE_GET_API(CreateCommand);
+    REDISMODULE_GET_API(SetModuleAttribs);
+    REDISMODULE_GET_API(IsModuleNameBusy);
+    REDISMODULE_GET_API(WrongArity);
+    REDISMODULE_GET_API(ReplyWithLongLong);
+    REDISMODULE_GET_API(ReplyWithError);
+    REDISMODULE_GET_API(ReplyWithSimpleString);
+    REDISMODULE_GET_API(ReplyWithArray);
+    REDISMODULE_GET_API(ReplyWithNullArray);
+    REDISMODULE_GET_API(ReplyWithEmptyArray);
+    REDISMODULE_GET_API(ReplySetArrayLength);
+    REDISMODULE_GET_API(ReplyWithStringBuffer);
+    REDISMODULE_GET_API(ReplyWithCString);
+    REDISMODULE_GET_API(ReplyWithString);
+    REDISMODULE_GET_API(ReplyWithEmptyString);
+    REDISMODULE_GET_API(ReplyWithVerbatimString);
+    REDISMODULE_GET_API(ReplyWithNull);
+    REDISMODULE_GET_API(ReplyWithCallReply);
+    REDISMODULE_GET_API(ReplyWithDouble);
+    REDISMODULE_GET_API(ReplyWithLongDouble);
+    REDISMODULE_GET_API(GetSelectedDb);
+    REDISMODULE_GET_API(SelectDb);
+    REDISMODULE_GET_API(OpenKey);
+    REDISMODULE_GET_API(CloseKey);
+    REDISMODULE_GET_API(KeyType);
+    REDISMODULE_GET_API(ValueLength);
+    REDISMODULE_GET_API(ListPush);
+    REDISMODULE_GET_API(ListPop);
+    REDISMODULE_GET_API(StringToLongLong);
+    REDISMODULE_GET_API(StringToDouble);
+    REDISMODULE_GET_API(StringToLongDouble);
+    REDISMODULE_GET_API(Call);
+    REDISMODULE_GET_API(CallReplyProto);
+    REDISMODULE_GET_API(FreeCallReply);
+    REDISMODULE_GET_API(CallReplyInteger);
+    REDISMODULE_GET_API(CallReplyType);
+    REDISMODULE_GET_API(CallReplyLength);
+    REDISMODULE_GET_API(CallReplyArrayElement);
+    REDISMODULE_GET_API(CallReplyStringPtr);
+    REDISMODULE_GET_API(CreateStringFromCallReply);
+    REDISMODULE_GET_API(CreateString);
+    REDISMODULE_GET_API(CreateStringFromLongLong);
+    REDISMODULE_GET_API(CreateStringFromDouble);
+    REDISMODULE_GET_API(CreateStringFromLongDouble);
+    REDISMODULE_GET_API(CreateStringFromString);
+    REDISMODULE_GET_API(CreateStringPrintf);
+    REDISMODULE_GET_API(FreeString);
+    REDISMODULE_GET_API(StringPtrLen);
+    REDISMODULE_GET_API(AutoMemory);
+    REDISMODULE_GET_API(Replicate);
+    REDISMODULE_GET_API(ReplicateVerbatim);
+    REDISMODULE_GET_API(DeleteKey);
+    REDISMODULE_GET_API(UnlinkKey);
+    REDISMODULE_GET_API(StringSet);
+    REDISMODULE_GET_API(StringDMA);
+    REDISMODULE_GET_API(StringTruncate);
+    REDISMODULE_GET_API(GetExpire);
+    REDISMODULE_GET_API(SetExpire);
+    REDISMODULE_GET_API(ResetDataset);
+    REDISMODULE_GET_API(DbSize);
+    REDISMODULE_GET_API(RandomKey);
+    REDISMODULE_GET_API(ZsetAdd);
+    REDISMODULE_GET_API(ZsetIncrby);
+    REDISMODULE_GET_API(ZsetScore);
+    REDISMODULE_GET_API(ZsetRem);
+    REDISMODULE_GET_API(ZsetRangeStop);
+    REDISMODULE_GET_API(ZsetFirstInScoreRange);
+    REDISMODULE_GET_API(ZsetLastInScoreRange);
+    REDISMODULE_GET_API(ZsetFirstInLexRange);
+    REDISMODULE_GET_API(ZsetLastInLexRange);
+    REDISMODULE_GET_API(ZsetRangeCurrentElement);
+    REDISMODULE_GET_API(ZsetRangeNext);
+    REDISMODULE_GET_API(ZsetRangePrev);
+    REDISMODULE_GET_API(ZsetRangeEndReached);
+    REDISMODULE_GET_API(HashSet);
+    REDISMODULE_GET_API(HashGet);
+    REDISMODULE_GET_API(IsKeysPositionRequest);
+    REDISMODULE_GET_API(KeyAtPos);
+    REDISMODULE_GET_API(GetClientId);
+    REDISMODULE_GET_API(GetContextFlags);
+    REDISMODULE_GET_API(AvoidReplicaTraffic);
+    REDISMODULE_GET_API(PoolAlloc);
+    REDISMODULE_GET_API(CreateDataType);
+    REDISMODULE_GET_API(ModuleTypeSetValue);
+    REDISMODULE_GET_API(ModuleTypeReplaceValue);
+    REDISMODULE_GET_API(ModuleTypeGetType);
+    REDISMODULE_GET_API(ModuleTypeGetValue);
+    REDISMODULE_GET_API(IsIOError);
+    REDISMODULE_GET_API(SetModuleOptions);
+    REDISMODULE_GET_API(SignalModifiedKey);
+    REDISMODULE_GET_API(SaveUnsigned);
+    REDISMODULE_GET_API(LoadUnsigned);
+    REDISMODULE_GET_API(SaveSigned);
+    REDISMODULE_GET_API(LoadSigned);
+    REDISMODULE_GET_API(SaveString);
+    REDISMODULE_GET_API(SaveStringBuffer);
+    REDISMODULE_GET_API(LoadString);
+    REDISMODULE_GET_API(LoadStringBuffer);
+    REDISMODULE_GET_API(SaveDouble);
+    REDISMODULE_GET_API(LoadDouble);
+    REDISMODULE_GET_API(SaveFloat);
+    REDISMODULE_GET_API(LoadFloat);
+    REDISMODULE_GET_API(SaveLongDouble);
+    REDISMODULE_GET_API(LoadLongDouble);
+    REDISMODULE_GET_API(SaveDataTypeToString);
+    REDISMODULE_GET_API(LoadDataTypeFromString);
+    REDISMODULE_GET_API(EmitAOF);
+    REDISMODULE_GET_API(Log);
+    REDISMODULE_GET_API(LogIOError);
+    REDISMODULE_GET_API(_Assert);
+    REDISMODULE_GET_API(LatencyAddSample);
+    REDISMODULE_GET_API(StringAppendBuffer);
+    REDISMODULE_GET_API(RetainString);
+    REDISMODULE_GET_API(HoldString);
+    REDISMODULE_GET_API(StringCompare);
+    REDISMODULE_GET_API(GetContextFromIO);
+    REDISMODULE_GET_API(GetKeyNameFromIO);
+    REDISMODULE_GET_API(GetKeyNameFromModuleKey);
+    REDISMODULE_GET_API(Milliseconds);
+    REDISMODULE_GET_API(DigestAddStringBuffer);
+    REDISMODULE_GET_API(DigestAddLongLong);
+    REDISMODULE_GET_API(DigestEndSequence);
+    REDISMODULE_GET_API(CreateDict);
+    REDISMODULE_GET_API(FreeDict);
+    REDISMODULE_GET_API(DictSize);
+    REDISMODULE_GET_API(DictSetC);
+    REDISMODULE_GET_API(DictReplaceC);
+    REDISMODULE_GET_API(DictSet);
+    REDISMODULE_GET_API(DictReplace);
+    REDISMODULE_GET_API(DictGetC);
+    REDISMODULE_GET_API(DictGet);
+    REDISMODULE_GET_API(DictDelC);
+    REDISMODULE_GET_API(DictDel);
+    REDISMODULE_GET_API(DictIteratorStartC);
+    REDISMODULE_GET_API(DictIteratorStart);
+    REDISMODULE_GET_API(DictIteratorStop);
+    REDISMODULE_GET_API(DictIteratorReseekC);
+    REDISMODULE_GET_API(DictIteratorReseek);
+    REDISMODULE_GET_API(DictNextC);
+    REDISMODULE_GET_API(DictPrevC);
+    REDISMODULE_GET_API(DictNext);
+    REDISMODULE_GET_API(DictPrev);
+    REDISMODULE_GET_API(DictCompare);
+    REDISMODULE_GET_API(DictCompareC);
+    REDISMODULE_GET_API(RegisterInfoFunc);
+    REDISMODULE_GET_API(InfoAddSection);
+    REDISMODULE_GET_API(InfoBeginDictField);
+    REDISMODULE_GET_API(InfoEndDictField);
+    REDISMODULE_GET_API(InfoAddFieldString);
+    REDISMODULE_GET_API(InfoAddFieldCString);
+    REDISMODULE_GET_API(InfoAddFieldDouble);
+    REDISMODULE_GET_API(InfoAddFieldLongLong);
+    REDISMODULE_GET_API(InfoAddFieldULongLong);
+    REDISMODULE_GET_API(GetServerInfo);
+    REDISMODULE_GET_API(FreeServerInfo);
+    REDISMODULE_GET_API(ServerInfoGetField);
+    REDISMODULE_GET_API(ServerInfoGetFieldC);
+    REDISMODULE_GET_API(ServerInfoGetFieldSigned);
+    REDISMODULE_GET_API(ServerInfoGetFieldUnsigned);
+    REDISMODULE_GET_API(ServerInfoGetFieldDouble);
+    REDISMODULE_GET_API(GetClientInfoById);
+    REDISMODULE_GET_API(PublishMessage);
+    REDISMODULE_GET_API(SubscribeToServerEvent);
+    REDISMODULE_GET_API(SetLRU);
+    REDISMODULE_GET_API(GetLRU);
+    REDISMODULE_GET_API(SetLFU);
+    REDISMODULE_GET_API(GetLFU);
+    REDISMODULE_GET_API(BlockClientOnKeys);
+    REDISMODULE_GET_API(SignalKeyAsReady);
+    REDISMODULE_GET_API(GetBlockedClientReadyKey);
+    REDISMODULE_GET_API(ScanCursorCreate);
+    REDISMODULE_GET_API(ScanCursorRestart);
+    REDISMODULE_GET_API(ScanCursorDestroy);
+    REDISMODULE_GET_API(Scan);
+    REDISMODULE_GET_API(ScanKey);
+    REDISMODULE_GET_API(GetContextFlagsAll);
+    REDISMODULE_GET_API(GetKeyspaceNotificationFlagsAll);
+    REDISMODULE_GET_API(IsSubEventSupported);
+    REDISMODULE_GET_API(GetServerVersion);
+    REDISMODULE_GET_API(GetTypeMethodVersion);
 
 #ifdef REDISMODULE_EXPERIMENTAL_API
-	REDISMODULE_GET_API(GetThreadSafeContext);
-	REDISMODULE_GET_API(GetDetachedThreadSafeContext);
-	REDISMODULE_GET_API(FreeThreadSafeContext);
-	REDISMODULE_GET_API(ThreadSafeContextLock);
-	REDISMODULE_GET_API(ThreadSafeContextTryLock);
-	REDISMODULE_GET_API(ThreadSafeContextUnlock);
-	REDISMODULE_GET_API(BlockClient);
-	REDISMODULE_GET_API(UnblockClient);
-	REDISMODULE_GET_API(IsBlockedReplyRequest);
-	REDISMODULE_GET_API(IsBlockedTimeoutRequest);
-	REDISMODULE_GET_API(GetBlockedClientPrivateData);
-	REDISMODULE_GET_API(GetBlockedClientHandle);
-	REDISMODULE_GET_API(AbortBlock);
-	REDISMODULE_GET_API(SetDisconnectCallback);
-	REDISMODULE_GET_API(SubscribeToKeyspaceEvents);
-	REDISMODULE_GET_API(NotifyKeyspaceEvent);
-	REDISMODULE_GET_API(GetNotifyKeyspaceEvents);
-	REDISMODULE_GET_API(BlockedClientDisconnected);
-	REDISMODULE_GET_API(RegisterClusterMessageReceiver);
-	REDISMODULE_GET_API(SendClusterMessage);
-	REDISMODULE_GET_API(GetClusterNodeInfo);
-	REDISMODULE_GET_API(GetClusterNodesList);
-	REDISMODULE_GET_API(FreeClusterNodesList);
-	REDISMODULE_GET_API(CreateTimer);
-	REDISMODULE_GET_API(StopTimer);
-	REDISMODULE_GET_API(GetTimerInfo);
-	REDISMODULE_GET_API(GetMyClusterID);
-	REDISMODULE_GET_API(GetClusterSize);
-	REDISMODULE_GET_API(GetRandomBytes);
-	REDISMODULE_GET_API(GetRandomHexChars);
-	REDISMODULE_GET_API(SetClusterFlags);
-	REDISMODULE_GET_API(ExportSharedAPI);
-	REDISMODULE_GET_API(GetSharedAPI);
-	REDISMODULE_GET_API(RegisterCommandFilter);
-	REDISMODULE_GET_API(UnregisterCommandFilter);
-	REDISMODULE_GET_API(CommandFilterArgsCount);
-	REDISMODULE_GET_API(CommandFilterArgGet);
-	REDISMODULE_GET_API(CommandFilterArgInsert);
-	REDISMODULE_GET_API(CommandFilterArgReplace);
-	REDISMODULE_GET_API(CommandFilterArgDelete);
-	REDISMODULE_GET_API(Fork);
-	REDISMODULE_GET_API(ExitFromChild);
-	REDISMODULE_GET_API(KillForkChild);
-	REDISMODULE_GET_API(GetUsedMemoryRatio);
-	REDISMODULE_GET_API(MallocSize);
-	REDISMODULE_GET_API(CreateModuleUser);
-	REDISMODULE_GET_API(FreeModuleUser);
-	REDISMODULE_GET_API(SetModuleUserACL);
-	REDISMODULE_GET_API(DeauthenticateAndCloseClient);
-	REDISMODULE_GET_API(AuthenticateClientWithACLUser);
-	REDISMODULE_GET_API(AuthenticateClientWithUser);
-	REDISMODULE_GET_API(GetClientCertificate);
-	REDISMODULE_GET_API(GetCommandKeys);
+    REDISMODULE_GET_API(GetThreadSafeContext);
+    REDISMODULE_GET_API(GetDetachedThreadSafeContext);
+    REDISMODULE_GET_API(FreeThreadSafeContext);
+    REDISMODULE_GET_API(ThreadSafeContextLock);
+    REDISMODULE_GET_API(ThreadSafeContextTryLock);
+    REDISMODULE_GET_API(ThreadSafeContextUnlock);
+    REDISMODULE_GET_API(BlockClient);
+    REDISMODULE_GET_API(UnblockClient);
+    REDISMODULE_GET_API(IsBlockedReplyRequest);
+    REDISMODULE_GET_API(IsBlockedTimeoutRequest);
+    REDISMODULE_GET_API(GetBlockedClientPrivateData);
+    REDISMODULE_GET_API(GetBlockedClientHandle);
+    REDISMODULE_GET_API(AbortBlock);
+    REDISMODULE_GET_API(SetDisconnectCallback);
+    REDISMODULE_GET_API(SubscribeToKeyspaceEvents);
+    REDISMODULE_GET_API(NotifyKeyspaceEvent);
+    REDISMODULE_GET_API(GetNotifyKeyspaceEvents);
+    REDISMODULE_GET_API(BlockedClientDisconnected);
+    REDISMODULE_GET_API(RegisterClusterMessageReceiver);
+    REDISMODULE_GET_API(SendClusterMessage);
+    REDISMODULE_GET_API(GetClusterNodeInfo);
+    REDISMODULE_GET_API(GetClusterNodesList);
+    REDISMODULE_GET_API(FreeClusterNodesList);
+    REDISMODULE_GET_API(CreateTimer);
+    REDISMODULE_GET_API(StopTimer);
+    REDISMODULE_GET_API(GetTimerInfo);
+    REDISMODULE_GET_API(GetMyClusterID);
+    REDISMODULE_GET_API(GetClusterSize);
+    REDISMODULE_GET_API(GetRandomBytes);
+    REDISMODULE_GET_API(GetRandomHexChars);
+    REDISMODULE_GET_API(SetClusterFlags);
+    REDISMODULE_GET_API(ExportSharedAPI);
+    REDISMODULE_GET_API(GetSharedAPI);
+    REDISMODULE_GET_API(RegisterCommandFilter);
+    REDISMODULE_GET_API(UnregisterCommandFilter);
+    REDISMODULE_GET_API(CommandFilterArgsCount);
+    REDISMODULE_GET_API(CommandFilterArgGet);
+    REDISMODULE_GET_API(CommandFilterArgInsert);
+    REDISMODULE_GET_API(CommandFilterArgReplace);
+    REDISMODULE_GET_API(CommandFilterArgDelete);
+    REDISMODULE_GET_API(Fork);
+    REDISMODULE_GET_API(ExitFromChild);
+    REDISMODULE_GET_API(KillForkChild);
+    REDISMODULE_GET_API(GetUsedMemoryRatio);
+    REDISMODULE_GET_API(MallocSize);
+    REDISMODULE_GET_API(CreateModuleUser);
+    REDISMODULE_GET_API(FreeModuleUser);
+    REDISMODULE_GET_API(SetModuleUserACL);
+    REDISMODULE_GET_API(DeauthenticateAndCloseClient);
+    REDISMODULE_GET_API(AuthenticateClientWithACLUser);
+    REDISMODULE_GET_API(AuthenticateClientWithUser);
+    REDISMODULE_GET_API(GetClientCertificate);
+    REDISMODULE_GET_API(GetCommandKeys);
 #endif
 
-	if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;
-	RedisModule_SetModuleAttribs(ctx,name,ver,apiver);
-	return REDISMODULE_OK;
+    if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name))
+        return REDISMODULE_ERR;
+    RedisModule_SetModuleAttribs(ctx, name, ver, apiver);
+    return REDISMODULE_OK;
 }
 
-#define RedisModule_Assert(_e) ((_e)?(void)0 : (RedisModule__Assert(#_e,__FILE__,__LINE__),exit(1)))
+#define RedisModule_Assert(_e)                                                                     \
+    ((_e) ? (void)0 : (RedisModule__Assert(#_e, __FILE__, __LINE__), exit(1)))
 
 #define RMAPI_FUNC_SUPPORTED(func) (func != NULL)
 

--- a/src/rmutil/alloc.c
+++ b/src/rmutil/alloc.c
@@ -5,10 +5,10 @@
 
 /* A patched implementation of strdup that will use our patched calloc */
 char *rmalloc_strndup(const char *s, size_t n) {
-  char *ret = calloc(n + 1, sizeof(char));
-  if (ret)
-    memcpy(ret, s, n);
-  return ret;
+    char *ret = calloc(n + 1, sizeof(char));
+    if (ret)
+        memcpy(ret, s, n);
+    return ret;
 }
 
 /*
@@ -24,9 +24,9 @@ char *rmalloc_strndup(const char *s, size_t n) {
  * patches the RM_Alloc functions back to the original mallocs. */
 void RMUTil_InitAlloc() {
 
-  RedisModule_Alloc = malloc;
-  RedisModule_Realloc = realloc;
-  RedisModule_Calloc = calloc;
-  RedisModule_Free = free;
-  RedisModule_Strdup = strdup;
+    RedisModule_Alloc = malloc;
+    RedisModule_Realloc = realloc;
+    RedisModule_Calloc = calloc;
+    RedisModule_Free = free;
+    RedisModule_Strdup = strdup;
 }

--- a/src/rmutil/alloc.h
+++ b/src/rmutil/alloc.h
@@ -23,10 +23,10 @@ char *rmalloc_strndup(const char *s, size_t n);
 
 #ifdef REDIS_MODULE_TARGET /* Set this when compiling your code as a module */
 
-#define malloc(size) RedisModule_Alloc(size)
+#define malloc(size)        RedisModule_Alloc(size)
 #define calloc(count, size) RedisModule_Calloc(count, size)
-#define realloc(ptr, size) RedisModule_Realloc(ptr, size)
-#define free(ptr) RedisModule_Free(ptr)
+#define realloc(ptr, size)  RedisModule_Realloc(ptr, size)
+#define free(ptr)           RedisModule_Free(ptr)
 
 #ifdef strdup
 #undef strdup

--- a/src/rmutil/args.c
+++ b/src/rmutil/args.c
@@ -6,110 +6,108 @@
 #include <assert.h>
 #include <stdarg.h>
 
-int AC_Advance(ArgsCursor *ac) {
-  return AC_AdvanceBy(ac, 1);
-}
+int AC_Advance(ArgsCursor *ac) { return AC_AdvanceBy(ac, 1); }
 
 int AC_AdvanceBy(ArgsCursor *ac, size_t by) {
-  if (ac->offset + by > ac->argc) {
-    return AC_ERR_NOARG;
-  } else {
-    ac->offset += by;
-  }
-  return AC_OK;
+    if (ac->offset + by > ac->argc) {
+        return AC_ERR_NOARG;
+    } else {
+        ac->offset += by;
+    }
+    return AC_OK;
 }
 
 int AC_AdvanceIfMatch(ArgsCursor *ac, const char *s) {
-  const char *cur;
-  if (AC_IsAtEnd(ac)) {
-    return 0;
-  }
+    const char *cur;
+    if (AC_IsAtEnd(ac)) {
+        return 0;
+    }
 
-  int rv = AC_GetString(ac, &cur, NULL, AC_F_NOADVANCE);
-  assert(rv == AC_OK);
-  rv = !strcasecmp(s, cur);
-  if (rv) {
-    AC_Advance(ac);
-  }
-  return rv;
+    int rv = AC_GetString(ac, &cur, NULL, AC_F_NOADVANCE);
+    assert(rv == AC_OK);
+    rv = !strcasecmp(s, cur);
+    if (rv) {
+        AC_Advance(ac);
+    }
+    return rv;
 }
 
-#define MAYBE_ADVANCE()            \
-  if (!(flags & AC_F_NOADVANCE)) { \
-    AC_Advance(ac);                \
-  }
+#define MAYBE_ADVANCE()                                                                            \
+    if (!(flags & AC_F_NOADVANCE)) {                                                               \
+        AC_Advance(ac);                                                                            \
+    }
 
 static int tryReadAsDouble(ArgsCursor *ac, long long *ll, int flags) {
-  double dTmp = 0.0;
-  if (AC_GetDouble(ac, &dTmp, flags | AC_F_NOADVANCE) != AC_OK) {
-    return AC_ERR_PARSE;
-  }
-  if (flags & AC_F_COALESCE) {
-    *ll = dTmp;
-    return AC_OK;
-  }
+    double dTmp = 0.0;
+    if (AC_GetDouble(ac, &dTmp, flags | AC_F_NOADVANCE) != AC_OK) {
+        return AC_ERR_PARSE;
+    }
+    if (flags & AC_F_COALESCE) {
+        *ll = dTmp;
+        return AC_OK;
+    }
 
-  if ((double)(long long)dTmp != dTmp) {
-    return AC_ERR_PARSE;
-  } else {
-    *ll = dTmp;
-    return AC_OK;
-  }
+    if ((double)(long long)dTmp != dTmp) {
+        return AC_ERR_PARSE;
+    } else {
+        *ll = dTmp;
+        return AC_OK;
+    }
 }
 
 int AC_GetLongLong(ArgsCursor *ac, long long *ll, int flags) {
-  if (ac->offset == ac->argc) {
-    return AC_ERR_NOARG;
-  }
-
-  int hasErr = 0;
-  // Try to parse the number as a normal integer first. If that fails, try
-  // to parse it as a double. This will work if the number is in the format of
-  // 3.00, OR if the number is in the format of 3.14 *AND* AC_F_COALESCE is set.
-  if (ac->type == AC_TYPE_RSTRING) {
-    if (RedisModule_StringToLongLong(AC_CURRENT(ac), ll) == REDISMODULE_ERR) {
-      hasErr = 1;
+    if (ac->offset == ac->argc) {
+        return AC_ERR_NOARG;
     }
-  } else {
-    char *endptr = AC_CURRENT(ac);
-    *ll = strtoll(AC_CURRENT(ac), &endptr, 10);
-    if (*endptr != '\0' || *ll == LLONG_MIN || *ll == LLONG_MAX) {
-      hasErr = 1;
+
+    int hasErr = 0;
+    // Try to parse the number as a normal integer first. If that fails, try
+    // to parse it as a double. This will work if the number is in the format of
+    // 3.00, OR if the number is in the format of 3.14 *AND* AC_F_COALESCE is set.
+    if (ac->type == AC_TYPE_RSTRING) {
+        if (RedisModule_StringToLongLong(AC_CURRENT(ac), ll) == REDISMODULE_ERR) {
+            hasErr = 1;
+        }
+    } else {
+        char *endptr = AC_CURRENT(ac);
+        *ll = strtoll(AC_CURRENT(ac), &endptr, 10);
+        if (*endptr != '\0' || *ll == LLONG_MIN || *ll == LLONG_MAX) {
+            hasErr = 1;
+        }
     }
-  }
 
-  if (hasErr && tryReadAsDouble(ac, ll, flags) != AC_OK) {
-    return AC_ERR_PARSE;
-  }
+    if (hasErr && tryReadAsDouble(ac, ll, flags) != AC_OK) {
+        return AC_ERR_PARSE;
+    }
 
-  if ((flags & AC_F_GE0) && *ll < 0) {
-    return AC_ERR_ELIMIT;
-  }
-  // Do validation
-  if ((flags & AC_F_GE1) && *ll < 1) {
-    return AC_ERR_ELIMIT;
-  }
-  MAYBE_ADVANCE();
-  return AC_OK;
+    if ((flags & AC_F_GE0) && *ll < 0) {
+        return AC_ERR_ELIMIT;
+    }
+    // Do validation
+    if ((flags & AC_F_GE1) && *ll < 1) {
+        return AC_ERR_ELIMIT;
+    }
+    MAYBE_ADVANCE();
+    return AC_OK;
 }
 
-#define GEN_AC_FUNC(name, T, minVal, maxVal, isUnsigned)      \
-  int name(ArgsCursor *ac, T *p, int flags) {                 \
-    if (isUnsigned) {                                         \
-      flags |= AC_F_GE0;                                      \
-    }                                                         \
-    long long ll;                                             \
-    int rv = AC_GetLongLong(ac, &ll, flags | AC_F_NOADVANCE); \
-    if (rv) {                                                 \
-      return rv;                                              \
-    }                                                         \
-    if (ll > maxVal || ll < minVal) {                         \
-      return AC_ERR_ELIMIT;                                   \
-    }                                                         \
-    *p = ll;                                                  \
-    MAYBE_ADVANCE();                                          \
-    return AC_OK;                                             \
-  }
+#define GEN_AC_FUNC(name, T, minVal, maxVal, isUnsigned)                                           \
+    int name(ArgsCursor *ac, T *p, int flags) {                                                    \
+        if (isUnsigned) {                                                                          \
+            flags |= AC_F_GE0;                                                                     \
+        }                                                                                          \
+        long long ll;                                                                              \
+        int rv = AC_GetLongLong(ac, &ll, flags | AC_F_NOADVANCE);                                  \
+        if (rv) {                                                                                  \
+            return rv;                                                                             \
+        }                                                                                          \
+        if (ll > maxVal || ll < minVal) {                                                          \
+            return AC_ERR_ELIMIT;                                                                  \
+        }                                                                                          \
+        *p = ll;                                                                                   \
+        MAYBE_ADVANCE();                                                                           \
+        return AC_OK;                                                                              \
+    }
 
 GEN_AC_FUNC(AC_GetUnsignedLongLong, unsigned long long, 0, LLONG_MAX, 1)
 GEN_AC_FUNC(AC_GetUnsigned, unsigned, 0, UINT_MAX, 1)
@@ -118,219 +116,221 @@ GEN_AC_FUNC(AC_GetU32, uint32_t, 0, UINT32_MAX, 1)
 GEN_AC_FUNC(AC_GetU64, uint64_t, 0, UINT64_MAX, 1)
 
 int AC_GetDouble(ArgsCursor *ac, double *d, int flags) {
-  if (ac->type == AC_TYPE_RSTRING) {
-    if (RedisModule_StringToDouble(ac->objs[ac->offset], d) != REDISMODULE_OK) {
-      return AC_ERR_PARSE;
+    if (ac->type == AC_TYPE_RSTRING) {
+        if (RedisModule_StringToDouble(ac->objs[ac->offset], d) != REDISMODULE_OK) {
+            return AC_ERR_PARSE;
+        }
+    } else {
+        char *endptr = AC_CURRENT(ac);
+        *d = strtod(AC_CURRENT(ac), &endptr);
+        if (*endptr != '\0' || *d == HUGE_VAL || *d == -HUGE_VAL) {
+            return AC_ERR_PARSE;
+        }
     }
-  } else {
-    char *endptr = AC_CURRENT(ac);
-    *d = strtod(AC_CURRENT(ac), &endptr);
-    if (*endptr != '\0' || *d == HUGE_VAL || *d == -HUGE_VAL) {
-      return AC_ERR_PARSE;
+    if ((flags & AC_F_GE0) && *d < 0.0) {
+        return AC_ERR_ELIMIT;
     }
-  }
-  if ((flags & AC_F_GE0) && *d < 0.0) {
-    return AC_ERR_ELIMIT;
-  }
-  if ((flags & AC_F_GE1) && *d < 1.0) {
-    return AC_ERR_ELIMIT;
-  }
-  MAYBE_ADVANCE();
-  return AC_OK;
+    if ((flags & AC_F_GE1) && *d < 1.0) {
+        return AC_ERR_ELIMIT;
+    }
+    MAYBE_ADVANCE();
+    return AC_OK;
 }
 
 int AC_GetRString(ArgsCursor *ac, RedisModuleString **s, int flags) {
-  assert(ac->type == AC_TYPE_RSTRING);
-  if (ac->offset == ac->argc) {
-    return AC_ERR_NOARG;
-  }
-  *s = AC_CURRENT(ac);
-  MAYBE_ADVANCE();
-  return AC_OK;
+    assert(ac->type == AC_TYPE_RSTRING);
+    if (ac->offset == ac->argc) {
+        return AC_ERR_NOARG;
+    }
+    *s = AC_CURRENT(ac);
+    MAYBE_ADVANCE();
+    return AC_OK;
 }
 
 int AC_GetString(ArgsCursor *ac, const char **s, size_t *n, int flags) {
-  if (ac->offset == ac->argc) {
-    return AC_ERR_NOARG;
-  }
-  if (ac->type == AC_TYPE_RSTRING) {
-    *s = RedisModule_StringPtrLen(AC_CURRENT(ac), n);
-  } else {
-    *s = AC_CURRENT(ac);
-    if (n) {
-      if (ac->type == AC_TYPE_SDS) {
-        *n = sdslen((const sds)*s);
-      } else {
-        *n = strlen(*s);
-      }
+    if (ac->offset == ac->argc) {
+        return AC_ERR_NOARG;
     }
-  }
-  MAYBE_ADVANCE();
-  return AC_OK;
+    if (ac->type == AC_TYPE_RSTRING) {
+        *s = RedisModule_StringPtrLen(AC_CURRENT(ac), n);
+    } else {
+        *s = AC_CURRENT(ac);
+        if (n) {
+            if (ac->type == AC_TYPE_SDS) {
+                *n = sdslen((const sds)*s);
+            } else {
+                *n = strlen(*s);
+            }
+        }
+    }
+    MAYBE_ADVANCE();
+    return AC_OK;
 }
 
 const char *AC_GetStringNC(ArgsCursor *ac, size_t *len) {
-  const char *s = NULL;
-  if (AC_GetString(ac, &s, len, 0) != AC_OK) {
-    return NULL;
-  }
-  return s;
+    const char *s = NULL;
+    if (AC_GetString(ac, &s, len, 0) != AC_OK) {
+        return NULL;
+    }
+    return s;
 }
 
 int AC_GetVarArgs(ArgsCursor *ac, ArgsCursor *dst) {
-  unsigned nargs;
-  int rv = AC_GetUnsigned(ac, &nargs, 0);
-  if (rv != AC_OK) {
-    return rv;
-  }
-  return AC_GetSlice(ac, dst, nargs);
+    unsigned nargs;
+    int rv = AC_GetUnsigned(ac, &nargs, 0);
+    if (rv != AC_OK) {
+        return rv;
+    }
+    return AC_GetSlice(ac, dst, nargs);
 }
 
 int AC_GetSlice(ArgsCursor *ac, ArgsCursor *dst, size_t n) {
-  if (n > AC_NumRemaining(ac)) {
-    return AC_ERR_NOARG;
-  }
+    if (n > AC_NumRemaining(ac)) {
+        return AC_ERR_NOARG;
+    }
 
-  dst->objs = ac->objs + ac->offset;
-  dst->argc = n;
-  dst->offset = 0;
-  dst->type = ac->type;
-  AC_AdvanceBy(ac, n);
-  return 0;
+    dst->objs = ac->objs + ac->offset;
+    dst->argc = n;
+    dst->offset = 0;
+    dst->type = ac->type;
+    AC_AdvanceBy(ac, n);
+    return 0;
 }
 
 int AC_AdvanceUntilMatches(ArgsCursor *ac, int n, const char **args) {
-  const char *cur;
-  if (AC_IsAtEnd(ac)) {
-    return 0;
-  }
-
-  int rv;
-  int matched = 0;
-  while (!AC_IsAtEnd(ac)) {
-    rv = AC_GetString(ac, &cur, NULL, AC_F_NOADVANCE);
-    assert(rv == AC_OK);
-    for (int i=0; i<n; i++) {
-      matched = !strcasecmp(args[i], cur);
-      if (matched) break;
+    const char *cur;
+    if (AC_IsAtEnd(ac)) {
+        return 0;
     }
-    if (matched) break;
-    AC_Advance(ac);
-  }
 
-  return rv;
+    int rv;
+    int matched = 0;
+    while (!AC_IsAtEnd(ac)) {
+        rv = AC_GetString(ac, &cur, NULL, AC_F_NOADVANCE);
+        assert(rv == AC_OK);
+        for (int i = 0; i < n; i++) {
+            matched = !strcasecmp(args[i], cur);
+            if (matched)
+                break;
+        }
+        if (matched)
+            break;
+        AC_Advance(ac);
+    }
+
+    return rv;
 }
 
 int AC_GetSliceUntilMatches(ArgsCursor *ac, ArgsCursor *dest, int n, const char **args) {
-  size_t offset0 = ac->offset;
+    size_t offset0 = ac->offset;
 
-  int rv = AC_AdvanceUntilMatches(ac, n, args);
+    int rv = AC_AdvanceUntilMatches(ac, n, args);
 
-  dest->objs = ac->objs + offset0;
-  dest->argc = ac->offset - offset0;
-  dest->offset = 0;
-  dest->type = ac->type;
+    dest->objs = ac->objs + offset0;
+    dest->argc = ac->offset - offset0;
+    dest->offset = 0;
+    dest->type = ac->type;
 
-  return 0;
+    return 0;
 }
 
 int AC_GetSliceToOffset(ArgsCursor *ac, ArgsCursor *dest, int offset) {
-  size_t offset0 = ac->offset;
+    size_t offset0 = ac->offset;
 
-  if (offset0 > offset) {
+    if (offset0 > offset) {
+        dest->objs = ac->objs + offset0;
+        dest->argc = 0;
+        dest->offset = 0;
+        dest->type = ac->type;
+        return 0;
+    }
+
+    size_t n = offset - offset0;
+
     dest->objs = ac->objs + offset0;
-    dest->argc = 0;
+    dest->argc = n;
     dest->offset = 0;
     dest->type = ac->type;
+
+    AC_AdvanceBy(ac, n);
+
     return 0;
-  }
-
-  size_t n = offset - offset0;
-
-  dest->objs = ac->objs + offset0;
-  dest->argc = n;
-  dest->offset = 0;
-  dest->type = ac->type;
-
-  AC_AdvanceBy(ac, n);
-
-  return 0;
 }
 
 int AC_GetSliceToEnd(ArgsCursor *ac, ArgsCursor *dest) {
-  return AC_GetSliceToOffset(ac, dest, ac->argc);
+    return AC_GetSliceToOffset(ac, dest, ac->argc);
 }
 
 static int parseSingleSpec(ArgsCursor *ac, ACArgSpec *spec) {
-  switch (spec->type) {
+    switch (spec->type) {
     case AC_ARGTYPE_BOOLFLAG:
-      *(int *)spec->target = 1;
-      return AC_OK;
+        *(int *)spec->target = 1;
+        return AC_OK;
     case AC_ARGTYPE_BITFLAG:
-      *(uint32_t *)(spec->target) |= spec->slicelen;
-      return AC_OK;
+        *(uint32_t *)(spec->target) |= spec->slicelen;
+        return AC_OK;
     case AC_ARGTYPE_UNFLAG:
-      *(uint32_t *)spec->target &= ~spec->slicelen;
-      return AC_OK;
+        *(uint32_t *)spec->target &= ~spec->slicelen;
+        return AC_OK;
     case AC_ARGTYPE_DOUBLE:
-      return AC_GetDouble(ac, spec->target, spec->intflags);
+        return AC_GetDouble(ac, spec->target, spec->intflags);
     case AC_ARGTYPE_INT:
-      return AC_GetInt(ac, spec->target, spec->intflags);
+        return AC_GetInt(ac, spec->target, spec->intflags);
     case AC_ARGTYPE_LLONG:
-      return AC_GetLongLong(ac, spec->target, spec->intflags);
+        return AC_GetLongLong(ac, spec->target, spec->intflags);
     case AC_ARGTYPE_ULLONG:
-      return AC_GetUnsignedLongLong(ac, spec->target, spec->intflags);
+        return AC_GetUnsignedLongLong(ac, spec->target, spec->intflags);
     case AC_ARGTYPE_UINT:
-      return AC_GetUnsigned(ac, spec->target, spec->intflags);
+        return AC_GetUnsigned(ac, spec->target, spec->intflags);
     case AC_ARGTYPE_STRING:
-      return AC_GetString(ac, spec->target, spec->len, 0);
+        return AC_GetString(ac, spec->target, spec->len, 0);
     case AC_ARGTYPE_RSTRING:
-      return AC_GetRString(ac, spec->target, 0);
+        return AC_GetRString(ac, spec->target, 0);
     case AC_ARGTYPE_SUBARGS:
-      return AC_GetVarArgs(ac, spec->target);
+        return AC_GetVarArgs(ac, spec->target);
     case AC_ARGTYPE_SUBARGS_N:
-      return AC_GetSlice(ac, spec->target, spec->slicelen);
+        return AC_GetSlice(ac, spec->target, spec->slicelen);
     default:
-      fprintf(stderr, "Unknown type");
-      abort();
-  }
+        fprintf(stderr, "Unknown type");
+        abort();
+    }
 }
 
 int AC_ParseArgSpec(ArgsCursor *ac, ACArgSpec *specs, ACArgSpec **errSpec) {
-  const char *s = NULL;
-  size_t n;
-  int rv;
+    const char *s = NULL;
+    size_t n;
+    int rv;
 
-  if (errSpec) {
-    *errSpec = NULL;
-  }
-
-  while (!AC_IsAtEnd(ac)) {
-    if ((rv = AC_GetString(ac, &s, &n, AC_F_NOADVANCE) != AC_OK)) {
-      return rv;
-    }
-    ACArgSpec *cur = specs;
-
-    for (; cur->name != NULL; cur++) {
-      if (n != strlen(cur->name)) {
-        continue;
-      }
-      if (!strncasecmp(cur->name, s, n)) {
-        break;
-      }
+    if (errSpec) {
+        *errSpec = NULL;
     }
 
-    if (cur->name == NULL) {
-      return AC_ERR_ENOENT;
-    }
+    while (!AC_IsAtEnd(ac)) {
+        if ((rv = AC_GetString(ac, &s, &n, AC_F_NOADVANCE) != AC_OK)) {
+            return rv;
+        }
+        ACArgSpec *cur = specs;
 
-    AC_Advance(ac);
-    if ((rv = parseSingleSpec(ac, cur)) != AC_OK) {
-      if (errSpec) {
-        *errSpec = cur;
-      }
-      return rv;
+        for (; cur->name != NULL; cur++) {
+            if (n != strlen(cur->name)) {
+                continue;
+            }
+            if (!strncasecmp(cur->name, s, n)) {
+                break;
+            }
+        }
+
+        if (cur->name == NULL) {
+            return AC_ERR_ENOENT;
+        }
+
+        AC_Advance(ac);
+        if ((rv = parseSingleSpec(ac, cur)) != AC_OK) {
+            if (errSpec) {
+                *errSpec = cur;
+            }
+            return rv;
+        }
     }
-  }
-  return AC_OK;
+    return AC_OK;
 }

--- a/src/rmutil/args.h
+++ b/src/rmutil/args.h
@@ -12,10 +12,10 @@ extern "C" {
 #endif
 
 typedef enum {
-  AC_TYPE_UNINIT = 0,  // Comment for formatting
-  AC_TYPE_RSTRING,
-  AC_TYPE_CHAR,
-  AC_TYPE_SDS
+    AC_TYPE_UNINIT = 0, // Comment for formatting
+    AC_TYPE_RSTRING,
+    AC_TYPE_CHAR,
+    AC_TYPE_SDS
 } ACType;
 
 #define AC_IsInitialized(ac) ((ac)->type != AC_TYPE_UNINIT)
@@ -26,46 +26,46 @@ typedef enum {
  * for finer grained error handling.
  */
 typedef struct {
-  void **objs;
-  int type;
-  size_t argc;
-  size_t offset;
+    void **objs;
+    int type;
+    size_t argc;
+    size_t offset;
 } ArgsCursor;
 
 static inline void ArgsCursor_InitCString(ArgsCursor *cursor, const char **argv, int argc) {
-  cursor->objs = (void **)argv;
-  cursor->type = AC_TYPE_CHAR;
-  cursor->offset = 0;
-  cursor->argc = argc;
+    cursor->objs = (void **)argv;
+    cursor->type = AC_TYPE_CHAR;
+    cursor->offset = 0;
+    cursor->argc = argc;
 }
 
 static inline void ArgsCursor_InitSDS(ArgsCursor *cursor, const sds *argv, int argc) {
-  cursor->objs = (void **)argv;
-  cursor->type = AC_TYPE_SDS;
-  cursor->offset = 0;
-  cursor->argc = argc;
+    cursor->objs = (void **)argv;
+    cursor->type = AC_TYPE_SDS;
+    cursor->offset = 0;
+    cursor->argc = argc;
 }
 
 static inline void ArgsCursor_InitRString(ArgsCursor *cursor, RedisModuleString **argv, int argc) {
-  cursor->objs = (void **)argv;
-  cursor->type = AC_TYPE_RSTRING;
-  cursor->offset = 0;
-  cursor->argc = argc;
+    cursor->objs = (void **)argv;
+    cursor->type = AC_TYPE_RSTRING;
+    cursor->offset = 0;
+    cursor->argc = argc;
 }
 
 typedef enum {
-  AC_OK = 0,      // Not an error
-  AC_ERR_PARSE,   // Couldn't parse as integer or other type
-  AC_ERR_NOARG,   // Missing required argument
-  AC_ERR_ELIMIT,  // Exceeded limitations of this type (i.e. bad value, but parsed OK)
-  AC_ERR_ENOENT   // Argument name not found in list
+    AC_OK = 0,     // Not an error
+    AC_ERR_PARSE,  // Couldn't parse as integer or other type
+    AC_ERR_NOARG,  // Missing required argument
+    AC_ERR_ELIMIT, // Exceeded limitations of this type (i.e. bad value, but parsed OK)
+    AC_ERR_ENOENT  // Argument name not found in list
 } ACStatus;
 
 // These flags can be AND'd with the original type
-#define AC_F_GE1 0x100        // Must be >= 1 (no zero or negative)
-#define AC_F_GE0 0x200        // Must be >= 0 (no negative)
-#define AC_F_NOADVANCE 0x400  // Don't advance cursor position
-#define AC_F_COALESCE 0x800   // Coalesce non-integral input
+#define AC_F_GE1       0x100 // Must be >= 1 (no zero or negative)
+#define AC_F_GE0       0x200 // Must be >= 0 (no negative)
+#define AC_F_NOADVANCE 0x400 // Don't advance cursor position
+#define AC_F_COALESCE  0x800 // Coalesce non-integral input
 
 // These functions return AC_OK or an error code on error. Note that the
 // output value is not guaranteed to remain untouched in the case of an error
@@ -124,59 +124,59 @@ int AC_GetSliceToOffset(ArgsCursor *ac, ArgsCursor *dest, int offset);
 int AC_GetSliceToEnd(ArgsCursor *ac, ArgsCursor *dest);
 
 typedef enum {
-  AC_ARGTYPE_STRING,
-  AC_ARGTYPE_RSTRING,
-  AC_ARGTYPE_LLONG,
-  AC_ARGTYPE_ULLONG,
-  AC_ARGTYPE_UINT,
-  AC_ARGTYPE_U32 = AC_ARGTYPE_UINT,
-  AC_ARGTYPE_INT,
-  AC_ARGTYPE_DOUBLE,
-  /**
-   * This means the name is a flag and does not accept any additional arguments.
-   * In this case, the target value is assumed to be an int, and is set to
-   * nonzero
-   */
-  AC_ARGTYPE_BOOLFLAG,
+    AC_ARGTYPE_STRING,
+    AC_ARGTYPE_RSTRING,
+    AC_ARGTYPE_LLONG,
+    AC_ARGTYPE_ULLONG,
+    AC_ARGTYPE_UINT,
+    AC_ARGTYPE_U32 = AC_ARGTYPE_UINT,
+    AC_ARGTYPE_INT,
+    AC_ARGTYPE_DOUBLE,
+    /**
+     * This means the name is a flag and does not accept any additional arguments.
+     * In this case, the target value is assumed to be an int, and is set to
+     * nonzero
+     */
+    AC_ARGTYPE_BOOLFLAG,
 
-  /**
-   * Uses AC_GetVarArgs, gets a sub-arg list
-   */
-  AC_ARGTYPE_SUBARGS,
+    /**
+     * Uses AC_GetVarArgs, gets a sub-arg list
+     */
+    AC_ARGTYPE_SUBARGS,
 
-  /**
-   * Use AC_GetSlice. Set slicelen in the spec to the expected count.
-   */
-  AC_ARGTYPE_SUBARGS_N,
+    /**
+     * Use AC_GetSlice. Set slicelen in the spec to the expected count.
+     */
+    AC_ARGTYPE_SUBARGS_N,
 
-  /**
-   * Accepts U32 target. Use 'slicelen' as the field to indicate which bit should
-   * be set.
-   */
-  AC_ARGTYPE_BITFLAG,
+    /**
+     * Accepts U32 target. Use 'slicelen' as the field to indicate which bit should
+     * be set.
+     */
+    AC_ARGTYPE_BITFLAG,
 
-  /**
-   * Like bitflag, except the value is _removed_ from the target. Accepts U32 target
-   */
-  AC_ARGTYPE_UNFLAG,
+    /**
+     * Like bitflag, except the value is _removed_ from the target. Accepts U32 target
+     */
+    AC_ARGTYPE_UNFLAG,
 } ACArgType;
 
 /**
  * Helper macro to define bitflag argtype
  */
-#define AC_MKBITFLAG(name_, target_, bit_) \
-  .name = name_, .target = target_, .type = AC_ARGTYPE_BITFLAG, .slicelen = bit_
+#define AC_MKBITFLAG(name_, target_, bit_)                                                         \
+    .name = name_, .target = target_, .type = AC_ARGTYPE_BITFLAG, .slicelen = bit_
 
-#define AC_MKUNFLAG(name_, target_, bit_) \
-  .name = name_, .target = target_, .type = AC_ARGTYPE_UNFLAG, .slicelen = bit_
+#define AC_MKUNFLAG(name_, target_, bit_)                                                          \
+    .name = name_, .target = target_, .type = AC_ARGTYPE_UNFLAG, .slicelen = bit_
 
 typedef struct {
-  const char *name;  // Name of the argument
-  void *target;      // [out] Target pointer, e.g. `int*`, `RedisModuleString**`
-  size_t *len;       // [out] Target length pointer. Valid only for strings
-  ACArgType type;    // Type of argument
-  int intflags;      // AC_F_COALESCE, etc.
-  size_t slicelen;   // When using slice length, set this to the expected slice count
+    const char *name; // Name of the argument
+    void *target;     // [out] Target pointer, e.g. `int*`, `RedisModuleString**`
+    size_t *len;      // [out] Target length pointer. Valid only for strings
+    ACArgType type;   // Type of argument
+    int intflags;     // AC_F_COALESCE, etc.
+    size_t slicelen;  // When using slice length, set this to the expected slice count
 } ACArgSpec;
 
 /**
@@ -194,27 +194,27 @@ typedef struct {
 int AC_ParseArgSpec(ArgsCursor *ac, ACArgSpec *specs, ACArgSpec **errSpec);
 
 static inline const char *AC_Strerror(int code) {
-  switch (code) {
+    switch (code) {
     case AC_OK:
-      return "SUCCESS";
+        return "SUCCESS";
     case AC_ERR_ELIMIT:
-      return "Value is outside acceptable bounds";
+        return "Value is outside acceptable bounds";
     case AC_ERR_NOARG:
-      return "Expected an argument, but none provided";
+        return "Expected an argument, but none provided";
     case AC_ERR_PARSE:
-      return "Could not convert argument to expected type";
+        return "Could not convert argument to expected type";
     case AC_ERR_ENOENT:
-      return "Unknown argument";
+        return "Unknown argument";
     default:
-      return "(AC: You should not be seeing this message. This is a bug)";
-  }
+        return "(AC: You should not be seeing this message. This is a bug)";
+    }
 }
 
-#define AC_CURRENT(ac) ((ac)->objs[(ac)->offset])
-#define AC_Clear(ac)  // NOOP
-#define AC_IsAtEnd(ac) ((ac)->offset >= (ac)->argc)
+#define AC_CURRENT(ac)      ((ac)->objs[(ac)->offset])
+#define AC_Clear(ac)        // NOOP
+#define AC_IsAtEnd(ac)      ((ac)->offset >= (ac)->argc)
 #define AC_NumRemaining(ac) ((ac)->argc - (ac)->offset)
-#define AC_NumArgs(ac) (ac)->argc
+#define AC_NumArgs(ac)      (ac)->argc
 #define AC_StringArg(ac, N) (const char *)((ac)->objs[N])
 #ifdef __cplusplus
 }
@@ -224,33 +224,28 @@ static inline const char *AC_Strerror(int code) {
 #include <type_traits>
 #include <array>
 class ArgsCursorCXX : public ArgsCursor {
- public:
-  template <typename... T>
-  ArgsCursorCXX(T... args) {
-    typedef typename std::tuple_element<0, std::tuple<T...>>::type FirstType;
-    typedef const typename std::remove_pointer<FirstType>::type *ConstPointerType;
-    typedef typename std::conditional<std::is_pointer<FirstType>::value, ConstPointerType,
-                                      FirstType>::type RealType;
-    std::array<const void *, sizeof...(args)> stackarr = {{args...}};
-    arr.assign(stackarr.begin(), stackarr.end());
-    RealType *arrptr = (RealType *)(&arr[0]);
-    init(&arrptr[0], arr.size());
-  }
+  public:
+    template <typename... T> ArgsCursorCXX(T... args) {
+        typedef typename std::tuple_element<0, std::tuple<T...>>::type FirstType;
+        typedef const typename std::remove_pointer<FirstType>::type *ConstPointerType;
+        typedef typename std::conditional<std::is_pointer<FirstType>::value, ConstPointerType,
+                                          FirstType>::type RealType;
+        std::array<const void *, sizeof...(args)> stackarr = {{args...}};
+        arr.assign(stackarr.begin(), stackarr.end());
+        RealType *arrptr = (RealType *)(&arr[0]);
+        init(&arrptr[0], arr.size());
+    }
 
-  void append(void *p) {
-    arr.push_back(p);
-    objs = (void **)&arr[0];
-    argc = arr.size();
-  }
+    void append(void *p) {
+        arr.push_back(p);
+        objs = (void **)&arr[0];
+        argc = arr.size();
+    }
 
- private:
-  std::vector<const void *> arr;
-  void init(const char **s, size_t n) {
-    ArgsCursor_InitCString(this, s, n);
-  }
-  void init(RedisModuleString **s, size_t n) {
-    ArgsCursor_InitRString(this, s, n);
-  }
+  private:
+    std::vector<const void *> arr;
+    void init(const char **s, size_t n) { ArgsCursor_InitCString(this, s, n); }
+    void init(RedisModuleString **s, size_t n) { ArgsCursor_InitRString(this, s, n); }
 };
 #endif
 #endif

--- a/src/rmutil/heap.c
+++ b/src/rmutil/heap.c
@@ -1,101 +1,102 @@
 #include "heap.h"
 
 /* Byte-wise swap two items of size SIZE. */
-#define SWAP(a, b, size)                  \
-  do {                                    \
-    register size_t __size = (size);      \
-    register char *__a = (a), *__b = (b); \
-    do {                                  \
-      char __tmp = *__a;                  \
-      *__a++ = *__b;                      \
-      *__b++ = __tmp;                     \
-    } while (--__size > 0);               \
-  } while (0)
+#define SWAP(a, b, size)                                                                           \
+    do {                                                                                           \
+        register size_t __size = (size);                                                           \
+        register char *__a = (a), *__b = (b);                                                      \
+        do {                                                                                       \
+            char __tmp = *__a;                                                                     \
+            *__a++ = *__b;                                                                         \
+            *__b++ = __tmp;                                                                        \
+        } while (--__size > 0);                                                                    \
+    } while (0)
 
-char *__vector_GetPtr(Vector *v, size_t pos) {
-  return v->data + (pos * v->elemSize);
-}
+char *__vector_GetPtr(Vector *v, size_t pos) { return v->data + (pos * v->elemSize); }
 
 void __sift_up(Vector *v, size_t first, size_t last, int (*cmp)(void *, void *)) {
-  size_t len = last - first;
-  if (len > 1) {
-    len = (len - 2) / 2;
-    size_t ptr = first + len;
-    if (cmp(__vector_GetPtr(v, ptr), __vector_GetPtr(v, --last)) < 0) {
-      char t[v->elemSize];
-      memcpy(t, __vector_GetPtr(v, last), v->elemSize);
-      do {
-        memcpy(__vector_GetPtr(v, last), __vector_GetPtr(v, ptr), v->elemSize);
-        last = ptr;
-        if (len == 0) break;
-        len = (len - 1) / 2;
-        ptr = first + len;
-      } while (cmp(__vector_GetPtr(v, ptr), t) < 0);
-      memcpy(__vector_GetPtr(v, last), t, v->elemSize);
+    size_t len = last - first;
+    if (len > 1) {
+        len = (len - 2) / 2;
+        size_t ptr = first + len;
+        if (cmp(__vector_GetPtr(v, ptr), __vector_GetPtr(v, --last)) < 0) {
+            char t[v->elemSize];
+            memcpy(t, __vector_GetPtr(v, last), v->elemSize);
+            do {
+                memcpy(__vector_GetPtr(v, last), __vector_GetPtr(v, ptr), v->elemSize);
+                last = ptr;
+                if (len == 0)
+                    break;
+                len = (len - 1) / 2;
+                ptr = first + len;
+            } while (cmp(__vector_GetPtr(v, ptr), t) < 0);
+            memcpy(__vector_GetPtr(v, last), t, v->elemSize);
+        }
     }
-  }
 }
 
 void __sift_down(Vector *v, size_t first, size_t last, int (*cmp)(void *, void *), size_t start) {
-  // left-child of __start is at 2 * __start + 1
-  // right-child of __start is at 2 * __start + 2
-  size_t len = last - first;
-  size_t child = start - first;
+    // left-child of __start is at 2 * __start + 1
+    // right-child of __start is at 2 * __start + 2
+    size_t len = last - first;
+    size_t child = start - first;
 
-  if (len < 2 || (len - 2) / 2 < child) return;
+    if (len < 2 || (len - 2) / 2 < child)
+        return;
 
-  child = 2 * child + 1;
-
-  if ((child + 1) < len &&
-      cmp(__vector_GetPtr(v, first + child), __vector_GetPtr(v, first + child + 1)) < 0) {
-    // right-child exists and is greater than left-child
-    ++child;
-  }
-
-  // check if we are in heap-order
-  if (cmp(__vector_GetPtr(v, first + child), __vector_GetPtr(v, start)) < 0)
-    // we are, __start is larger than it's largest child
-    return;
-
-  char top[v->elemSize];
-  memcpy(top, __vector_GetPtr(v, start), v->elemSize);
-  do {
-    // we are not in heap-order, swap the parent with it's largest child
-    memcpy(__vector_GetPtr(v, start), __vector_GetPtr(v, first + child), v->elemSize);
-    start = first + child;
-
-    if ((len - 2) / 2 < child) break;
-
-    // recompute the child based off of the updated parent
     child = 2 * child + 1;
 
     if ((child + 1) < len &&
         cmp(__vector_GetPtr(v, first + child), __vector_GetPtr(v, first + child + 1)) < 0) {
-      // right-child exists and is greater than left-child
-      ++child;
+        // right-child exists and is greater than left-child
+        ++child;
     }
 
     // check if we are in heap-order
-  } while (cmp(__vector_GetPtr(v, first + child), top) >= 0);
-  memcpy(__vector_GetPtr(v, start), top, v->elemSize);
+    if (cmp(__vector_GetPtr(v, first + child), __vector_GetPtr(v, start)) < 0)
+        // we are, __start is larger than it's largest child
+        return;
+
+    char top[v->elemSize];
+    memcpy(top, __vector_GetPtr(v, start), v->elemSize);
+    do {
+        // we are not in heap-order, swap the parent with it's largest child
+        memcpy(__vector_GetPtr(v, start), __vector_GetPtr(v, first + child), v->elemSize);
+        start = first + child;
+
+        if ((len - 2) / 2 < child)
+            break;
+
+        // recompute the child based off of the updated parent
+        child = 2 * child + 1;
+
+        if ((child + 1) < len &&
+            cmp(__vector_GetPtr(v, first + child), __vector_GetPtr(v, first + child + 1)) < 0) {
+            // right-child exists and is greater than left-child
+            ++child;
+        }
+
+        // check if we are in heap-order
+    } while (cmp(__vector_GetPtr(v, first + child), top) >= 0);
+    memcpy(__vector_GetPtr(v, start), top, v->elemSize);
 }
 
 void Make_Heap(Vector *v, size_t first, size_t last, int (*cmp)(void *, void *)) {
-  if (last - first > 1) {
-    // start from the first parent, there is no need to consider children
-    for (int start = (last - first - 2) / 2; start >= 0; --start) {
-      __sift_down(v, first, last, cmp, first + start);
+    if (last - first > 1) {
+        // start from the first parent, there is no need to consider children
+        for (int start = (last - first - 2) / 2; start >= 0; --start) {
+            __sift_down(v, first, last, cmp, first + start);
+        }
     }
-  }
 }
 
 inline void Heap_Push(Vector *v, size_t first, size_t last, int (*cmp)(void *, void *)) {
-  __sift_up(v, first, last, cmp);
+    __sift_up(v, first, last, cmp);
 }
 
 inline void Heap_Pop(Vector *v, size_t first, size_t last, int (*cmp)(void *, void *)) {
-  if (last - first > 1) {
-    SWAP(__vector_GetPtr(v, first), __vector_GetPtr(v, --last), v->elemSize);
-    __sift_down(v, first, last, cmp, first);
-  }
+    if (last - first > 1) {
+        SWAP(__vector_GetPtr(v, first), __vector_GetPtr(v, --last), v->elemSize);
+        __sift_down(v, first, last, cmp, first);
+    }
 }

--- a/src/rmutil/heap.h
+++ b/src/rmutil/heap.h
@@ -3,35 +3,33 @@
 
 #include "vector.h"
 
-
 /* Make heap from range
  * Rearranges the elements in the range [first,last) in such a way that they form a heap.
- * A heap is a way to organize the elements of a range that allows for fast retrieval of the element with the highest
- * value at any moment (with pop_heap), even repeatedly, while allowing for fast insertion of new elements (with
- * push_heap).
- * The element with the highest value is always pointed by first. The order of the other elements depends on the
- * particular implementation, but it is consistent throughout all heap-related functions of this header.
- * The elements are compared using cmp.
+ * A heap is a way to organize the elements of a range that allows for fast retrieval of the element
+ * with the highest value at any moment (with pop_heap), even repeatedly, while allowing for fast
+ * insertion of new elements (with push_heap). The element with the highest value is always pointed
+ * by first. The order of the other elements depends on the particular implementation, but it is
+ * consistent throughout all heap-related functions of this header. The elements are compared using
+ * cmp.
  */
 void Make_Heap(Vector *v, size_t first, size_t last, int (*cmp)(void *, void *));
 
-
 /* Push element into heap range
- * Given a heap in the range [first,last-1), this function extends the range considered a heap to [first,last) by
- * placing the value in (last-1) into its corresponding location within it.
- * A range can be organized into a heap by calling make_heap. After that, its heap properties are preserved if elements
- * are added and removed from it using push_heap and pop_heap, respectively.
+ * Given a heap in the range [first,last-1), this function extends the range considered a heap to
+ * [first,last) by placing the value in (last-1) into its corresponding location within it. A range
+ * can be organized into a heap by calling make_heap. After that, its heap properties are preserved
+ * if elements are added and removed from it using push_heap and pop_heap, respectively.
  */
 void Heap_Push(Vector *v, size_t first, size_t last, int (*cmp)(void *, void *));
 
-
 /* Pop element from heap range
- * Rearranges the elements in the heap range [first,last) in such a way that the part considered a heap is shortened
- * by one: The element with the highest value is moved to (last-1).
- * While the element with the highest value is moved from first to (last-1) (which now is out of the heap), the other
- * elements are reorganized in such a way that the range [first,last-1) preserves the properties of a heap.
- * A range can be organized into a heap by calling make_heap. After that, its heap properties are preserved if elements
- * are added and removed from it using push_heap and pop_heap, respectively.
+ * Rearranges the elements in the heap range [first,last) in such a way that the part considered a
+ * heap is shortened by one: The element with the highest value is moved to (last-1). While the
+ * element with the highest value is moved from first to (last-1) (which now is out of the heap),
+ * the other elements are reorganized in such a way that the range [first,last-1) preserves the
+ * properties of a heap. A range can be organized into a heap by calling make_heap. After that, its
+ * heap properties are preserved if elements are added and removed from it using push_heap and
+ * pop_heap, respectively.
  */
 void Heap_Pop(Vector *v, size_t first, size_t last, int (*cmp)(void *, void *));
 

--- a/src/rmutil/khash.h
+++ b/src/rmutil/khash.h
@@ -161,20 +161,20 @@ typedef unsigned long long khint64_t;
 typedef khint32_t khint_t;
 typedef khint_t khiter_t;
 
-#define __ac_isempty(flag, i) ((flag[i >> 4] >> ((i & 0xfU) << 1)) & 2)
-#define __ac_isdel(flag, i) ((flag[i >> 4] >> ((i & 0xfU) << 1)) & 1)
-#define __ac_iseither(flag, i) ((flag[i >> 4] >> ((i & 0xfU) << 1)) & 3)
-#define __ac_set_isdel_false(flag, i) (flag[i >> 4] &= ~(1ul << ((i & 0xfU) << 1)))
+#define __ac_isempty(flag, i)           ((flag[i >> 4] >> ((i & 0xfU) << 1)) & 2)
+#define __ac_isdel(flag, i)             ((flag[i >> 4] >> ((i & 0xfU) << 1)) & 1)
+#define __ac_iseither(flag, i)          ((flag[i >> 4] >> ((i & 0xfU) << 1)) & 3)
+#define __ac_set_isdel_false(flag, i)   (flag[i >> 4] &= ~(1ul << ((i & 0xfU) << 1)))
 #define __ac_set_isempty_false(flag, i) (flag[i >> 4] &= ~(2ul << ((i & 0xfU) << 1)))
-#define __ac_set_isboth_false(flag, i) (flag[i >> 4] &= ~(3ul << ((i & 0xfU) << 1)))
-#define __ac_set_isdel_true(flag, i) (flag[i >> 4] |= 1ul << ((i & 0xfU) << 1))
+#define __ac_set_isboth_false(flag, i)  (flag[i >> 4] &= ~(3ul << ((i & 0xfU) << 1)))
+#define __ac_set_isdel_true(flag, i)    (flag[i >> 4] |= 1ul << ((i & 0xfU) << 1))
 
 #define __ac_fsize(m) ((m) < 16 ? 1 : (m) >> 4)
 
 #ifndef kroundup32
-#define kroundup32(x)                                                                           \
-  (--(x), (x) |= (x) >> 1, (x) |= (x) >> 2, (x) |= (x) >> 4, (x) |= (x) >> 8, (x) |= (x) >> 16, \
-   ++(x))
+#define kroundup32(x)                                                                              \
+    (--(x), (x) |= (x) >> 1, (x) |= (x) >> 2, (x) |= (x) >> 4, (x) |= (x) >> 8, (x) |= (x) >> 16,  \
+     ++(x))
 #endif
 
 #ifndef kcalloc
@@ -192,213 +192,222 @@ typedef khint_t khiter_t;
 
 static const double __ac_HASH_UPPER = 0.77;
 
-#define __KHASH_TYPE(name, khkey_t, khval_t)          \
-  typedef struct kh_##name##_s {                      \
-    khint_t n_buckets, size, n_occupied, upper_bound; \
-    khint32_t *flags;                                 \
-    khkey_t *keys;                                    \
-    khval_t *vals;                                    \
-  } kh_##name##_t;
+#define __KHASH_TYPE(name, khkey_t, khval_t)                                                       \
+    typedef struct kh_##name##_s {                                                                 \
+        khint_t n_buckets, size, n_occupied, upper_bound;                                          \
+        khint32_t *flags;                                                                          \
+        khkey_t *keys;                                                                             \
+        khval_t *vals;                                                                             \
+    } kh_##name##_t;
 
-#define __KHASH_PROTOTYPES(name, khkey_t, khval_t)                       \
-  extern kh_##name##_t *kh_init_##name(void);                            \
-  extern void kh_destroy_##name(kh_##name##_t *h);                       \
-  extern void kh_clear_##name(kh_##name##_t *h);                         \
-  extern khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key);     \
-  extern int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets);  \
-  extern khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret); \
-  extern void kh_del_##name(kh_##name##_t *h, khint_t x);
+#define __KHASH_PROTOTYPES(name, khkey_t, khval_t)                                                 \
+    extern kh_##name##_t *kh_init_##name(void);                                                    \
+    extern void kh_destroy_##name(kh_##name##_t *h);                                               \
+    extern void kh_clear_##name(kh_##name##_t *h);                                                 \
+    extern khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key);                             \
+    extern int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets);                          \
+    extern khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret);                         \
+    extern void kh_del_##name(kh_##name##_t *h, khint_t x);
 
-#define __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)        \
-  SCOPE kh_##name##_t *kh_init_##name(void) {                                                    \
-    return (kh_##name##_t *)kcalloc(1, sizeof(kh_##name##_t));                                   \
-  }                                                                                              \
-  SCOPE void kh_destroy_##name(kh_##name##_t *h) {                                               \
-    if (h) {                                                                                     \
-      kfree((void *)h->keys);                                                                    \
-      kfree(h->flags);                                                                           \
-      kfree((void *)h->vals);                                                                    \
-      kfree(h);                                                                                  \
-    }                                                                                            \
-  }                                                                                              \
-  SCOPE void kh_clear_##name(kh_##name##_t *h) {                                                 \
-    if (h && h->flags) {                                                                         \
-      memset(h->flags, 0xaa, __ac_fsize(h->n_buckets) * sizeof(khint32_t));                      \
-      h->size = h->n_occupied = 0;                                                               \
-    }                                                                                            \
-  }                                                                                              \
-  SCOPE khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key) {                             \
-    if (h->n_buckets) {                                                                          \
-      khint_t k, i, last, mask, step = 0;                                                        \
-      mask = h->n_buckets - 1;                                                                   \
-      k = __hash_func(key);                                                                      \
-      i = k & mask;                                                                              \
-      last = i;                                                                                  \
-      while (!__ac_isempty(h->flags, i) &&                                                       \
-             (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) {                      \
-        i = (i + (++step)) & mask;                                                               \
-        if (i == last) return h->n_buckets;                                                      \
-      }                                                                                          \
-      return __ac_iseither(h->flags, i) ? h->n_buckets : i;                                      \
-    } else                                                                                       \
-      return 0;                                                                                  \
-  }                                                                                              \
-  SCOPE int kh_resize_##name(kh_##name##_t *h,                                                   \
-                             khint_t new_n_buckets) { /* This function uses 0.25*n_buckets bytes \
-                                                         of working space instead of             \
-                                                         [sizeof(key_t+val_t)+.25]*n_buckets. */ \
-    khint32_t *new_flags = 0;                                                                    \
-    khint_t j = 1;                                                                               \
-    {                                                                                            \
-      kroundup32(new_n_buckets);                                                                 \
-      if (new_n_buckets < 4) new_n_buckets = 4;                                                  \
-      if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5))                           \
-        j = 0; /* requested size is too small */                                                 \
-      else {   /* hash table size to be changed (shrink or expand); rehash */                    \
-        new_flags = (khint32_t *)kmalloc(__ac_fsize(new_n_buckets) * sizeof(khint32_t));         \
-        if (!new_flags) return -1;                                                               \
-        memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t));                  \
-        if (h->n_buckets < new_n_buckets) { /* expand */                                         \
-          khkey_t *new_keys =                                                                    \
-              (khkey_t *)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t));             \
-          if (!new_keys) {                                                                       \
-            kfree(new_flags);                                                                    \
-            return -1;                                                                           \
-          }                                                                                      \
-          h->keys = new_keys;                                                                    \
-          if (kh_is_map) {                                                                       \
-            khval_t *new_vals =                                                                  \
-                (khval_t *)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t));           \
-            if (!new_vals) {                                                                     \
-              kfree(new_flags);                                                                  \
-              return -1;                                                                         \
-            }                                                                                    \
-            h->vals = new_vals;                                                                  \
-          }                                                                                      \
-        } /* otherwise shrink */                                                                 \
-      }                                                                                          \
-    }                                                                                            \
-    if (j) { /* rehashing is needed */                                                           \
-      for (j = 0; j != h->n_buckets; ++j) {                                                      \
-        if (__ac_iseither(h->flags, j) == 0) {                                                   \
-          khkey_t key = h->keys[j];                                                              \
-          khval_t val;                                                                           \
-          khint_t new_mask;                                                                      \
-          new_mask = new_n_buckets - 1;                                                          \
-          if (kh_is_map) val = h->vals[j];                                                       \
-          __ac_set_isdel_true(h->flags, j);                                                      \
-          while (1) { /* kick-out process; sort of like in Cuckoo hashing */                     \
-            khint_t k, i, step = 0;                                                              \
-            k = __hash_func(key);                                                                \
-            i = k & new_mask;                                                                    \
-            while (!__ac_isempty(new_flags, i)) i = (i + (++step)) & new_mask;                   \
-            __ac_set_isempty_false(new_flags, i);                                                \
-            if (i < h->n_buckets &&                                                              \
-                __ac_iseither(h->flags, i) == 0) { /* kick out the existing element */           \
-              {                                                                                  \
-                khkey_t tmp = h->keys[i];                                                        \
-                h->keys[i] = key;                                                                \
-                key = tmp;                                                                       \
-              }                                                                                  \
-              if (kh_is_map) {                                                                   \
-                khval_t tmp = h->vals[i];                                                        \
-                h->vals[i] = val;                                                                \
-                val = tmp;                                                                       \
-              }                                                                                  \
-              __ac_set_isdel_true(h->flags, i); /* mark it as deleted in the old hash table */   \
-            } else {                            /* write the element and jump out of the loop */ \
-              h->keys[i] = key;                                                                  \
-              if (kh_is_map) h->vals[i] = val;                                                   \
-              break;                                                                             \
-            }                                                                                    \
-          }                                                                                      \
-        }                                                                                        \
-      }                                                                                          \
-      if (h->n_buckets > new_n_buckets) { /* shrink the hash table */                            \
-        h->keys = (khkey_t *)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t));         \
-        if (kh_is_map)                                                                           \
-          h->vals = (khval_t *)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t));       \
-      }                                                                                          \
-      kfree(h->flags); /* free the working space */                                              \
-      h->flags = new_flags;                                                                      \
-      h->n_buckets = new_n_buckets;                                                              \
-      h->n_occupied = h->size;                                                                   \
-      h->upper_bound = (khint_t)(h->n_buckets * __ac_HASH_UPPER + 0.5);                          \
-    }                                                                                            \
-    return 0;                                                                                    \
-  }                                                                                              \
-  SCOPE khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret) {                         \
-    khint_t x;                                                                                   \
-    if (h->n_occupied >= h->upper_bound) { /* update the hash table */                           \
-      if (h->n_buckets > (h->size << 1)) {                                                       \
-        if (kh_resize_##name(h, h->n_buckets - 1) < 0) { /* clear "deleted" elements */          \
-          *ret = -1;                                                                             \
-          return h->n_buckets;                                                                   \
-        }                                                                                        \
-      } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */        \
-        *ret = -1;                                                                               \
-        return h->n_buckets;                                                                     \
-      }                                                                                          \
-    } /* TODO: to implement automatically shrinking; resize() already support shrinking */       \
-    {                                                                                            \
-      khint_t k, i, site, last, mask = h->n_buckets - 1, step = 0;                               \
-      x = site = h->n_buckets;                                                                   \
-      k = __hash_func(key);                                                                      \
-      i = k & mask;                                                                              \
-      if (__ac_isempty(h->flags, i))                                                             \
-        x = i; /* for speed up */                                                                \
-      else {                                                                                     \
-        last = i;                                                                                \
-        while (!__ac_isempty(h->flags, i) &&                                                     \
-               (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) {                    \
-          if (__ac_isdel(h->flags, i)) site = i;                                                 \
-          i = (i + (++step)) & mask;                                                             \
-          if (i == last) {                                                                       \
-            x = site;                                                                            \
-            break;                                                                               \
-          }                                                                                      \
-        }                                                                                        \
-        if (x == h->n_buckets) {                                                                 \
-          if (__ac_isempty(h->flags, i) && site != h->n_buckets)                                 \
-            x = site;                                                                            \
-          else                                                                                   \
-            x = i;                                                                               \
-        }                                                                                        \
-      }                                                                                          \
-    }                                                                                            \
-    if (__ac_isempty(h->flags, x)) { /* not present at all */                                    \
-      h->keys[x] = key;                                                                          \
-      __ac_set_isboth_false(h->flags, x);                                                        \
-      ++h->size;                                                                                 \
-      ++h->n_occupied;                                                                           \
-      *ret = 1;                                                                                  \
-    } else if (__ac_isdel(h->flags, x)) { /* deleted */                                          \
-      h->keys[x] = key;                                                                          \
-      __ac_set_isboth_false(h->flags, x);                                                        \
-      ++h->size;                                                                                 \
-      *ret = 2;                                                                                  \
-    } else                                                                                       \
-      *ret = 0; /* Don't touch h->keys[x] if present and not deleted */                          \
-    return x;                                                                                    \
-  }                                                                                              \
-  SCOPE void kh_del_##name(kh_##name##_t *h, khint_t x) {                                        \
-    if (x != h->n_buckets && !__ac_iseither(h->flags, x)) {                                      \
-      __ac_set_isdel_true(h->flags, x);                                                          \
-      --h->size;                                                                                 \
-    }                                                                                            \
-  }
+#define __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)          \
+    SCOPE kh_##name##_t *kh_init_##name(void) {                                                    \
+        return (kh_##name##_t *)kcalloc(1, sizeof(kh_##name##_t));                                 \
+    }                                                                                              \
+    SCOPE void kh_destroy_##name(kh_##name##_t *h) {                                               \
+        if (h) {                                                                                   \
+            kfree((void *)h->keys);                                                                \
+            kfree(h->flags);                                                                       \
+            kfree((void *)h->vals);                                                                \
+            kfree(h);                                                                              \
+        }                                                                                          \
+    }                                                                                              \
+    SCOPE void kh_clear_##name(kh_##name##_t *h) {                                                 \
+        if (h && h->flags) {                                                                       \
+            memset(h->flags, 0xaa, __ac_fsize(h->n_buckets) * sizeof(khint32_t));                  \
+            h->size = h->n_occupied = 0;                                                           \
+        }                                                                                          \
+    }                                                                                              \
+    SCOPE khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key) {                             \
+        if (h->n_buckets) {                                                                        \
+            khint_t k, i, last, mask, step = 0;                                                    \
+            mask = h->n_buckets - 1;                                                               \
+            k = __hash_func(key);                                                                  \
+            i = k & mask;                                                                          \
+            last = i;                                                                              \
+            while (!__ac_isempty(h->flags, i) &&                                                   \
+                   (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) {                  \
+                i = (i + (++step)) & mask;                                                         \
+                if (i == last)                                                                     \
+                    return h->n_buckets;                                                           \
+            }                                                                                      \
+            return __ac_iseither(h->flags, i) ? h->n_buckets : i;                                  \
+        } else                                                                                     \
+            return 0;                                                                              \
+    }                                                                                              \
+    SCOPE int kh_resize_##name(kh_##name##_t *h,                                                   \
+                               khint_t new_n_buckets) { /* This function uses 0.25*n_buckets bytes \
+                                                           of working space instead of             \
+                                                           [sizeof(key_t+val_t)+.25]*n_buckets. */ \
+        khint32_t *new_flags = 0;                                                                  \
+        khint_t j = 1;                                                                             \
+        {                                                                                          \
+            kroundup32(new_n_buckets);                                                             \
+            if (new_n_buckets < 4)                                                                 \
+                new_n_buckets = 4;                                                                 \
+            if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5))                       \
+                j = 0; /* requested size is too small */                                           \
+            else {     /* hash table size to be changed (shrink or expand); rehash */              \
+                new_flags = (khint32_t *)kmalloc(__ac_fsize(new_n_buckets) * sizeof(khint32_t));   \
+                if (!new_flags)                                                                    \
+                    return -1;                                                                     \
+                memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t));            \
+                if (h->n_buckets < new_n_buckets) { /* expand */                                   \
+                    khkey_t *new_keys =                                                            \
+                        (khkey_t *)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t));     \
+                    if (!new_keys) {                                                               \
+                        kfree(new_flags);                                                          \
+                        return -1;                                                                 \
+                    }                                                                              \
+                    h->keys = new_keys;                                                            \
+                    if (kh_is_map) {                                                               \
+                        khval_t *new_vals =                                                        \
+                            (khval_t *)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
+                        if (!new_vals) {                                                           \
+                            kfree(new_flags);                                                      \
+                            return -1;                                                             \
+                        }                                                                          \
+                        h->vals = new_vals;                                                        \
+                    }                                                                              \
+                } /* otherwise shrink */                                                           \
+            }                                                                                      \
+        }                                                                                          \
+        if (j) { /* rehashing is needed */                                                         \
+            for (j = 0; j != h->n_buckets; ++j) {                                                  \
+                if (__ac_iseither(h->flags, j) == 0) {                                             \
+                    khkey_t key = h->keys[j];                                                      \
+                    khval_t val;                                                                   \
+                    khint_t new_mask;                                                              \
+                    new_mask = new_n_buckets - 1;                                                  \
+                    if (kh_is_map)                                                                 \
+                        val = h->vals[j];                                                          \
+                    __ac_set_isdel_true(h->flags, j);                                              \
+                    while (1) { /* kick-out process; sort of like in Cuckoo hashing */             \
+                        khint_t k, i, step = 0;                                                    \
+                        k = __hash_func(key);                                                      \
+                        i = k & new_mask;                                                          \
+                        while (!__ac_isempty(new_flags, i))                                        \
+                            i = (i + (++step)) & new_mask;                                         \
+                        __ac_set_isempty_false(new_flags, i);                                      \
+                        if (i < h->n_buckets &&                                                    \
+                            __ac_iseither(h->flags, i) == 0) { /* kick out the existing element */ \
+                            {                                                                      \
+                                khkey_t tmp = h->keys[i];                                          \
+                                h->keys[i] = key;                                                  \
+                                key = tmp;                                                         \
+                            }                                                                      \
+                            if (kh_is_map) {                                                       \
+                                khval_t tmp = h->vals[i];                                          \
+                                h->vals[i] = val;                                                  \
+                                val = tmp;                                                         \
+                            }                                                                      \
+                            __ac_set_isdel_true(h->flags,                                          \
+                                                i); /* mark it as deleted in the old hash table */ \
+                        } else { /* write the element and jump out of the loop */                  \
+                            h->keys[i] = key;                                                      \
+                            if (kh_is_map)                                                         \
+                                h->vals[i] = val;                                                  \
+                            break;                                                                 \
+                        }                                                                          \
+                    }                                                                              \
+                }                                                                                  \
+            }                                                                                      \
+            if (h->n_buckets > new_n_buckets) { /* shrink the hash table */                        \
+                h->keys = (khkey_t *)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t));   \
+                if (kh_is_map)                                                                     \
+                    h->vals =                                                                      \
+                        (khval_t *)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t));     \
+            }                                                                                      \
+            kfree(h->flags); /* free the working space */                                          \
+            h->flags = new_flags;                                                                  \
+            h->n_buckets = new_n_buckets;                                                          \
+            h->n_occupied = h->size;                                                               \
+            h->upper_bound = (khint_t)(h->n_buckets * __ac_HASH_UPPER + 0.5);                      \
+        }                                                                                          \
+        return 0;                                                                                  \
+    }                                                                                              \
+    SCOPE khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret) {                         \
+        khint_t x;                                                                                 \
+        if (h->n_occupied >= h->upper_bound) { /* update the hash table */                         \
+            if (h->n_buckets > (h->size << 1)) {                                                   \
+                if (kh_resize_##name(h, h->n_buckets - 1) < 0) { /* clear "deleted" elements */    \
+                    *ret = -1;                                                                     \
+                    return h->n_buckets;                                                           \
+                }                                                                                  \
+            } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */    \
+                *ret = -1;                                                                         \
+                return h->n_buckets;                                                               \
+            }                                                                                      \
+        } /* TODO: to implement automatically shrinking; resize() already support shrinking */     \
+        {                                                                                          \
+            khint_t k, i, site, last, mask = h->n_buckets - 1, step = 0;                           \
+            x = site = h->n_buckets;                                                               \
+            k = __hash_func(key);                                                                  \
+            i = k & mask;                                                                          \
+            if (__ac_isempty(h->flags, i))                                                         \
+                x = i; /* for speed up */                                                          \
+            else {                                                                                 \
+                last = i;                                                                          \
+                while (!__ac_isempty(h->flags, i) &&                                               \
+                       (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) {              \
+                    if (__ac_isdel(h->flags, i))                                                   \
+                        site = i;                                                                  \
+                    i = (i + (++step)) & mask;                                                     \
+                    if (i == last) {                                                               \
+                        x = site;                                                                  \
+                        break;                                                                     \
+                    }                                                                              \
+                }                                                                                  \
+                if (x == h->n_buckets) {                                                           \
+                    if (__ac_isempty(h->flags, i) && site != h->n_buckets)                         \
+                        x = site;                                                                  \
+                    else                                                                           \
+                        x = i;                                                                     \
+                }                                                                                  \
+            }                                                                                      \
+        }                                                                                          \
+        if (__ac_isempty(h->flags, x)) { /* not present at all */                                  \
+            h->keys[x] = key;                                                                      \
+            __ac_set_isboth_false(h->flags, x);                                                    \
+            ++h->size;                                                                             \
+            ++h->n_occupied;                                                                       \
+            *ret = 1;                                                                              \
+        } else if (__ac_isdel(h->flags, x)) { /* deleted */                                        \
+            h->keys[x] = key;                                                                      \
+            __ac_set_isboth_false(h->flags, x);                                                    \
+            ++h->size;                                                                             \
+            *ret = 2;                                                                              \
+        } else                                                                                     \
+            *ret = 0; /* Don't touch h->keys[x] if present and not deleted */                      \
+        return x;                                                                                  \
+    }                                                                                              \
+    SCOPE void kh_del_##name(kh_##name##_t *h, khint_t x) {                                        \
+        if (x != h->n_buckets && !__ac_iseither(h->flags, x)) {                                    \
+            __ac_set_isdel_true(h->flags, x);                                                      \
+            --h->size;                                                                             \
+        }                                                                                          \
+    }
 
-#define KHASH_DECLARE(name, khkey_t, khval_t) \
-  __KHASH_TYPE(name, khkey_t, khval_t)        \
-  __KHASH_PROTOTYPES(name, khkey_t, khval_t)
+#define KHASH_DECLARE(name, khkey_t, khval_t)                                                      \
+    __KHASH_TYPE(name, khkey_t, khval_t)                                                           \
+    __KHASH_PROTOTYPES(name, khkey_t, khval_t)
 
-#define KHASH_INIT2(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
-  __KHASH_TYPE(name, khkey_t, khval_t)                                                   \
-  __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+#define KHASH_INIT2(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)           \
+    __KHASH_TYPE(name, khkey_t, khval_t)                                                           \
+    __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
 
-#define KHASH_INIT(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)            \
-  KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, \
-              __hash_equal)
+#define KHASH_INIT(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)                   \
+    KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func,      \
+                __hash_equal)
 
 /* --- BEGIN OF HASH FUNCTIONS --- */
 
@@ -428,10 +437,11 @@ static const double __ac_HASH_UPPER = 0.77;
   @return       The hash value
  */
 static kh_inline khint_t __ac_X31_hash_string(const char *s) {
-  khint_t h = (khint_t)*s;
-  if (h)
-    for (++s; *s; ++s) h = (h << 5) - h + (khint_t)*s;
-  return h;
+    khint_t h = (khint_t)*s;
+    if (h)
+        for (++s; *s; ++s)
+            h = (h << 5) - h + (khint_t)*s;
+    return h;
 }
 /*! @function
   @abstract     Another interface to const char* hash function
@@ -445,13 +455,13 @@ static kh_inline khint_t __ac_X31_hash_string(const char *s) {
 #define kh_str_hash_equal(a, b) (strcmp(a, b) == 0)
 
 static kh_inline khint_t __ac_Wang_hash(khint_t key) {
-  key += ~(key << 15);
-  key ^= (key >> 10);
-  key += (key << 3);
-  key ^= (key >> 6);
-  key += ~(key << 11);
-  key ^= (key >> 16);
-  return key;
+    key += ~(key << 15);
+    key ^= (key >> 10);
+    key += (key << 3);
+    key ^= (key >> 6);
+    key += ~(key << 11);
+    key ^= (key >> 16);
+    return key;
 }
 #define kh_int_hash_func2(key) __ac_Wang_hash((khint_t)key)
 
@@ -589,16 +599,17 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key) {
   @param  vvar  Variable to which value will be assigned
   @param  code  Block of code to execute
  */
-#define kh_foreach(h, kvar, vvar, code)                \
-  {                                                    \
-    khint_t __i;                                       \
-    for (__i = kh_begin(h); __i != kh_end(h); ++__i) { \
-      if (!kh_exist(h, __i)) continue;                 \
-      (kvar) = kh_key(h, __i);                         \
-      (vvar) = kh_val(h, __i);                         \
-      code;                                            \
-    }                                                  \
-  }
+#define kh_foreach(h, kvar, vvar, code)                                                            \
+    {                                                                                              \
+        khint_t __i;                                                                               \
+        for (__i = kh_begin(h); __i != kh_end(h); ++__i) {                                         \
+            if (!kh_exist(h, __i))                                                                 \
+                continue;                                                                          \
+            (kvar) = kh_key(h, __i);                                                               \
+            (vvar) = kh_val(h, __i);                                                               \
+            code;                                                                                  \
+        }                                                                                          \
+    }
 
 /*! @function
   @abstract     Iterate over the values in the hash table
@@ -606,15 +617,16 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key) {
   @param  vvar  Variable to which value will be assigned
   @param  code  Block of code to execute
  */
-#define kh_foreach_value(h, vvar, code)                \
-  {                                                    \
-    khint_t __i;                                       \
-    for (__i = kh_begin(h); __i != kh_end(h); ++__i) { \
-      if (!kh_exist(h, __i)) continue;                 \
-      (vvar) = kh_val(h, __i);                         \
-      code;                                            \
-    }                                                  \
-  }
+#define kh_foreach_value(h, vvar, code)                                                            \
+    {                                                                                              \
+        khint_t __i;                                                                               \
+        for (__i = kh_begin(h); __i != kh_end(h); ++__i) {                                         \
+            if (!kh_exist(h, __i))                                                                 \
+                continue;                                                                          \
+            (vvar) = kh_val(h, __i);                                                               \
+            code;                                                                                  \
+        }                                                                                          \
+    }
 
 /* More conenient interfaces */
 
@@ -622,46 +634,46 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key) {
   @abstract     Instantiate a hash set containing integer keys
   @param  name  Name of the hash table [symbol]
  */
-#define KHASH_SET_INIT_INT(name) \
-  KHASH_INIT(name, khint32_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
+#define KHASH_SET_INIT_INT(name)                                                                   \
+    KHASH_INIT(name, khint32_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
 
 /*! @function
   @abstract     Instantiate a hash map containing integer keys
   @param  name  Name of the hash table [symbol]
   @param  khval_t  Type of values [type]
  */
-#define KHASH_MAP_INIT_INT(name, khval_t) \
-  KHASH_INIT(name, khint32_t, khval_t, 1, kh_int_hash_func, kh_int_hash_equal)
+#define KHASH_MAP_INIT_INT(name, khval_t)                                                          \
+    KHASH_INIT(name, khint32_t, khval_t, 1, kh_int_hash_func, kh_int_hash_equal)
 
 /*! @function
   @abstract     Instantiate a hash map containing 64-bit integer keys
   @param  name  Name of the hash table [symbol]
  */
-#define KHASH_SET_INIT_INT64(name) \
-  KHASH_INIT(name, khint64_t, char, 0, kh_int64_hash_func, kh_int64_hash_equal)
+#define KHASH_SET_INIT_INT64(name)                                                                 \
+    KHASH_INIT(name, khint64_t, char, 0, kh_int64_hash_func, kh_int64_hash_equal)
 
 /*! @function
   @abstract     Instantiate a hash map containing 64-bit integer keys
   @param  name  Name of the hash table [symbol]
   @param  khval_t  Type of values [type]
  */
-#define KHASH_MAP_INIT_INT64(name, khval_t) \
-  KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
+#define KHASH_MAP_INIT_INT64(name, khval_t)                                                        \
+    KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
 
 typedef const char *kh_cstr_t;
 /*! @function
   @abstract     Instantiate a hash map containing const char* keys
   @param  name  Name of the hash table [symbol]
  */
-#define KHASH_SET_INIT_STR(name) \
-  KHASH_INIT(name, kh_cstr_t, char, 0, kh_str_hash_func, kh_str_hash_equal)
+#define KHASH_SET_INIT_STR(name)                                                                   \
+    KHASH_INIT(name, kh_cstr_t, char, 0, kh_str_hash_func, kh_str_hash_equal)
 
 /*! @function
   @abstract     Instantiate a hash map containing const char* keys
   @param  name  Name of the hash table [symbol]
   @param  khval_t  Type of values [type]
  */
-#define KHASH_MAP_INIT_STR(name, khval_t) \
-  KHASH_INIT(name, kh_cstr_t, khval_t, 1, kh_str_hash_func, kh_str_hash_equal)
+#define KHASH_MAP_INIT_STR(name, khval_t)                                                          \
+    KHASH_INIT(name, kh_cstr_t, khval_t, 1, kh_str_hash_func, kh_str_hash_equal)
 
 #endif /* __AC_KHASH_H */

--- a/src/rmutil/priority_queue.c
+++ b/src/rmutil/priority_queue.c
@@ -8,13 +8,9 @@ PriorityQueue *__newPriorityQueueSize(size_t elemSize, size_t cap, int (*cmp)(vo
     return pq;
 }
 
-inline size_t Priority_Queue_Size(PriorityQueue *pq) {
-    return Vector_Size(pq->v);
-}
+inline size_t Priority_Queue_Size(PriorityQueue *pq) { return Vector_Size(pq->v); }
 
-inline int Priority_Queue_Top(PriorityQueue *pq, void *ptr) {
-    return Vector_Get(pq->v, 0, ptr);
-}
+inline int Priority_Queue_Top(PriorityQueue *pq, void *ptr) { return Vector_Get(pq->v, 0, ptr); }
 
 inline size_t __priority_Queue_PushPtr(PriorityQueue *pq, void *elem) {
     size_t top = __vector_PushPtr(pq->v, elem);

--- a/src/rmutil/priority_queue.h
+++ b/src/rmutil/priority_queue.h
@@ -4,11 +4,11 @@
 #include "vector.h"
 
 /* Priority queue
- * Priority queues are designed such that its first element is always the greatest of the elements it contains.
- * This context is similar to a heap, where elements can be inserted at any moment, and only the max heap element can be
- * retrieved (the one at the top in the priority queue).
- * Priority queues are implemented as Vectors. Elements are popped from the "back" of Vector, which is known as the top
- * of the priority queue.
+ * Priority queues are designed such that its first element is always the greatest of the elements
+ * it contains. This context is similar to a heap, where elements can be inserted at any moment, and
+ * only the max heap element can be retrieved (the one at the top in the priority queue). Priority
+ * queues are implemented as Vectors. Elements are popped from the "back" of Vector, which is known
+ * as the top of the priority queue.
  */
 typedef struct {
     Vector *v;
@@ -42,9 +42,9 @@ size_t __priority_Queue_PushPtr(PriorityQueue *pq, void *elem);
 #define Priority_Queue_Push(pq, elem) __priority_Queue_PushPtr(pq, &(typeof(elem)){elem})
 
 /* Remove top element
- * Removes the element on top of the priority_queue, effectively reducing its size by one. The element removed is the
- * one with the highest value.
- * The value of this element can be retrieved before being popped by calling Priority_Queue_Top.
+ * Removes the element on top of the priority_queue, effectively reducing its size by one. The
+ * element removed is the one with the highest value. The value of this element can be retrieved
+ * before being popped by calling Priority_Queue_Top.
  */
 void Priority_Queue_Pop(PriorityQueue *pq);
 

--- a/src/rmutil/sds.h
+++ b/src/rmutil/sds.h
@@ -48,171 +48,171 @@ extern const char *SDS_NOINIT;
 /* Note: sdshdr5 is never used, we just access the flags byte directly.
  * However is here to document the layout of type 5 SDS strings. */
 struct __attribute__((__packed__)) sdshdr5 {
-  unsigned char flags; /* 3 lsb of type, and 5 msb of string length */
-  char buf[];
+    unsigned char flags; /* 3 lsb of type, and 5 msb of string length */
+    char buf[];
 };
 struct __attribute__((__packed__)) sdshdr8 {
-  uint8_t len;         /* used */
-  uint8_t alloc;       /* excluding the header and null terminator */
-  unsigned char flags; /* 3 lsb of type, 5 unused bits */
-  char buf[];
+    uint8_t len;         /* used */
+    uint8_t alloc;       /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
 };
 struct __attribute__((__packed__)) sdshdr16 {
-  uint16_t len;        /* used */
-  uint16_t alloc;      /* excluding the header and null terminator */
-  unsigned char flags; /* 3 lsb of type, 5 unused bits */
-  char buf[];
+    uint16_t len;        /* used */
+    uint16_t alloc;      /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
 };
 struct __attribute__((__packed__)) sdshdr32 {
-  uint32_t len;        /* used */
-  uint32_t alloc;      /* excluding the header and null terminator */
-  unsigned char flags; /* 3 lsb of type, 5 unused bits */
-  char buf[];
+    uint32_t len;        /* used */
+    uint32_t alloc;      /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
 };
 struct __attribute__((__packed__)) sdshdr64 {
-  uint64_t len;        /* used */
-  uint64_t alloc;      /* excluding the header and null terminator */
-  unsigned char flags; /* 3 lsb of type, 5 unused bits */
-  char buf[];
+    uint64_t len;        /* used */
+    uint64_t alloc;      /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
 };
 
-#define SDS_TYPE_5 0
-#define SDS_TYPE_8 1
-#define SDS_TYPE_16 2
-#define SDS_TYPE_32 3
-#define SDS_TYPE_64 4
+#define SDS_TYPE_5    0
+#define SDS_TYPE_8    1
+#define SDS_TYPE_16   2
+#define SDS_TYPE_32   3
+#define SDS_TYPE_64   4
 #define SDS_TYPE_MASK 7
 #define SDS_TYPE_BITS 3
-#define SDS_HDR_VAR(T, s) \
-  struct sdshdr##T *sh = (struct sdshdr##T *)((void *)((s) - (sizeof(struct sdshdr##T))));
-#define SDS_HDR(T, s) ((struct sdshdr##T *)((s) - (sizeof(struct sdshdr##T))))
+#define SDS_HDR_VAR(T, s)                                                                          \
+    struct sdshdr##T *sh = (struct sdshdr##T *)((void *)((s) - (sizeof(struct sdshdr##T))));
+#define SDS_HDR(T, s)     ((struct sdshdr##T *)((s) - (sizeof(struct sdshdr##T))))
 #define SDS_TYPE_5_LEN(f) ((f) >> SDS_TYPE_BITS)
 
 static inline size_t sdslen(const sds s) {
-  unsigned char flags = s[-1];
-  switch (flags & SDS_TYPE_MASK) {
+    unsigned char flags = s[-1];
+    switch (flags & SDS_TYPE_MASK) {
     case SDS_TYPE_5:
-      return SDS_TYPE_5_LEN(flags);
+        return SDS_TYPE_5_LEN(flags);
     case SDS_TYPE_8:
-      return SDS_HDR(8, s)->len;
+        return SDS_HDR(8, s)->len;
     case SDS_TYPE_16:
-      return SDS_HDR(16, s)->len;
+        return SDS_HDR(16, s)->len;
     case SDS_TYPE_32:
-      return SDS_HDR(32, s)->len;
+        return SDS_HDR(32, s)->len;
     case SDS_TYPE_64:
-      return SDS_HDR(64, s)->len;
-  }
-  return 0;
+        return SDS_HDR(64, s)->len;
+    }
+    return 0;
 }
 
 static inline size_t sdsavail(const sds s) {
-  unsigned char flags = s[-1];
-  switch (flags & SDS_TYPE_MASK) {
+    unsigned char flags = s[-1];
+    switch (flags & SDS_TYPE_MASK) {
     case SDS_TYPE_5: {
-      return 0;
+        return 0;
     }
     case SDS_TYPE_8: {
-      SDS_HDR_VAR(8, s);
-      return sh->alloc - sh->len;
+        SDS_HDR_VAR(8, s);
+        return sh->alloc - sh->len;
     }
     case SDS_TYPE_16: {
-      SDS_HDR_VAR(16, s);
-      return sh->alloc - sh->len;
+        SDS_HDR_VAR(16, s);
+        return sh->alloc - sh->len;
     }
     case SDS_TYPE_32: {
-      SDS_HDR_VAR(32, s);
-      return sh->alloc - sh->len;
+        SDS_HDR_VAR(32, s);
+        return sh->alloc - sh->len;
     }
     case SDS_TYPE_64: {
-      SDS_HDR_VAR(64, s);
-      return sh->alloc - sh->len;
+        SDS_HDR_VAR(64, s);
+        return sh->alloc - sh->len;
     }
-  }
-  return 0;
+    }
+    return 0;
 }
 
 static inline void sdssetlen(sds s, size_t newlen) {
-  unsigned char flags = s[-1];
-  switch (flags & SDS_TYPE_MASK) {
+    unsigned char flags = s[-1];
+    switch (flags & SDS_TYPE_MASK) {
     case SDS_TYPE_5: {
-      unsigned char *fp = ((unsigned char *)s) - 1;
-      *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
+        unsigned char *fp = ((unsigned char *)s) - 1;
+        *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
     } break;
     case SDS_TYPE_8:
-      SDS_HDR(8, s)->len = newlen;
-      break;
+        SDS_HDR(8, s)->len = newlen;
+        break;
     case SDS_TYPE_16:
-      SDS_HDR(16, s)->len = newlen;
-      break;
+        SDS_HDR(16, s)->len = newlen;
+        break;
     case SDS_TYPE_32:
-      SDS_HDR(32, s)->len = newlen;
-      break;
+        SDS_HDR(32, s)->len = newlen;
+        break;
     case SDS_TYPE_64:
-      SDS_HDR(64, s)->len = newlen;
-      break;
-  }
+        SDS_HDR(64, s)->len = newlen;
+        break;
+    }
 }
 
 static inline void sdsinclen(sds s, size_t inc) {
-  unsigned char flags = s[-1];
-  switch (flags & SDS_TYPE_MASK) {
+    unsigned char flags = s[-1];
+    switch (flags & SDS_TYPE_MASK) {
     case SDS_TYPE_5: {
-      unsigned char *fp = ((unsigned char *)s) - 1;
-      unsigned char newlen = SDS_TYPE_5_LEN(flags) + inc;
-      *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
+        unsigned char *fp = ((unsigned char *)s) - 1;
+        unsigned char newlen = SDS_TYPE_5_LEN(flags) + inc;
+        *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
     } break;
     case SDS_TYPE_8:
-      SDS_HDR(8, s)->len += inc;
-      break;
+        SDS_HDR(8, s)->len += inc;
+        break;
     case SDS_TYPE_16:
-      SDS_HDR(16, s)->len += inc;
-      break;
+        SDS_HDR(16, s)->len += inc;
+        break;
     case SDS_TYPE_32:
-      SDS_HDR(32, s)->len += inc;
-      break;
+        SDS_HDR(32, s)->len += inc;
+        break;
     case SDS_TYPE_64:
-      SDS_HDR(64, s)->len += inc;
-      break;
-  }
+        SDS_HDR(64, s)->len += inc;
+        break;
+    }
 }
 
 /* sdsalloc() = sdsavail() + sdslen() */
 static inline size_t sdsalloc(const sds s) {
-  unsigned char flags = s[-1];
-  switch (flags & SDS_TYPE_MASK) {
+    unsigned char flags = s[-1];
+    switch (flags & SDS_TYPE_MASK) {
     case SDS_TYPE_5:
-      return SDS_TYPE_5_LEN(flags);
+        return SDS_TYPE_5_LEN(flags);
     case SDS_TYPE_8:
-      return SDS_HDR(8, s)->alloc;
+        return SDS_HDR(8, s)->alloc;
     case SDS_TYPE_16:
-      return SDS_HDR(16, s)->alloc;
+        return SDS_HDR(16, s)->alloc;
     case SDS_TYPE_32:
-      return SDS_HDR(32, s)->alloc;
+        return SDS_HDR(32, s)->alloc;
     case SDS_TYPE_64:
-      return SDS_HDR(64, s)->alloc;
-  }
-  return 0;
+        return SDS_HDR(64, s)->alloc;
+    }
+    return 0;
 }
 
 static inline void sdssetalloc(sds s, size_t newlen) {
-  unsigned char flags = s[-1];
-  switch (flags & SDS_TYPE_MASK) {
+    unsigned char flags = s[-1];
+    switch (flags & SDS_TYPE_MASK) {
     case SDS_TYPE_5:
-      /* Nothing to do, this type has no total allocation info. */
-      break;
+        /* Nothing to do, this type has no total allocation info. */
+        break;
     case SDS_TYPE_8:
-      SDS_HDR(8, s)->alloc = newlen;
-      break;
+        SDS_HDR(8, s)->alloc = newlen;
+        break;
     case SDS_TYPE_16:
-      SDS_HDR(16, s)->alloc = newlen;
-      break;
+        SDS_HDR(16, s)->alloc = newlen;
+        break;
     case SDS_TYPE_32:
-      SDS_HDR(32, s)->alloc = newlen;
-      break;
+        SDS_HDR(32, s)->alloc = newlen;
+        break;
     case SDS_TYPE_64:
-      SDS_HDR(64, s)->alloc = newlen;
-      break;
-  }
+        SDS_HDR(64, s)->alloc = newlen;
+        break;
+    }
 }
 
 sds sdsnewlen(const void *init, size_t initlen);

--- a/src/rmutil/sdsalloc.h
+++ b/src/rmutil/sdsalloc.h
@@ -43,6 +43,6 @@
 #include <malloc.h>
 #endif
 //#include "zmalloc.h"
-#define s_malloc malloc
+#define s_malloc  malloc
 #define s_realloc realloc
-#define s_free free
+#define s_free    free

--- a/src/rmutil/vector.c
+++ b/src/rmutil/vector.c
@@ -2,90 +2,86 @@
 #include <stdio.h>
 
 inline int __vector_PushPtr(Vector *v, void *elem) {
-  if (v->top == v->cap) {
-    Vector_Resize(v, v->cap ? v->cap * 2 : 1);
-  }
+    if (v->top == v->cap) {
+        Vector_Resize(v, v->cap ? v->cap * 2 : 1);
+    }
 
-  __vector_PutPtr(v, v->top, elem);
-  return v->top;
+    __vector_PutPtr(v, v->top, elem);
+    return v->top;
 }
 
 inline int Vector_Get(Vector *v, size_t pos, void *ptr) {
-  // return 0 if pos is out of bounds
-  if (pos >= v->top) {
-    return 0;
-  }
+    // return 0 if pos is out of bounds
+    if (pos >= v->top) {
+        return 0;
+    }
 
-  memcpy(ptr, v->data + (pos * v->elemSize), v->elemSize);
-  return 1;
+    memcpy(ptr, v->data + (pos * v->elemSize), v->elemSize);
+    return 1;
 }
 
 /* Get the element at the end of the vector, decreasing the size by one */
 inline int Vector_Pop(Vector *v, void *ptr) {
-  if (v->top > 0) {
-    if (ptr != NULL) {
-      Vector_Get(v, v->top - 1, ptr);
+    if (v->top > 0) {
+        if (ptr != NULL) {
+            Vector_Get(v, v->top - 1, ptr);
+        }
+        v->top--;
+        return 1;
     }
-    v->top--;
-    return 1;
-  }
-  return 0;
+    return 0;
 }
 
 inline int __vector_PutPtr(Vector *v, size_t pos, void *elem) {
-  // resize if pos is out of bounds
-  if (pos >= v->cap) {
-    Vector_Resize(v, pos + 1);
-  }
+    // resize if pos is out of bounds
+    if (pos >= v->cap) {
+        Vector_Resize(v, pos + 1);
+    }
 
-  if (elem) {
-    memcpy(v->data + pos * v->elemSize, elem, v->elemSize);
-  } else {
-    memset(v->data + pos * v->elemSize, 0, v->elemSize);
-  }
-  // move the end offset to pos if we grew
-  if (pos >= v->top) {
-    v->top = pos + 1;
-  }
-  return 1;
+    if (elem) {
+        memcpy(v->data + pos * v->elemSize, elem, v->elemSize);
+    } else {
+        memset(v->data + pos * v->elemSize, 0, v->elemSize);
+    }
+    // move the end offset to pos if we grew
+    if (pos >= v->top) {
+        v->top = pos + 1;
+    }
+    return 1;
 }
 
 int Vector_Resize(Vector *v, size_t newcap) {
-  int oldcap = v->cap;
-  v->cap = newcap;
+    int oldcap = v->cap;
+    v->cap = newcap;
 
-  v->data = realloc(v->data, v->cap * v->elemSize);
+    v->data = realloc(v->data, v->cap * v->elemSize);
 
-  // If we grew:
-  // put all zeros at the newly realloc'd part of the vector
-  if (newcap > oldcap) {
-    int offset = oldcap * v->elemSize;
-    memset(v->data + offset, 0, v->cap * v->elemSize - offset);
-  }
-  return v->cap;
+    // If we grew:
+    // put all zeros at the newly realloc'd part of the vector
+    if (newcap > oldcap) {
+        int offset = oldcap * v->elemSize;
+        memset(v->data + offset, 0, v->cap * v->elemSize - offset);
+    }
+    return v->cap;
 }
 
 Vector *__newVectorSize(size_t elemSize, size_t cap) {
-  Vector *vec = malloc(sizeof(Vector));
-  vec->data = calloc(cap, elemSize);
-  vec->top = 0;
-  vec->elemSize = elemSize;
-  vec->cap = cap;
+    Vector *vec = malloc(sizeof(Vector));
+    vec->data = calloc(cap, elemSize);
+    vec->top = 0;
+    vec->elemSize = elemSize;
+    vec->cap = cap;
 
-  return vec;
+    return vec;
 }
 
 void Vector_Free(Vector *v) {
-  free(v->data);
-  free(v);
+    free(v->data);
+    free(v);
 }
 
 /* return the used size of the vector, regardless of capacity */
-inline int Vector_Size(Vector *v) {
-  return v->top;
-}
+inline int Vector_Size(Vector *v) { return v->top; }
 
 /* return the actual capacity */
-inline int Vector_Cap(Vector *v) {
-  return v->cap;
-}
+inline int Vector_Cap(Vector *v) { return v->cap; }

--- a/src/rmutil/vector.h
+++ b/src/rmutil/vector.h
@@ -13,10 +13,10 @@ extern "C" {
  * Works like C++ std::vector with an underlying resizable buffer
  */
 typedef struct {
-  char *data;
-  size_t elemSize;
-  size_t cap;
-  size_t top;
+    char *data;
+    size_t elemSize;
+    size_t cap;
+    size_t top;
 
 } Vector;
 

--- a/src/run_info.c
+++ b/src/run_info.c
@@ -16,39 +16,34 @@
 #include "util/arr_rm_alloc.h"
 #include "util/dict.h"
 
-
-static uint64_t RAI_TensorDictKeyHashFunction(const void *key){
-  return AI_dictGenHashFunction(key, strlen((char*)key));
+static uint64_t RAI_TensorDictKeyHashFunction(const void *key) {
+    return AI_dictGenHashFunction(key, strlen((char *)key));
 }
 
-static int RAI_TensorDictKeyStrcmp(void *privdata, const void *key1, const void *key2){
-  const char* strKey1 = key1;
-  const char* strKey2 = key2;
-  return strcmp(strKey1, strKey2) == 0;
+static int RAI_TensorDictKeyStrcmp(void *privdata, const void *key1, const void *key2) {
+    const char *strKey1 = key1;
+    const char *strKey2 = key2;
+    return strcmp(strKey1, strKey2) == 0;
 }
 
-static void RAI_TensorDictKeyFree(void *privdata, void *key){
-  RedisModule_Free(key);
+static void RAI_TensorDictKeyFree(void *privdata, void *key) { RedisModule_Free(key); }
+
+static void *RAI_TensorDictKeyDup(void *privdata, const void *key) {
+    return RedisModule_Strdup((char *)key);
 }
 
-static void* RAI_TensorDictKeyDup(void *privdata, const void *key){
-  return RedisModule_Strdup((char*)key);
+static void RAI_TensorDictValFree(void *privdata, void *obj) {
+    return RAI_TensorFree((RAI_Tensor *)obj);
 }
-
-static void RAI_TensorDictValFree(void *privdata, void *obj){
-  return RAI_TensorFree((RAI_Tensor*)obj);
-}
-
 
 AI_dictType AI_dictTypeTensorVals = {
-        .hashFunction = RAI_TensorDictKeyHashFunction,
-        .keyDup = RAI_TensorDictKeyDup,
-        .valDup = NULL,
-        .keyCompare = RAI_TensorDictKeyStrcmp,
-        .keyDestructor = RAI_TensorDictKeyFree,
-        .valDestructor = RAI_TensorDictValFree,
+    .hashFunction = RAI_TensorDictKeyHashFunction,
+    .keyDup = RAI_TensorDictKeyDup,
+    .valDup = NULL,
+    .keyCompare = RAI_TensorDictKeyStrcmp,
+    .keyDestructor = RAI_TensorDictKeyFree,
+    .valDestructor = RAI_TensorDictValFree,
 };
-
 
 /**
  * Allocate the memory and initialise the RAI_DagOp.
@@ -57,41 +52,41 @@ AI_dictType AI_dictTypeTensorVals = {
  * failed.
  */
 int RAI_InitDagOp(RAI_DagOp **result) {
-  RAI_DagOp *dagOp;
-  dagOp = (RAI_DagOp *)RedisModule_Calloc(1, sizeof(RAI_DagOp));
-  if (!dagOp) {
-    return REDISMODULE_ERR;
-  }
-  dagOp->commandType = REDISAI_DAG_CMD_NONE;
-  dagOp->runkey = NULL;
-  dagOp->inkeys = (RedisModuleString **)array_new(RedisModuleString *, 1);
-  if (!(dagOp->inkeys)) {
-    return REDISMODULE_ERR;
-  }
-  dagOp->outkeys = (RedisModuleString **)array_new(RedisModuleString *, 1);
-  if (!(dagOp->outkeys)) {
-    return REDISMODULE_ERR;
-  }
-  dagOp->outTensors = (RAI_Tensor **)array_new(RAI_Tensor *, 1);
-  if (!(dagOp->outTensors)) {
-    return REDISMODULE_ERR;
-  }
-  dagOp->mctx = NULL;
-  dagOp->sctx = NULL;
-  dagOp->devicestr = NULL;
-  dagOp->duration_us = 0;
-  dagOp->result = -1;
-  RAI_InitError(&dagOp->err);
-  if (!(dagOp->err)) {
-    return REDISMODULE_ERR;
-  }
-  dagOp->argv = (RedisModuleString **)array_new(RedisModuleString *, 1);
-  if (!(dagOp->argv)) {
-    return REDISMODULE_ERR;
-  }
-  dagOp->argc = 0;
-  *result = dagOp;
-  return REDISMODULE_OK;
+    RAI_DagOp *dagOp;
+    dagOp = (RAI_DagOp *)RedisModule_Calloc(1, sizeof(RAI_DagOp));
+    if (!dagOp) {
+        return REDISMODULE_ERR;
+    }
+    dagOp->commandType = REDISAI_DAG_CMD_NONE;
+    dagOp->runkey = NULL;
+    dagOp->inkeys = (RedisModuleString **)array_new(RedisModuleString *, 1);
+    if (!(dagOp->inkeys)) {
+        return REDISMODULE_ERR;
+    }
+    dagOp->outkeys = (RedisModuleString **)array_new(RedisModuleString *, 1);
+    if (!(dagOp->outkeys)) {
+        return REDISMODULE_ERR;
+    }
+    dagOp->outTensors = (RAI_Tensor **)array_new(RAI_Tensor *, 1);
+    if (!(dagOp->outTensors)) {
+        return REDISMODULE_ERR;
+    }
+    dagOp->mctx = NULL;
+    dagOp->sctx = NULL;
+    dagOp->devicestr = NULL;
+    dagOp->duration_us = 0;
+    dagOp->result = -1;
+    RAI_InitError(&dagOp->err);
+    if (!(dagOp->err)) {
+        return REDISMODULE_ERR;
+    }
+    dagOp->argv = (RedisModuleString **)array_new(RedisModuleString *, 1);
+    if (!(dagOp->argv)) {
+        return REDISMODULE_ERR;
+    }
+    dagOp->argc = 0;
+    *result = dagOp;
+    return REDISMODULE_OK;
 }
 
 /**
@@ -101,249 +96,247 @@ int RAI_InitDagOp(RAI_DagOp **result) {
  * failed.
  */
 int RAI_InitRunInfo(RedisAI_RunInfo **result) {
-  RedisAI_RunInfo *rinfo;
-  rinfo = (RedisAI_RunInfo *)RedisModule_Calloc(1, sizeof(RedisAI_RunInfo));
-  if (!rinfo) {
-    return REDISMODULE_ERR;
-  }
-  rinfo->dagTensorsContext = AI_dictCreate(&AI_dictTypeTensorVals, NULL);
-  if (!(rinfo->dagTensorsContext)) {
-    return REDISMODULE_ERR;
-  }
-  rinfo->dagTensorsLoadedContext = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
-  if (!(rinfo->dagTensorsLoadedContext)) {
-    return REDISMODULE_ERR;
-  }
-  rinfo->dagTensorsPersistedContext = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
-  if (!(rinfo->dagTensorsPersistedContext)) {
-    return REDISMODULE_ERR;
-  }
-  rinfo->dagOps = (RAI_DagOp **)array_new(RAI_DagOp *, 1);
-  if (!(rinfo->dagOps)) {
-    return REDISMODULE_ERR;
-  }
-  rinfo->dagDeviceOps = (RAI_DagOp **)array_new(RAI_DagOp *, 1);
-  if (!(rinfo->dagDeviceOps)) {
-    return REDISMODULE_ERR;
-  }
-  rinfo->dagError = RedisModule_Calloc(1, sizeof(int));
-  rinfo->dagLock = RedisModule_Alloc(sizeof(pthread_rwlock_t));
-  rinfo->dagRefCount = RedisModule_Calloc(1, sizeof(long long));
-  rinfo->dagOpCount = 0;
-  rinfo->dagCompleteOpCount = RedisModule_Calloc(1, sizeof(long long));
-  rinfo->dagDeviceOpCount = 0;
-  rinfo->dagDeviceCompleteOpCount = 0;
-  pthread_rwlock_init(rinfo->dagLock, NULL);
-  rinfo->master = 1;
-  rinfo->timedOut = RedisModule_Calloc(1, sizeof(int));
-  *result = rinfo;
-  return REDISMODULE_OK;
+    RedisAI_RunInfo *rinfo;
+    rinfo = (RedisAI_RunInfo *)RedisModule_Calloc(1, sizeof(RedisAI_RunInfo));
+    if (!rinfo) {
+        return REDISMODULE_ERR;
+    }
+    rinfo->dagTensorsContext = AI_dictCreate(&AI_dictTypeTensorVals, NULL);
+    if (!(rinfo->dagTensorsContext)) {
+        return REDISMODULE_ERR;
+    }
+    rinfo->dagTensorsLoadedContext = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
+    if (!(rinfo->dagTensorsLoadedContext)) {
+        return REDISMODULE_ERR;
+    }
+    rinfo->dagTensorsPersistedContext = AI_dictCreate(&AI_dictTypeHeapStrings, NULL);
+    if (!(rinfo->dagTensorsPersistedContext)) {
+        return REDISMODULE_ERR;
+    }
+    rinfo->dagOps = (RAI_DagOp **)array_new(RAI_DagOp *, 1);
+    if (!(rinfo->dagOps)) {
+        return REDISMODULE_ERR;
+    }
+    rinfo->dagDeviceOps = (RAI_DagOp **)array_new(RAI_DagOp *, 1);
+    if (!(rinfo->dagDeviceOps)) {
+        return REDISMODULE_ERR;
+    }
+    rinfo->dagError = RedisModule_Calloc(1, sizeof(int));
+    rinfo->dagLock = RedisModule_Alloc(sizeof(pthread_rwlock_t));
+    rinfo->dagRefCount = RedisModule_Calloc(1, sizeof(long long));
+    rinfo->dagOpCount = 0;
+    rinfo->dagCompleteOpCount = RedisModule_Calloc(1, sizeof(long long));
+    rinfo->dagDeviceOpCount = 0;
+    rinfo->dagDeviceCompleteOpCount = 0;
+    pthread_rwlock_init(rinfo->dagLock, NULL);
+    rinfo->master = 1;
+    rinfo->timedOut = RedisModule_Calloc(1, sizeof(int));
+    *result = rinfo;
+    return REDISMODULE_OK;
 }
 
 int RAI_ShallowCopyDagRunInfo(RedisAI_RunInfo **result, RedisAI_RunInfo *src) {
-  RedisAI_RunInfo *rinfo;
-  rinfo = (RedisAI_RunInfo *)RedisModule_Calloc(1, sizeof(RedisAI_RunInfo));
-  if (!rinfo) {
-    return REDISMODULE_ERR;
-  }
-  memcpy(rinfo, src, sizeof(RedisAI_RunInfo));
-  rinfo->dagDeviceOps = (RAI_DagOp **)array_new(RAI_DagOp *, 1);
-  if (!(rinfo->dagDeviceOps)) {
-    return REDISMODULE_ERR;
-  }
-  rinfo->dagDeviceOpCount = 0;
-  rinfo->dagDeviceCompleteOpCount = 0;
-  rinfo->master = 0;
-  *result = rinfo;
-  return REDISMODULE_OK;
+    RedisAI_RunInfo *rinfo;
+    rinfo = (RedisAI_RunInfo *)RedisModule_Calloc(1, sizeof(RedisAI_RunInfo));
+    if (!rinfo) {
+        return REDISMODULE_ERR;
+    }
+    memcpy(rinfo, src, sizeof(RedisAI_RunInfo));
+    rinfo->dagDeviceOps = (RAI_DagOp **)array_new(RAI_DagOp *, 1);
+    if (!(rinfo->dagDeviceOps)) {
+        return REDISMODULE_ERR;
+    }
+    rinfo->dagDeviceOpCount = 0;
+    rinfo->dagDeviceCompleteOpCount = 0;
+    rinfo->master = 0;
+    *result = rinfo;
+    return REDISMODULE_OK;
 }
 
 void RAI_FreeDagOp(RedisModuleCtx *ctx, RAI_DagOp *dagOp) {
-  if (dagOp) {
-    RAI_FreeError(dagOp->err);
-    if(dagOp->runkey){
-      RedisModule_FreeString(ctx,dagOp->runkey);
-    }
-    if (dagOp->argv) {
-      for (size_t i = 0; i < array_len(dagOp->argv); i++) {
-        RedisModule_FreeString(ctx, dagOp->argv[i]);
-      }
-      array_free(dagOp->argv);
-    }
-    // dagOp->inkeys is released on all argv release above
-    // dagOp->outkeys is released on all argv release above
-    // dagOp->outTensors is released on RunInfo after checking what tensors to
-    // persist
-    for (size_t i = 0; i < array_len(dagOp->outTensors); i++) {
-      RAI_TensorFree(dagOp->outTensors[i]);
-    }
-    array_free(dagOp->outTensors);
+    if (dagOp) {
+        RAI_FreeError(dagOp->err);
+        if (dagOp->runkey) {
+            RedisModule_FreeString(ctx, dagOp->runkey);
+        }
+        if (dagOp->argv) {
+            for (size_t i = 0; i < array_len(dagOp->argv); i++) {
+                RedisModule_FreeString(ctx, dagOp->argv[i]);
+            }
+            array_free(dagOp->argv);
+        }
+        // dagOp->inkeys is released on all argv release above
+        // dagOp->outkeys is released on all argv release above
+        // dagOp->outTensors is released on RunInfo after checking what tensors to
+        // persist
+        for (size_t i = 0; i < array_len(dagOp->outTensors); i++) {
+            RAI_TensorFree(dagOp->outTensors[i]);
+        }
+        array_free(dagOp->outTensors);
 
-    if (dagOp->mctx) {
-      RAI_ModelRunCtxFree(dagOp->mctx, true);
-    }
-    if (dagOp->sctx) {
-      RAI_ScriptRunCtxFree(dagOp->sctx, true);
-    }
+        if (dagOp->mctx) {
+            RAI_ModelRunCtxFree(dagOp->mctx, true);
+        }
+        if (dagOp->sctx) {
+            RAI_ScriptRunCtxFree(dagOp->sctx, true);
+        }
 
-    if (dagOp->inkeys) {
-      for (size_t i=0; i<array_len(dagOp->inkeys); i++) {
-        RedisModule_FreeString(ctx,dagOp->inkeys[i]);
-      }
-      array_free(dagOp->inkeys);
-    }
+        if (dagOp->inkeys) {
+            for (size_t i = 0; i < array_len(dagOp->inkeys); i++) {
+                RedisModule_FreeString(ctx, dagOp->inkeys[i]);
+            }
+            array_free(dagOp->inkeys);
+        }
 
-    if (dagOp->outkeys) {
-      for (size_t i=0; i<array_len(dagOp->outkeys); i++) {
-        RedisModule_FreeString(ctx,dagOp->outkeys[i]);
-      }
-      array_free(dagOp->outkeys);
-    }
+        if (dagOp->outkeys) {
+            for (size_t i = 0; i < array_len(dagOp->outkeys); i++) {
+                RedisModule_FreeString(ctx, dagOp->outkeys[i]);
+            }
+            array_free(dagOp->outkeys);
+        }
 
-    RedisModule_Free(dagOp);
-  }
+        RedisModule_Free(dagOp);
+    }
 }
 
 void RAI_FreeRunInfo(RedisModuleCtx *ctx, struct RedisAI_RunInfo *rinfo) {
-  if (!rinfo) {
-    return;
-  }
-  if (rinfo->master == 0) {
+    if (!rinfo) {
+        return;
+    }
+    if (rinfo->master == 0) {
+        if (rinfo->dagDeviceOps) {
+            array_free(rinfo->dagDeviceOps);
+        }
+        RedisModule_Free(rinfo);
+        return;
+    } else {
+        pthread_rwlock_destroy(rinfo->dagLock);
+        RedisModule_Free(rinfo->dagLock);
+    }
+
+    if (rinfo->dagTensorsContext) {
+        AI_dictRelease(rinfo->dagTensorsContext);
+        AI_dictRelease(rinfo->dagTensorsLoadedContext);
+        AI_dictRelease(rinfo->dagTensorsPersistedContext);
+    }
+
+    if (rinfo->dagOps) {
+        for (size_t i = 0; i < array_len(rinfo->dagOps); i++) {
+            RAI_FreeDagOp(ctx, rinfo->dagOps[i]);
+        }
+        array_free(rinfo->dagOps);
+    }
+
     if (rinfo->dagDeviceOps) {
-      array_free(rinfo->dagDeviceOps);
+        array_free(rinfo->dagDeviceOps);
     }
+
+    if (rinfo->dagError) {
+        RedisModule_Free(rinfo->dagError);
+    }
+
+    RedisModule_Free(rinfo->dagRefCount);
+    RedisModule_Free(rinfo->dagCompleteOpCount);
+    RedisModule_Free(rinfo->timedOut);
+
     RedisModule_Free(rinfo);
-    return;
-  }
-  else {
-    pthread_rwlock_destroy(rinfo->dagLock);
-    RedisModule_Free(rinfo->dagLock);
-  }
-
-  if (rinfo->dagTensorsContext) {
-    AI_dictRelease(rinfo->dagTensorsContext);
-    AI_dictRelease(rinfo->dagTensorsLoadedContext);
-    AI_dictRelease(rinfo->dagTensorsPersistedContext);
-  }
-
-  if (rinfo->dagOps) {
-    for (size_t i = 0; i < array_len(rinfo->dagOps); i++) {
-      RAI_FreeDagOp(ctx, rinfo->dagOps[i]);
-    }
-    array_free(rinfo->dagOps);
-  }
-
-  if (rinfo->dagDeviceOps) {
-    array_free(rinfo->dagDeviceOps);
-  }
-
-  if (rinfo->dagError) {
-    RedisModule_Free(rinfo->dagError);
-  }
-
-  RedisModule_Free(rinfo->dagRefCount);
-  RedisModule_Free(rinfo->dagCompleteOpCount);
-  RedisModule_Free(rinfo->timedOut);
-
-  RedisModule_Free(rinfo);
 }
 
 void RAI_ContextReadLock(RedisAI_RunInfo *rinfo) {
-  if (rinfo->single_op_dag || rinfo->single_device_dag) {
-    return;
-  }
-  pthread_rwlock_rdlock(rinfo->dagLock);
+    if (rinfo->single_op_dag || rinfo->single_device_dag) {
+        return;
+    }
+    pthread_rwlock_rdlock(rinfo->dagLock);
 }
 
 void RAI_ContextWriteLock(RedisAI_RunInfo *rinfo) {
-  if (rinfo->single_op_dag || rinfo->single_device_dag) {
-    return;
-  }
-  pthread_rwlock_wrlock(rinfo->dagLock);
+    if (rinfo->single_op_dag || rinfo->single_device_dag) {
+        return;
+    }
+    pthread_rwlock_wrlock(rinfo->dagLock);
 }
 
 void RAI_ContextUnlock(RedisAI_RunInfo *rinfo) {
-  if (rinfo->single_op_dag || rinfo->single_device_dag) {
-    return;
-  }
-  pthread_rwlock_unlock(rinfo->dagLock);
+    if (rinfo->single_op_dag || rinfo->single_device_dag) {
+        return;
+    }
+    pthread_rwlock_unlock(rinfo->dagLock);
 }
 
 size_t RAI_RunInfoBatchSize(struct RAI_DagOp *op) {
-  if (op->mctx == NULL) {
-    return -1;
-  }
+    if (op->mctx == NULL) {
+        return -1;
+    }
 
-  size_t ninputs = RAI_ModelRunCtxNumInputs(op->mctx);
+    size_t ninputs = RAI_ModelRunCtxNumInputs(op->mctx);
 
-  int batchsize = 0;
+    int batchsize = 0;
 
-  if (ninputs == 0) {
+    if (ninputs == 0) {
+        return batchsize;
+    }
+
+    for (size_t i = 0; i < ninputs; i++) {
+        RAI_Tensor *input = RAI_ModelRunCtxInputTensor(op->mctx, i);
+
+        if (i == 0) {
+            batchsize = RAI_TensorDim(input, 0);
+            continue;
+        }
+
+        if (batchsize != RAI_TensorDim(input, 0)) {
+            batchsize = 0;
+            break;
+        }
+    }
+
     return batchsize;
-  }
-
-  for (size_t i = 0; i < ninputs; i++) {
-    RAI_Tensor *input = RAI_ModelRunCtxInputTensor(op->mctx, i);
-
-    if (i == 0) {
-      batchsize = RAI_TensorDim(input, 0);
-      continue;
-    }
-
-    if (batchsize != RAI_TensorDim(input, 0)) {
-      batchsize = 0;
-      break;
-    }
-  }
-
-  return batchsize;
 }
 
-int RAI_RunInfoBatchable(struct RAI_DagOp *op1,
-                         struct RAI_DagOp *op2) {
+int RAI_RunInfoBatchable(struct RAI_DagOp *op1, struct RAI_DagOp *op2) {
 
-  if (op1->mctx == NULL || op2->mctx == NULL) {
-    return 0;
-  }
-
-  if (op1->mctx->model != op2->mctx->model) {
-    return 0;
-  }
-
-  const int ninputs1 = RAI_ModelRunCtxNumInputs(op1->mctx);
-  const int ninputs2 = RAI_ModelRunCtxNumInputs(op2->mctx);
-
-  if (ninputs1 != ninputs2) {
-    return 0;
-  }
-
-  for (int i = 0; i < ninputs1; i++) {
-    RAI_Tensor *input1 = RAI_ModelRunCtxInputTensor(op1->mctx, i);
-    RAI_Tensor *input2 = RAI_ModelRunCtxInputTensor(op2->mctx, i);
-
-    int ndims1 = RAI_TensorNumDims(input1);
-    int ndims2 = RAI_TensorNumDims(input2);
-
-    if (!RAI_TensorIsDataTypeEqual(input1, input2)) {
-      return 0;
-    }
-
-    if (ndims1 != ndims2) {
-      return 0;
-    }
-
-    if (ndims1 == 0) {
-      continue;
-    }
-
-    for (int j = 1; j < ndims1; j++) {
-      int dim1 = RAI_TensorDim(input1, j);
-      int dim2 = RAI_TensorDim(input2, j);
-      if (dim1 != dim2) {
+    if (op1->mctx == NULL || op2->mctx == NULL) {
         return 0;
-      }
     }
-  }
 
-  return 1;
+    if (op1->mctx->model != op2->mctx->model) {
+        return 0;
+    }
+
+    const int ninputs1 = RAI_ModelRunCtxNumInputs(op1->mctx);
+    const int ninputs2 = RAI_ModelRunCtxNumInputs(op2->mctx);
+
+    if (ninputs1 != ninputs2) {
+        return 0;
+    }
+
+    for (int i = 0; i < ninputs1; i++) {
+        RAI_Tensor *input1 = RAI_ModelRunCtxInputTensor(op1->mctx, i);
+        RAI_Tensor *input2 = RAI_ModelRunCtxInputTensor(op2->mctx, i);
+
+        int ndims1 = RAI_TensorNumDims(input1);
+        int ndims2 = RAI_TensorNumDims(input2);
+
+        if (!RAI_TensorIsDataTypeEqual(input1, input2)) {
+            return 0;
+        }
+
+        if (ndims1 != ndims2) {
+            return 0;
+        }
+
+        if (ndims1 == 0) {
+            continue;
+        }
+
+        for (int j = 1; j < ndims1; j++) {
+            int dim1 = RAI_TensorDim(input1, j);
+            int dim2 = RAI_TensorDim(input2, j);
+            if (dim1 != dim2) {
+                return 0;
+            }
+        }
+    }
+
+    return 1;
 }

--- a/src/run_info.h
+++ b/src/run_info.h
@@ -19,32 +19,29 @@
 #include "util/dict.h"
 
 enum RedisAI_DAGCommands {
-  REDISAI_DAG_CMD_NONE = 0,
-  REDISAI_DAG_CMD_TENSORSET,
-  REDISAI_DAG_CMD_TENSORGET,
-  REDISAI_DAG_CMD_MODELRUN,
-  REDISAI_DAG_CMD_SCRIPTRUN
+    REDISAI_DAG_CMD_NONE = 0,
+    REDISAI_DAG_CMD_TENSORSET,
+    REDISAI_DAG_CMD_TENSORGET,
+    REDISAI_DAG_CMD_MODELRUN,
+    REDISAI_DAG_CMD_SCRIPTRUN
 };
 
-enum RedisAI_DAGMode {
-    REDISAI_DAG_READONLY_MODE = 0,
-    REDISAI_DAG_WRITE_MODE
-};
+enum RedisAI_DAGMode { REDISAI_DAG_READONLY_MODE = 0, REDISAI_DAG_WRITE_MODE };
 
 typedef struct RAI_DagOp {
-  int commandType;
-  RedisModuleString *runkey;
-  RedisModuleString **inkeys;
-  RedisModuleString **outkeys;
-  RAI_Tensor **outTensors;
-  RAI_ModelRunCtx *mctx;
-  RAI_ScriptRunCtx *sctx;
-  char* devicestr;
-  int result;  // REDISMODULE_OK or REDISMODULE_ERR
-  long long duration_us;
-  RAI_Error *err;
-  RedisModuleString **argv;
-  int argc;
+    int commandType;
+    RedisModuleString *runkey;
+    RedisModuleString **inkeys;
+    RedisModuleString **outkeys;
+    RAI_Tensor **outTensors;
+    RAI_ModelRunCtx *mctx;
+    RAI_ScriptRunCtx *sctx;
+    char *devicestr;
+    int result; // REDISMODULE_OK or REDISMODULE_ERR
+    long long duration_us;
+    RAI_Error *err;
+    RedisModuleString **argv;
+    int argc;
 } RAI_DagOp;
 
 /**
@@ -70,30 +67,31 @@ void RAI_FreeDagOp(RedisModuleCtx *ctx, RAI_DagOp *dagOp);
  * but only the fields needed in a given operation.
  */
 typedef struct RedisAI_RunInfo {
-  RedisModuleBlockedClient *client;
-  int single_op_dag;
-  int single_device_dag;
-  AI_dict *dagTensorsContext;
-  AI_dict *dagTensorsPersistedContext;  // dict to flag tensors to persist
-  AI_dict *dagTensorsLoadedContext;  // dict to flag tensors loaded from the keyspace
-  RAI_DagOp **dagOps; // all ops in DAG
-  RAI_DagOp **dagDeviceOps; // all ops in DAG for device
-  int dagReplyLength;
-  int dagOpCount; // number of ops in DAG
-  int *dagCompleteOpCount; // number of completed ops in DAG
-  int dagDeviceOpCount; // number of ops in DAG for device
-  int dagDeviceCompleteOpCount; // number of completed ops in DAG for device
-  // Pointer to integer signaling whether an error occurred anywhere in the DAG.
-  // This is shared across shallow copies in device queues.
-  int *dagError;
-  // Pointer to mutex used to exclusively access DagOps from multiple worker threads.
-  pthread_rwlock_t *dagLock;
-  // Pointer to ref count in DAG, shared across multiple worker thread
-  long long *dagRefCount;
-  int master;
-  long long timeout;
-  int *timedOut;
-  struct timeval queuingTime;
+    RedisModuleBlockedClient *client;
+    int single_op_dag;
+    int single_device_dag;
+    AI_dict *dagTensorsContext;
+    AI_dict *dagTensorsPersistedContext; // dict to flag tensors to persist
+    AI_dict *dagTensorsLoadedContext;    // dict to flag tensors loaded from the keyspace
+    RAI_DagOp **dagOps;                  // all ops in DAG
+    RAI_DagOp **dagDeviceOps;            // all ops in DAG for device
+    int dagReplyLength;
+    int dagOpCount;               // number of ops in DAG
+    int *dagCompleteOpCount;      // number of completed ops in DAG
+    int dagDeviceOpCount;         // number of ops in DAG for device
+    int dagDeviceCompleteOpCount; // number of completed ops in DAG for device
+    // Pointer to integer signaling whether an error occurred anywhere in the DAG.
+    // This is shared across shallow copies in device queues.
+    int *dagError;
+    // Pointer to mutex used to exclusively access DagOps from multiple worker
+    // threads.
+    pthread_rwlock_t *dagLock;
+    // Pointer to ref count in DAG, shared across multiple worker thread
+    long long *dagRefCount;
+    int master;
+    long long timeout;
+    int *timedOut;
+    struct timeval queuingTime;
 } RedisAI_RunInfo;
 
 /**
@@ -105,7 +103,7 @@ typedef struct RedisAI_RunInfo {
 int RAI_InitRunInfo(RedisAI_RunInfo **result);
 
 int RAI_ShallowCopyDagRunInfo(RedisAI_RunInfo **result, RedisAI_RunInfo *src);
- 
+
 /**
  * Frees the memory allocated on RedisAI_RunInfo
  * @param ctx Context in which Redis modules operate
@@ -150,7 +148,6 @@ size_t RAI_RunInfoBatchSize(struct RAI_DagOp *op);
  * @param op2 second DAG operation
  * @return 1 if batchable, 0 otherwise
  */
-int RAI_RunInfoBatchable(struct RAI_DagOp *op1,
-                         struct RAI_DagOp *op2);
+int RAI_RunInfoBatchable(struct RAI_DagOp *op1, struct RAI_DagOp *op2);
 
 #endif /* SRC_RUN_INFO_H_ */

--- a/src/script.c
+++ b/src/script.c
@@ -13,347 +13,337 @@
 #include "script_struct.h"
 #include "stats.h"
 #include "util/arr_rm_alloc.h"
-#include <pthread.h>
 #include "version.h"
+#include <pthread.h>
 
-RedisModuleType* RedisAI_ScriptType = NULL;
+RedisModuleType *RedisAI_ScriptType = NULL;
 
-static void* RAI_Script_RdbLoad(struct RedisModuleIO* io, int encver) {
-  // if (encver != RAI_ENC_VER) {
-  //   /* We should actually log an error here, or try to implement
-  //      the ability to load older versions of our data structure. */
-  //   return NULL;
-  // }
+static void *RAI_Script_RdbLoad(struct RedisModuleIO *io, int encver) {
+    // if (encver != RAI_ENC_VER) {
+    //   /* We should actually log an error here, or try to implement
+    //      the ability to load older versions of our data structure. */
+    //   return NULL;
+    // }
 
-  RAI_Error err = {0};
+    RAI_Error err = {0};
 
-  const char* devicestr = RedisModule_LoadStringBuffer(io, NULL);
-  const char* tag = RedisModule_LoadStringBuffer(io, NULL);
+    const char *devicestr = RedisModule_LoadStringBuffer(io, NULL);
+    const char *tag = RedisModule_LoadStringBuffer(io, NULL);
 
-  size_t len;
-  char* scriptdef = RedisModule_LoadStringBuffer(io, &len);
+    size_t len;
+    char *scriptdef = RedisModule_LoadStringBuffer(io, &len);
 
-  RAI_Script* script = RAI_ScriptCreate(devicestr, tag, scriptdef, &err);
+    RAI_Script *script = RAI_ScriptCreate(devicestr, tag, scriptdef, &err);
 
-  if (err.code == RAI_EBACKENDNOTLOADED) {
-    RedisModuleCtx* ctx = RedisModule_GetContextFromIO(io);
-    int ret = RAI_LoadDefaultBackend(ctx, RAI_BACKEND_TORCH);
-    if (ret == REDISMODULE_ERR) {
-      RedisModule_Log(ctx, "error", "Could not load default TORCH backend\n");
-      RAI_ClearError(&err);
-      return NULL;
+    if (err.code == RAI_EBACKENDNOTLOADED) {
+        RedisModuleCtx *ctx = RedisModule_GetContextFromIO(io);
+        int ret = RAI_LoadDefaultBackend(ctx, RAI_BACKEND_TORCH);
+        if (ret == REDISMODULE_ERR) {
+            RedisModule_Log(ctx, "error", "Could not load default TORCH backend\n");
+            RAI_ClearError(&err);
+            return NULL;
+        }
+        RAI_ClearError(&err);
+        script = RAI_ScriptCreate(devicestr, tag, scriptdef, &err);
     }
-    RAI_ClearError(&err);
-    script = RAI_ScriptCreate(devicestr, tag, scriptdef, &err);
-  }
 
-  RedisModule_Free(scriptdef);
+    RedisModule_Free(scriptdef);
 
-  if (err.code != RAI_OK) {
-    printf("ERR: %s\n", err.detail);
-    RAI_ClearError(&err);
-  }
+    if (err.code != RAI_OK) {
+        printf("ERR: %s\n", err.detail);
+        RAI_ClearError(&err);
+    }
 
-  RedisModuleCtx* stats_ctx = RedisModule_GetContextFromIO(io);
-  RedisModuleString* stats_keystr = RedisModule_CreateStringFromString(
-      stats_ctx, RedisModule_GetKeyNameFromIO(io));
-  const char* stats_devicestr = RedisModule_Strdup(devicestr);
-  const char* stats_tag = RedisModule_Strdup(tag);
+    RedisModuleCtx *stats_ctx = RedisModule_GetContextFromIO(io);
+    RedisModuleString *stats_keystr =
+        RedisModule_CreateStringFromString(stats_ctx, RedisModule_GetKeyNameFromIO(io));
+    const char *stats_devicestr = RedisModule_Strdup(devicestr);
+    const char *stats_tag = RedisModule_Strdup(tag);
 
-  script->infokey =
-      RAI_AddStatsEntry(stats_ctx, stats_keystr, RAI_SCRIPT, RAI_BACKEND_TORCH,
-                        stats_devicestr, stats_tag);
+    script->infokey = RAI_AddStatsEntry(stats_ctx, stats_keystr, RAI_SCRIPT, RAI_BACKEND_TORCH,
+                                        stats_devicestr, stats_tag);
 
-  RedisModule_Free(stats_keystr);
+    RedisModule_Free(stats_keystr);
 
-  return script;
+    return script;
 }
 
-static void RAI_Script_RdbSave(RedisModuleIO* io, void* value) {
-  RAI_Script* script = (RAI_Script*)value;
+static void RAI_Script_RdbSave(RedisModuleIO *io, void *value) {
+    RAI_Script *script = (RAI_Script *)value;
 
-  size_t len = strlen(script->scriptdef) + 1;
+    size_t len = strlen(script->scriptdef) + 1;
 
-  RedisModule_SaveStringBuffer(io, script->devicestr,
-                               strlen(script->devicestr) + 1);
-  RedisModule_SaveStringBuffer(io, script->tag, strlen(script->tag) + 1);
-  RedisModule_SaveStringBuffer(io, script->scriptdef, len);
+    RedisModule_SaveStringBuffer(io, script->devicestr, strlen(script->devicestr) + 1);
+    RedisModule_SaveStringBuffer(io, script->tag, strlen(script->tag) + 1);
+    RedisModule_SaveStringBuffer(io, script->scriptdef, len);
 }
 
-static void RAI_Script_AofRewrite(RedisModuleIO* aof, RedisModuleString* key,
-                                  void* value) {
-  RAI_Script* script = (RAI_Script*)value;
+static void RAI_Script_AofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *value) {
+    RAI_Script *script = (RAI_Script *)value;
 
-  RedisModule_EmitAOF(aof, "AI.SCRIPTSET", "scccc", key, script->devicestr,
-                      script->tag, "SOURCE", script->scriptdef);
+    RedisModule_EmitAOF(aof, "AI.SCRIPTSET", "scccc", key, script->devicestr, script->tag, "SOURCE",
+                        script->scriptdef);
 }
 
-static void RAI_Script_DTFree(void* value) {
-  RAI_Error err = {0};
-  RAI_ScriptFree(value, &err);
-  if (err.code != RAI_OK) {
-    printf("ERR: %s\n", err.detail);
-    RAI_ClearError(&err);
-  }
+static void RAI_Script_DTFree(void *value) {
+    RAI_Error err = {0};
+    RAI_ScriptFree(value, &err);
+    if (err.code != RAI_OK) {
+        printf("ERR: %s\n", err.detail);
+        RAI_ClearError(&err);
+    }
 }
 
-int RAI_ScriptInit(RedisModuleCtx* ctx) {
-  RedisModuleTypeMethods tmScript = {.version = REDISMODULE_TYPE_METHOD_VERSION,
-                                     .rdb_load = RAI_Script_RdbLoad,
-                                     .rdb_save = RAI_Script_RdbSave,
-                                     .aof_rewrite = RAI_Script_AofRewrite,
-                                     .mem_usage = NULL,
-                                     .free = RAI_Script_DTFree,
-                                     .digest = NULL};
+int RAI_ScriptInit(RedisModuleCtx *ctx) {
+    RedisModuleTypeMethods tmScript = {.version = REDISMODULE_TYPE_METHOD_VERSION,
+                                       .rdb_load = RAI_Script_RdbLoad,
+                                       .rdb_save = RAI_Script_RdbSave,
+                                       .aof_rewrite = RAI_Script_AofRewrite,
+                                       .mem_usage = NULL,
+                                       .free = RAI_Script_DTFree,
+                                       .digest = NULL};
 
-  RedisAI_ScriptType =
-      RedisModule_CreateDataType(ctx, "AI_SCRIPT", RAI_ENC_VER_MM, &tmScript);
-  return RedisAI_ScriptType != NULL;
+    RedisAI_ScriptType = RedisModule_CreateDataType(ctx, "AI_SCRIPT", RAI_ENC_VER_MM, &tmScript);
+    return RedisAI_ScriptType != NULL;
 }
 
-RAI_Script* RAI_ScriptCreate(const char* devicestr, const char* tag,
-                             const char* scriptdef, RAI_Error* err) {
-  if (!RAI_backends.torch.script_create) {
-    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
-    return NULL;
-  }
-  RAI_Script* script =
-      RAI_backends.torch.script_create(devicestr, scriptdef, err);
+RAI_Script *RAI_ScriptCreate(const char *devicestr, const char *tag, const char *scriptdef,
+                             RAI_Error *err) {
+    if (!RAI_backends.torch.script_create) {
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
+        return NULL;
+    }
+    RAI_Script *script = RAI_backends.torch.script_create(devicestr, scriptdef, err);
 
-  if (script) {
-    script->tag = RedisModule_Strdup(tag);
-  }
+    if (script) {
+        script->tag = RedisModule_Strdup(tag);
+    }
 
-  return script;
+    return script;
 }
 
-void RAI_ScriptFree(RAI_Script* script, RAI_Error* err) {
-  if (__atomic_sub_fetch(&script->refCount, 1, __ATOMIC_RELAXED) > 0) {
-    return;
-  }
+void RAI_ScriptFree(RAI_Script *script, RAI_Error *err) {
+    if (__atomic_sub_fetch(&script->refCount, 1, __ATOMIC_RELAXED) > 0) {
+        return;
+    }
 
-  if (!RAI_backends.torch.script_free) {
-    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
-    return;
-  }
+    if (!RAI_backends.torch.script_free) {
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
+        return;
+    }
 
-  RedisModule_Free(script->tag);
+    RedisModule_Free(script->tag);
 
-  RAI_RemoveStatsEntry(script->infokey);
+    RAI_RemoveStatsEntry(script->infokey);
 
-  RAI_backends.torch.script_free(script, err);
+    RAI_backends.torch.script_free(script, err);
 }
 
-RAI_ScriptRunCtx* RAI_ScriptRunCtxCreate(RAI_Script* script,
-                                         const char* fnname) {
+RAI_ScriptRunCtx *RAI_ScriptRunCtxCreate(RAI_Script *script, const char *fnname) {
 #define PARAM_INITIAL_SIZE 10
-  RAI_ScriptRunCtx* sctx = RedisModule_Calloc(1, sizeof(*sctx));
-  sctx->script = RAI_ScriptGetShallowCopy(script);
-  sctx->inputs = array_new(RAI_ScriptCtxParam, PARAM_INITIAL_SIZE);
-  sctx->outputs = array_new(RAI_ScriptCtxParam, PARAM_INITIAL_SIZE);
-  sctx->fnname = RedisModule_Strdup(fnname);
-  sctx->variadic = -1;
-  return sctx;
+    RAI_ScriptRunCtx *sctx = RedisModule_Calloc(1, sizeof(*sctx));
+    sctx->script = RAI_ScriptGetShallowCopy(script);
+    sctx->inputs = array_new(RAI_ScriptCtxParam, PARAM_INITIAL_SIZE);
+    sctx->outputs = array_new(RAI_ScriptCtxParam, PARAM_INITIAL_SIZE);
+    sctx->fnname = RedisModule_Strdup(fnname);
+    sctx->variadic = -1;
+    return sctx;
 }
 
-static int Script_RunCtxAddParam(RAI_ScriptRunCtx* sctx,
-                                 RAI_ScriptCtxParam** paramArr,
-                                 RAI_Tensor* tensor) {
-  RAI_ScriptCtxParam param = {
-      .tensor = tensor ? RAI_TensorGetShallowCopy(tensor) : NULL,
-  };
-  *paramArr = array_append(*paramArr, param);
-  return 1;
+static int Script_RunCtxAddParam(RAI_ScriptRunCtx *sctx, RAI_ScriptCtxParam **paramArr,
+                                 RAI_Tensor *tensor) {
+    RAI_ScriptCtxParam param = {
+        .tensor = tensor ? RAI_TensorGetShallowCopy(tensor) : NULL,
+    };
+    *paramArr = array_append(*paramArr, param);
+    return 1;
 }
 
-int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx* sctx, RAI_Tensor* inputTensor, RAI_Error* err) {
-  // Even if variadic is set, we still allow to add inputs in the LLAPI
-  return Script_RunCtxAddParam(sctx, &sctx->inputs, inputTensor);
+int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx *sctx, RAI_Tensor *inputTensor, RAI_Error *err) {
+    // Even if variadic is set, we still allow to add inputs in the LLAPI
+    return Script_RunCtxAddParam(sctx, &sctx->inputs, inputTensor);
 }
 
-int RAI_ScriptRunCtxAddInputList(RAI_ScriptRunCtx* sctx, RAI_Tensor** inputTensors, size_t len, RAI_Error* err) {
-  if (sctx->variadic == -1) {
-    sctx->variadic = array_len(sctx->inputs);
-  }
-  else {
-    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Already encountered a variable size list of tensors");
-    return 0;
-  }
-
-  int res;
-  for (size_t i=0; i < len; i++) {
-    res = Script_RunCtxAddParam(sctx, &sctx->inputs, inputTensors[i]);
-    if (res != 1) return res;
-  }
-  return 1;
-}
-
-int RAI_ScriptRunCtxAddOutput(RAI_ScriptRunCtx* sctx) {
-  return Script_RunCtxAddParam(sctx, &sctx->outputs, NULL);
-}
-
-size_t RAI_ScriptRunCtxNumOutputs(RAI_ScriptRunCtx* sctx) {
-  return array_len(sctx->outputs);
-}
-
-RAI_Tensor* RAI_ScriptRunCtxOutputTensor(RAI_ScriptRunCtx* sctx, size_t index) {
-  assert(RAI_ScriptRunCtxNumOutputs(sctx) > index && index >= 0);
-  return sctx->outputs[index].tensor;
-}
-
-void RAI_ScriptRunCtxFree(RAI_ScriptRunCtx* sctx, int freeTensors) {
-  if (freeTensors) {
-    for (size_t i = 0; i < array_len(sctx->inputs); ++i) {
-      RAI_TensorFree(sctx->inputs[i].tensor);
+int RAI_ScriptRunCtxAddInputList(RAI_ScriptRunCtx *sctx, RAI_Tensor **inputTensors, size_t len,
+                                 RAI_Error *err) {
+    if (sctx->variadic == -1) {
+        sctx->variadic = array_len(sctx->inputs);
+    } else {
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED,
+                     "ERR Already encountered a variable size list of tensors");
+        return 0;
     }
 
-    for (size_t i = 0; i < array_len(sctx->outputs); ++i) {
-      if (sctx->outputs[i].tensor) {
-        RAI_TensorFree(sctx->outputs[i].tensor);
-      }
+    int res;
+    for (size_t i = 0; i < len; i++) {
+        res = Script_RunCtxAddParam(sctx, &sctx->inputs, inputTensors[i]);
+        if (res != 1)
+            return res;
     }
-  }
-
-  array_free(sctx->inputs);
-  array_free(sctx->outputs);
-
-  RedisModule_Free(sctx->fnname);
-
-  RAI_Error err = {0};
-  RAI_ScriptFree(sctx->script, &err);
-
-  if (err.code != RAI_OK) {
-    // TODO: take it to client somehow
-    printf("ERR: %s\n", err.detail);
-    RAI_ClearError(&err);
-  }
-
-  RedisModule_Free(sctx);
+    return 1;
 }
 
-int RAI_ScriptRun(RAI_ScriptRunCtx* sctx, RAI_Error* err) {
-  if (!RAI_backends.torch.script_run) {
-    RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
-    return REDISMODULE_ERR;
-  }
-
-  return RAI_backends.torch.script_run(sctx, err);
+int RAI_ScriptRunCtxAddOutput(RAI_ScriptRunCtx *sctx) {
+    return Script_RunCtxAddParam(sctx, &sctx->outputs, NULL);
 }
 
-RAI_Script* RAI_ScriptGetShallowCopy(RAI_Script* script) {
-  __atomic_fetch_add(&script->refCount, 1, __ATOMIC_RELAXED);
-  return script;
+size_t RAI_ScriptRunCtxNumOutputs(RAI_ScriptRunCtx *sctx) { return array_len(sctx->outputs); }
+
+RAI_Tensor *RAI_ScriptRunCtxOutputTensor(RAI_ScriptRunCtx *sctx, size_t index) {
+    assert(RAI_ScriptRunCtxNumOutputs(sctx) > index && index >= 0);
+    return sctx->outputs[index].tensor;
+}
+
+void RAI_ScriptRunCtxFree(RAI_ScriptRunCtx *sctx, int freeTensors) {
+    if (freeTensors) {
+        for (size_t i = 0; i < array_len(sctx->inputs); ++i) {
+            RAI_TensorFree(sctx->inputs[i].tensor);
+        }
+
+        for (size_t i = 0; i < array_len(sctx->outputs); ++i) {
+            if (sctx->outputs[i].tensor) {
+                RAI_TensorFree(sctx->outputs[i].tensor);
+            }
+        }
+    }
+
+    array_free(sctx->inputs);
+    array_free(sctx->outputs);
+
+    RedisModule_Free(sctx->fnname);
+
+    RAI_Error err = {0};
+    RAI_ScriptFree(sctx->script, &err);
+
+    if (err.code != RAI_OK) {
+        // TODO: take it to client somehow
+        printf("ERR: %s\n", err.detail);
+        RAI_ClearError(&err);
+    }
+
+    RedisModule_Free(sctx);
+}
+
+int RAI_ScriptRun(RAI_ScriptRunCtx *sctx, RAI_Error *err) {
+    if (!RAI_backends.torch.script_run) {
+        RAI_SetError(err, RAI_EBACKENDNOTLOADED, "ERR Backend not loaded: TORCH");
+        return REDISMODULE_ERR;
+    }
+
+    return RAI_backends.torch.script_run(sctx, err);
+}
+
+RAI_Script *RAI_ScriptGetShallowCopy(RAI_Script *script) {
+    __atomic_fetch_add(&script->refCount, 1, __ATOMIC_RELAXED);
+    return script;
 }
 
 /* Return REDISMODULE_ERR if there was an error getting the Script.
  * Return REDISMODULE_OK if the model value stored at key was correctly
  * returned and available at *model variable. */
-int RAI_GetScriptFromKeyspace(RedisModuleCtx* ctx, RedisModuleString* keyName,
-                              RedisModuleKey** key, RAI_Script** script,
-                              int mode) {
-  *key = RedisModule_OpenKey(ctx, keyName, mode);
-  if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) {
-    RedisModule_CloseKey(*key);
-    RedisModule_ReplyWithError(ctx, "ERR script key is empty");
-    return REDISMODULE_ERR;
-  }
-  if (RedisModule_ModuleTypeGetType(*key) != RedisAI_ScriptType) {
-    RedisModule_CloseKey(*key);
-    RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-    return REDISMODULE_ERR;
-  }
-  *script = RedisModule_ModuleTypeGetValue(*key);
-  return REDISMODULE_OK;
+int RAI_GetScriptFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key,
+                              RAI_Script **script, int mode) {
+    *key = RedisModule_OpenKey(ctx, keyName, mode);
+    if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) {
+        RedisModule_CloseKey(*key);
+        RedisModule_ReplyWithError(ctx, "ERR script key is empty");
+        return REDISMODULE_ERR;
+    }
+    if (RedisModule_ModuleTypeGetType(*key) != RedisAI_ScriptType) {
+        RedisModule_CloseKey(*key);
+        RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        return REDISMODULE_ERR;
+    }
+    *script = RedisModule_ModuleTypeGetValue(*key);
+    return REDISMODULE_OK;
 }
 
 int RedisAI_ScriptRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
-                                                       RedisModuleString **argv, int argc){
-  RedisModule_KeyAtPos(ctx, 1);
-  size_t startpos = 3;
-  if (startpos >= argc) {
-    return REDISMODULE_ERR;
-  }
-  const char *str = RedisModule_StringPtrLen(argv[startpos], NULL);
-  if (!strcasecmp(str, "TIMEOUT")) {
-    startpos += 2;
-  }
-  startpos += 1;
-  if (startpos >= argc) {
-    return REDISMODULE_ERR;
-  }
-  for (size_t argpos = startpos; argpos < argc; argpos++){
-    str = RedisModule_StringPtrLen(argv[argpos], NULL);
-    if (!strcasecmp(str, "OUTPUTS")) {
-      continue;
+                                                       RedisModuleString **argv, int argc) {
+    RedisModule_KeyAtPos(ctx, 1);
+    size_t startpos = 3;
+    if (startpos >= argc) {
+        return REDISMODULE_ERR;
     }
-    RedisModule_KeyAtPos(ctx,argpos);
-  }
-  return REDISMODULE_OK;
+    const char *str = RedisModule_StringPtrLen(argv[startpos], NULL);
+    if (!strcasecmp(str, "TIMEOUT")) {
+        startpos += 2;
+    }
+    startpos += 1;
+    if (startpos >= argc) {
+        return REDISMODULE_ERR;
+    }
+    for (size_t argpos = startpos; argpos < argc; argpos++) {
+        str = RedisModule_StringPtrLen(argv[argpos], NULL);
+        if (!strcasecmp(str, "OUTPUTS")) {
+            continue;
+        }
+        RedisModule_KeyAtPos(ctx, argpos);
+    }
+    return REDISMODULE_OK;
 }
 
 /**
- * AI.SCRIPTRUN <key> <function> INPUTS <input> [input ...] OUTPUTS <output> [output ...]
+ * AI.SCRIPTRUN <key> <function> INPUTS <input> [input ...] OUTPUTS <output>
+ * [output ...]
  */
-int RedisAI_Parse_ScriptRun_RedisCommand(RedisModuleCtx *ctx,
-                                        RedisModuleString **argv, int argc,
-                                        RedisModuleString ***inkeys,
-                                        RedisModuleString ***outkeys,
-                                        int *variadic,
-                                        RAI_Error *error) {
-  if (argc < 6) {
-    RAI_SetError(error, RAI_ESCRIPTRUN, "ERR wrong number of arguments for 'AI.SCRIPTRUN' command");
-    return -1;
-  }
-
-  const char *inputstr = RedisModule_StringPtrLen(argv[2], NULL);
-  if (strcasecmp(inputstr, "INPUTS") == 0) {
-    RAI_SetError(error, RAI_ESCRIPTRUN, "ERR function name not specified");
-    return -1;
-  }
-
-  inputstr = RedisModule_StringPtrLen(argv[3], NULL);
-  if (strcasecmp(inputstr, "INPUTS")) {
-    RAI_SetError(error, RAI_ESCRIPTRUN, "ERR INPUTS not specified");
-    return -1;
-  }
-
-  // parsing aux vars
-  int is_output = 0;
-  int outputs_flag_count = 0;
-  int variadic_ = *variadic;
-  size_t argpos = 4;
-  for (; argpos <= argc - 1; argpos++) {
-    const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
-    if (!arg_string) {
-      RAI_SetError(error, RAI_ESCRIPTRUN, "ERR NULL argument on SCRIPTRUN");
-      return -1;
+int RedisAI_Parse_ScriptRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                                         RedisModuleString ***inkeys, RedisModuleString ***outkeys,
+                                         int *variadic, RAI_Error *error) {
+    if (argc < 6) {
+        RAI_SetError(error, RAI_ESCRIPTRUN,
+                     "ERR wrong number of arguments for 'AI.SCRIPTRUN' command");
+        return -1;
     }
-    if (!strcasecmp(arg_string, "OUTPUTS") && outputs_flag_count == 0) {
-      is_output = 1;
-      outputs_flag_count = 1;
-    } else {
-      if (!strcasecmp(arg_string, "$")) {
-        if (variadic_ > -1) {
-          RAI_SetError(error, RAI_ESCRIPTRUN, "ERR Already encountered a variable size list of tensors");
-          return -1;
+
+    const char *inputstr = RedisModule_StringPtrLen(argv[2], NULL);
+    if (strcasecmp(inputstr, "INPUTS") == 0) {
+        RAI_SetError(error, RAI_ESCRIPTRUN, "ERR function name not specified");
+        return -1;
+    }
+
+    inputstr = RedisModule_StringPtrLen(argv[3], NULL);
+    if (strcasecmp(inputstr, "INPUTS")) {
+        RAI_SetError(error, RAI_ESCRIPTRUN, "ERR INPUTS not specified");
+        return -1;
+    }
+
+    // parsing aux vars
+    int is_output = 0;
+    int outputs_flag_count = 0;
+    int variadic_ = *variadic;
+    size_t argpos = 4;
+    for (; argpos <= argc - 1; argpos++) {
+        const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
+        if (!arg_string) {
+            RAI_SetError(error, RAI_ESCRIPTRUN, "ERR NULL argument on SCRIPTRUN");
+            return -1;
         }
-        variadic_ = argpos - 4;
-        continue;
-      }
-      RedisModule_RetainString(ctx, argv[argpos]);
-      if (is_output == 0) {
-        *inkeys = array_append(*inkeys, argv[argpos]);
-      } else {
-        *outkeys = array_append(*outkeys, argv[argpos]);
-      }
+        if (!strcasecmp(arg_string, "OUTPUTS") && outputs_flag_count == 0) {
+            is_output = 1;
+            outputs_flag_count = 1;
+        } else {
+            if (!strcasecmp(arg_string, "$")) {
+                if (variadic_ > -1) {
+                    RAI_SetError(error, RAI_ESCRIPTRUN,
+                                 "ERR Already encountered a variable size list of tensors");
+                    return -1;
+                }
+                variadic_ = argpos - 4;
+                continue;
+            }
+            RedisModule_RetainString(ctx, argv[argpos]);
+            if (is_output == 0) {
+                *inkeys = array_append(*inkeys, argv[argpos]);
+            } else {
+                *outkeys = array_append(*outkeys, argv[argpos]);
+            }
+        }
     }
-  }
 
-  *variadic = variadic_;
+    *variadic = variadic_;
 
-  return argpos;
+    return argpos;
 }
 
-RedisModuleType *RAI_ScriptRedisType(void) {
-  return RedisAI_ScriptType;
-}
+RedisModuleType *RAI_ScriptRedisType(void) { return RedisAI_ScriptType; }

--- a/src/script.h
+++ b/src/script.h
@@ -15,7 +15,7 @@
 #include "script_struct.h"
 #include "tensor.h"
 
-extern RedisModuleType* RedisAI_ScriptType;
+extern RedisModuleType *RedisAI_ScriptType;
 
 /**
  * Helper method to register the script type exported by the module.
@@ -23,7 +23,7 @@ extern RedisModuleType* RedisAI_ScriptType;
  * @param ctx Context in which Redis modules operate
  * @return
  */
-int RAI_ScriptInit(RedisModuleCtx* ctx);
+int RAI_ScriptInit(RedisModuleCtx *ctx);
 
 /**
  * Helper method to allocated and initialize a RAI_Script. Relies on Pytorch
@@ -36,8 +36,8 @@ int RAI_ScriptInit(RedisModuleCtx* ctx);
  * failures
  * @return RAI_Script script structure on success, or NULL if failed
  */
-RAI_Script* RAI_ScriptCreate(const char* devicestr, const char* tag,
-                             const char* scriptdef, RAI_Error* err);
+RAI_Script *RAI_ScriptCreate(const char *devicestr, const char *tag, const char *scriptdef,
+                             RAI_Error *err);
 
 /**
  * Frees the memory of the RAI_Script when the script reference count reaches
@@ -47,7 +47,7 @@ RAI_Script* RAI_ScriptCreate(const char* devicestr, const char* tag,
  * @param error error data structure to store error message in the case of
  * failures
  */
-void RAI_ScriptFree(RAI_Script* script, RAI_Error* err);
+void RAI_ScriptFree(RAI_Script *script, RAI_Error *err);
 
 /**
  * Allocates the RAI_ScriptRunCtx data structure required for async background
@@ -57,8 +57,7 @@ void RAI_ScriptFree(RAI_Script* script, RAI_Error* err);
  * @param fnname function name to used from the script
  * @return RAI_ScriptRunCtx to be used within
  */
-RAI_ScriptRunCtx* RAI_ScriptRunCtxCreate(RAI_Script* script,
-                                         const char* fnname);
+RAI_ScriptRunCtx *RAI_ScriptRunCtxCreate(RAI_Script *script, const char *fnname);
 
 /**
  * Allocates a RAI_ScriptCtxParam data structure, and enforces a shallow copy of
@@ -71,12 +70,12 @@ RAI_ScriptRunCtx* RAI_ScriptRunCtxCreate(RAI_Script* script,
  * failures
  * @return returns 1 on success, 0 in case of error.
  */
-int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx* sctx, RAI_Tensor* inputTensor, RAI_Error* err);
+int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx *sctx, RAI_Tensor *inputTensor, RAI_Error *err);
 
 /**
- * For each Allocates a RAI_ScriptCtxParam data structure, and enforces a shallow copy of
- * the provided input tensor, adding it to the input tensors array of the
- * RAI_ScriptRunCtx.
+ * For each Allocates a RAI_ScriptCtxParam data structure, and enforces a
+ * shallow copy of the provided input tensor, adding it to the input tensors
+ * array of the RAI_ScriptRunCtx.
  *
  * @param sctx input RAI_ScriptRunCtx to add the input tensor
  * @param inputTensors input tensors array
@@ -85,7 +84,8 @@ int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx* sctx, RAI_Tensor* inputTensor, RA
  * failures
  * @return returns 1 on success, 0 in case of error.
  */
-int RAI_ScriptRunCtxAddInputList(RAI_ScriptRunCtx* sctx, RAI_Tensor** inputTensors, size_t len, RAI_Error* err);
+int RAI_ScriptRunCtxAddInputList(RAI_ScriptRunCtx *sctx, RAI_Tensor **inputTensors, size_t len,
+                                 RAI_Error *err);
 
 /**
  * Allocates a RAI_ScriptCtxParam data structure, and sets the tensor reference
@@ -95,7 +95,7 @@ int RAI_ScriptRunCtxAddInputList(RAI_ScriptRunCtx* sctx, RAI_Tensor** inputTenso
  * @param sctx input RAI_ScriptRunCtx to add the output tensor
  * @return returns 1 on success ( always returns success )
  */
-int RAI_ScriptRunCtxAddOutput(RAI_ScriptRunCtx* sctx);
+int RAI_ScriptRunCtxAddOutput(RAI_ScriptRunCtx *sctx);
 
 /**
  * Returns the total number of output tensors of the RAI_ScriptRunCtx
@@ -103,7 +103,7 @@ int RAI_ScriptRunCtxAddOutput(RAI_ScriptRunCtx* sctx);
  * @param sctx RAI_ScriptRunCtx
  * @return the total number of output tensors of the RAI_ScriptRunCtx
  */
-size_t RAI_ScriptRunCtxNumOutputs(RAI_ScriptRunCtx* sctx);
+size_t RAI_ScriptRunCtxNumOutputs(RAI_ScriptRunCtx *sctx);
 
 /**
  * Get the RAI_Tensor at the output array index position
@@ -112,7 +112,7 @@ size_t RAI_ScriptRunCtxNumOutputs(RAI_ScriptRunCtx* sctx);
  * @param index input array index position
  * @return RAI_Tensor
  */
-RAI_Tensor* RAI_ScriptRunCtxOutputTensor(RAI_ScriptRunCtx* sctx, size_t index);
+RAI_Tensor *RAI_ScriptRunCtxOutputTensor(RAI_ScriptRunCtx *sctx, size_t index);
 
 /**
  * Frees the RAI_ScriptRunCtx data structure used within for async background
@@ -121,7 +121,7 @@ RAI_Tensor* RAI_ScriptRunCtxOutputTensor(RAI_ScriptRunCtx* sctx, size_t index);
  * @param sctx
  * @param freeTensors free input and output tensors or leave them allocated
  */
-void RAI_ScriptRunCtxFree(RAI_ScriptRunCtx* sctx, int freeTensors);
+void RAI_ScriptRunCtxFree(RAI_ScriptRunCtx *sctx, int freeTensors);
 
 /**
  * Given the input script context, run associated script
@@ -135,7 +135,7 @@ void RAI_ScriptRunCtxFree(RAI_ScriptRunCtx* sctx, int freeTensors);
  * @return REDISMODULE_OK if the underlying backend `script_run` ran
  * successfully, or REDISMODULE_ERR if failed.
  */
-int RAI_ScriptRun(RAI_ScriptRunCtx* sctx, RAI_Error* err);
+int RAI_ScriptRun(RAI_ScriptRunCtx *sctx, RAI_Error *err);
 
 /**
  * Every call to this function, will make the RAI_Script 'script' requiring an
@@ -145,7 +145,7 @@ int RAI_ScriptRun(RAI_ScriptRunCtx* sctx, RAI_Error* err);
  * @param script input script
  * @return script
  */
-RAI_Script* RAI_ScriptGetShallowCopy(RAI_Script* script);
+RAI_Script *RAI_ScriptGetShallowCopy(RAI_Script *script);
 
 /* Return REDISMODULE_ERR if there was an error getting the Script.
  * Return REDISMODULE_OK if the model value stored at key was correctly
@@ -165,10 +165,8 @@ RAI_Script* RAI_ScriptGetShallowCopy(RAI_Script* script);
  * returned and available at *script variable, or REDISMODULE_ERR if there was
  * an error getting the Script
  */
-int RAI_GetScriptFromKeyspace(RedisModuleCtx* ctx, RedisModuleString* keyName,
-                              RedisModuleKey** key, RAI_Script** script,
-                              int mode);
-
+int RAI_GetScriptFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key,
+                              RAI_Script **script, int mode);
 
 /**
  * When a module command is called in order to obtain the position of
@@ -183,7 +181,7 @@ int RAI_GetScriptFromKeyspace(RedisModuleCtx* ctx, RedisModuleString* keyName,
  * @return
  */
 int RedisAI_ScriptRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
-                               RedisModuleString **argv, int argc);
+                                                       RedisModuleString **argv, int argc);
 
 /**
  * Helper method to parse AI.SCRIPTRUN arguments
@@ -198,13 +196,9 @@ int RedisAI_ScriptRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
  * parsing failures
  * @return processed number of arguments on success, or -1 if the parsing failed
  */
-int RedisAI_Parse_ScriptRun_RedisCommand(RedisModuleCtx *ctx,
-                                         RedisModuleString **argv, int argc,
-                                         RedisModuleString ***inkeys,
-                                         RedisModuleString ***outkeys,
-                                         int *variadic,
-                                         RAI_Error *error);
-
+int RedisAI_Parse_ScriptRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                                         RedisModuleString ***inkeys, RedisModuleString ***outkeys,
+                                         int *variadic, RAI_Error *error);
 
 #if 0
 /**

--- a/src/script_struct.h
+++ b/src/script_struct.h
@@ -5,29 +5,29 @@
 #include "tensor_struct.h"
 
 typedef struct RAI_Script {
-  void* script;
-  char* scriptdef;
-  // TODO: scripts do not have placement in PyTorch
-  // Placement depends on the inputs, as do outputs
-  // We keep it here at the moment, until we have a
-  // CUDA allocator for dlpack
-  char* devicestr;
-  char* tag;
-  long long refCount;
-  void* infokey;
+    void *script;
+    char *scriptdef;
+    // TODO: scripts do not have placement in PyTorch
+    // Placement depends on the inputs, as do outputs
+    // We keep it here at the moment, until we have a
+    // CUDA allocator for dlpack
+    char *devicestr;
+    char *tag;
+    long long refCount;
+    void *infokey;
 } RAI_Script;
 
 typedef struct RAI_ScriptCtxParam {
-  RAI_Tensor* tensor;
+    RAI_Tensor *tensor;
 } RAI_ScriptCtxParam;
 
 typedef struct RAI_ScriptRunCtx {
-  size_t ctxtype;
-  RAI_Script* script;
-  char* fnname;
-  RAI_ScriptCtxParam* inputs;
-  RAI_ScriptCtxParam* outputs;
-  int variadic;
+    size_t ctxtype;
+    RAI_Script *script;
+    char *fnname;
+    RAI_ScriptCtxParam *inputs;
+    RAI_ScriptCtxParam *outputs;
+    int variadic;
 } RAI_ScriptRunCtx;
 
 #endif /* SRC_SCRIPT_STRUCT_H_ */

--- a/src/stats.c
+++ b/src/stats.c
@@ -12,125 +12,123 @@
 #include <sys/time.h>
 
 long long ustime(void) {
-  struct timeval tv;
-  long long ust;
+    struct timeval tv;
+    long long ust;
 
-  gettimeofday(&tv, NULL);
-  ust = ((long long)tv.tv_sec) * 1000000;
-  ust += tv.tv_usec;
-  return ust;
+    gettimeofday(&tv, NULL);
+    ust = ((long long)tv.tv_sec) * 1000000;
+    ust += tv.tv_usec;
+    return ust;
 }
 
 mstime_t mstime(void) { return ustime() / 1000; }
 
-void* RAI_AddStatsEntry(RedisModuleCtx* ctx, RedisModuleString* key,
-                        RAI_RunType runtype, RAI_Backend backend,
-                        const char* devicestr, const char* tag) {
-  const char* infokey = RedisModule_StringPtrLen(key, NULL);
+void *RAI_AddStatsEntry(RedisModuleCtx *ctx, RedisModuleString *key, RAI_RunType runtype,
+                        RAI_Backend backend, const char *devicestr, const char *tag) {
+    const char *infokey = RedisModule_StringPtrLen(key, NULL);
 
-  struct RedisAI_RunStats* rstats = NULL;
-  rstats = RedisModule_Calloc(1, sizeof(struct RedisAI_RunStats));
-  RedisModule_RetainString(ctx, key);
-  rstats->key = key;
-  rstats->type = runtype;
-  rstats->backend = backend;
-  rstats->devicestr = RedisModule_Strdup(devicestr);
-  rstats->tag = RedisModule_Strdup(tag);
+    struct RedisAI_RunStats *rstats = NULL;
+    rstats = RedisModule_Calloc(1, sizeof(struct RedisAI_RunStats));
+    RedisModule_RetainString(ctx, key);
+    rstats->key = key;
+    rstats->type = runtype;
+    rstats->backend = backend;
+    rstats->devicestr = RedisModule_Strdup(devicestr);
+    rstats->tag = RedisModule_Strdup(tag);
 
-  AI_dictAdd(run_stats, (void*)infokey, (void*)rstats);
+    AI_dictAdd(run_stats, (void *)infokey, (void *)rstats);
 
-  return (void*)infokey;
+    return (void *)infokey;
 }
 
-void RAI_ListStatsEntries(RAI_RunType type, long long* nkeys,
-                          RedisModuleString*** keys, const char*** tags) {
-  AI_dictIterator* stats_iter = AI_dictGetSafeIterator(run_stats);
+void RAI_ListStatsEntries(RAI_RunType type, long long *nkeys, RedisModuleString ***keys,
+                          const char ***tags) {
+    AI_dictIterator *stats_iter = AI_dictGetSafeIterator(run_stats);
 
-  long long stats_size = AI_dictSize(run_stats);
+    long long stats_size = AI_dictSize(run_stats);
 
-  *keys = RedisModule_Calloc(stats_size, sizeof(RedisModuleString*));
-  *tags = RedisModule_Calloc(stats_size, sizeof(const char*));
+    *keys = RedisModule_Calloc(stats_size, sizeof(RedisModuleString *));
+    *tags = RedisModule_Calloc(stats_size, sizeof(const char *));
 
-  *nkeys = 0;
+    *nkeys = 0;
 
-  AI_dictEntry* stats_entry = AI_dictNext(stats_iter);
-  struct RedisAI_RunStats* rstats = NULL;
+    AI_dictEntry *stats_entry = AI_dictNext(stats_iter);
+    struct RedisAI_RunStats *rstats = NULL;
 
-  while (stats_entry) {
-    rstats = AI_dictGetVal(stats_entry);
+    while (stats_entry) {
+        rstats = AI_dictGetVal(stats_entry);
 
-    if (rstats->type == type) {
-      (*keys)[*nkeys] = rstats->key;
-      (*tags)[*nkeys] = rstats->tag;
-      *nkeys += 1;
+        if (rstats->type == type) {
+            (*keys)[*nkeys] = rstats->key;
+            (*tags)[*nkeys] = rstats->tag;
+            *nkeys += 1;
+        }
+
+        stats_entry = AI_dictNext(stats_iter);
     }
 
-    stats_entry = AI_dictNext(stats_iter);
-  }
-
-  AI_dictReleaseIterator(stats_iter);
+    AI_dictReleaseIterator(stats_iter);
 }
 
-void RAI_RemoveStatsEntry(void* infokey) {
-  AI_dictEntry* stats_entry = AI_dictFind(run_stats, infokey);
+void RAI_RemoveStatsEntry(void *infokey) {
+    AI_dictEntry *stats_entry = AI_dictFind(run_stats, infokey);
 
-  if (stats_entry) {
-    struct RedisAI_RunStats* rstats = AI_dictGetVal(stats_entry);
-    AI_dictDelete(run_stats, infokey);
+    if (stats_entry) {
+        struct RedisAI_RunStats *rstats = AI_dictGetVal(stats_entry);
+        AI_dictDelete(run_stats, infokey);
+        RAI_FreeRunStats(rstats);
+    }
+}
+
+int RAI_ResetRunStats(struct RedisAI_RunStats *rstats) {
+    rstats->duration_us = 0;
+    rstats->samples = 0;
+    rstats->calls = 0;
+    rstats->nerrors = 0;
+    return 0;
+}
+
+int RAI_SafeAddDataPoint(struct RedisAI_RunStats *rstats, long long duration, long long calls,
+                         long long errors, long long samples) {
+    int result = 1;
+    if (rstats == NULL) {
+        return result;
+    } else {
+        rstats->duration_us += duration;
+        rstats->calls += calls;
+        rstats->nerrors += errors;
+        rstats->samples += samples;
+        result = 0;
+    }
+    return result;
+}
+
+void RAI_FreeRunStats(struct RedisAI_RunStats *rstats) {
+    if (rstats) {
+        if (rstats->devicestr) {
+            RedisModule_Free(rstats->devicestr);
+        }
+        if (rstats->tag) {
+            RedisModule_Free(rstats->tag);
+        }
+        RedisModule_Free(rstats);
+    }
+}
+
+int RAI_GetRunStats(const char *runkey, struct RedisAI_RunStats **rstats) {
+    int result = 1;
+    if (run_stats == NULL) {
+        return result;
+    }
+    AI_dictEntry *entry = AI_dictFind(run_stats, runkey);
+    if (entry) {
+        *rstats = AI_dictGetVal(entry);
+        result = 0;
+    }
+    return result;
+}
+
+void RedisAI_FreeRunStats(RedisModuleCtx *ctx, struct RedisAI_RunStats *rstats) {
+    RedisModule_FreeString(ctx, rstats->key);
     RAI_FreeRunStats(rstats);
-  }
-}
-
-int RAI_ResetRunStats(struct RedisAI_RunStats* rstats) {
-  rstats->duration_us = 0;
-  rstats->samples = 0;
-  rstats->calls = 0;
-  rstats->nerrors = 0;
-  return 0;
-}
-
-int RAI_SafeAddDataPoint(struct RedisAI_RunStats* rstats, long long duration,
-                         long long calls, long long errors, long long samples) {
-  int result = 1;
-  if (rstats == NULL) {
-    return result;
-  } else {
-    rstats->duration_us += duration;
-    rstats->calls += calls;
-    rstats->nerrors += errors;
-    rstats->samples += samples;
-    result = 0;
-  }
-  return result;
-}
-
-void RAI_FreeRunStats(struct RedisAI_RunStats* rstats) {
-  if (rstats) {
-    if (rstats->devicestr) {
-      RedisModule_Free(rstats->devicestr);
-    }
-    if (rstats->tag) {
-      RedisModule_Free(rstats->tag);
-    }
-    RedisModule_Free(rstats);
-  }
-}
-
-int RAI_GetRunStats(const char* runkey, struct RedisAI_RunStats** rstats) {
-  int result = 1;
-  if (run_stats == NULL) {
-    return result;
-  }
-  AI_dictEntry* entry = AI_dictFind(run_stats, runkey);
-  if (entry) {
-    *rstats = AI_dictGetVal(entry);
-    result = 0;
-  }
-  return result;
-}
-
-void RedisAI_FreeRunStats(RedisModuleCtx* ctx,
-                          struct RedisAI_RunStats* rstats) {
-  RedisModule_FreeString(ctx, rstats->key);
-  RAI_FreeRunStats(rstats);
 }

--- a/src/stats.h
+++ b/src/stats.h
@@ -17,18 +17,18 @@
 #include "util/dict.h"
 
 struct RedisAI_RunStats {
-  RedisModuleString* key;
-  RAI_RunType type;
-  RAI_Backend backend;
-  char* devicestr;
-  char* tag;
-  long long duration_us;
-  long long samples;
-  long long calls;
-  long long nerrors;
+    RedisModuleString *key;
+    RAI_RunType type;
+    RAI_Backend backend;
+    char *devicestr;
+    char *tag;
+    long long duration_us;
+    long long samples;
+    long long calls;
+    long long nerrors;
 };
 
-AI_dict* run_stats;
+AI_dict *run_stats;
 
 long long ustime(void);
 mstime_t mstime(void);
@@ -46,16 +46,15 @@ mstime_t mstime(void);
  * @param tag optional tag of Model/Script
  * @return
  */
-void* RAI_AddStatsEntry(RedisModuleCtx* ctx, RedisModuleString* key,
-                        RAI_RunType type, RAI_Backend backend,
-                        const char* devicestr, const char* tag);
+void *RAI_AddStatsEntry(RedisModuleCtx *ctx, RedisModuleString *key, RAI_RunType type,
+                        RAI_Backend backend, const char *devicestr, const char *tag);
 
 /**
  * Removes the statistical entry with the provided unique stats identifier
  *
  * @param infokey
  */
-void RAI_RemoveStatsEntry(void* infokey);
+void RAI_RemoveStatsEntry(void *infokey);
 
 /**
  * Returns a list of all statistical entries that match a specific RAI_RunType (
@@ -67,15 +66,15 @@ void RAI_RemoveStatsEntry(void* infokey);
  * @param keys output variable containing the list of returned keys
  * @param tags output variable containing the list of returned tags
  */
-void RAI_ListStatsEntries(RAI_RunType type, long long* nkeys,
-                          RedisModuleString*** keys, const char*** tags);
+void RAI_ListStatsEntries(RAI_RunType type, long long *nkeys, RedisModuleString ***keys,
+                          const char ***tags);
 
 /**
  *
  * @param rstats
  * @return 0 on success, or 1 if the reset failed
  */
-int RAI_ResetRunStats(struct RedisAI_RunStats* rstats);
+int RAI_ResetRunStats(struct RedisAI_RunStats *rstats);
 
 /**
  * Safely add datapoint to the run stats. Protected against null pointer
@@ -87,10 +86,10 @@ int RAI_ResetRunStats(struct RedisAI_RunStats* rstats);
  * @param samples
  * @return 0 on success, or 1 if the addition failed
  */
-int RAI_SafeAddDataPoint(struct RedisAI_RunStats* rstats, long long duration,
-                         long long calls, long long errors, long long samples);
+int RAI_SafeAddDataPoint(struct RedisAI_RunStats *rstats, long long duration, long long calls,
+                         long long errors, long long samples);
 
-void RAI_FreeRunStats(struct RedisAI_RunStats* rstats);
+void RAI_FreeRunStats(struct RedisAI_RunStats *rstats);
 
 /**
  *
@@ -98,8 +97,8 @@ void RAI_FreeRunStats(struct RedisAI_RunStats* rstats);
  * @param rstats
  * @return 0 on success, or 1 if the the run stats with runkey does not exist
  */
-int RAI_GetRunStats(const char* runkey, struct RedisAI_RunStats** rstats);
+int RAI_GetRunStats(const char *runkey, struct RedisAI_RunStats **rstats);
 
-void RedisAI_FreeRunStats(RedisModuleCtx* ctx, struct RedisAI_RunStats* rstats);
+void RedisAI_FreeRunStats(RedisModuleCtx *ctx, struct RedisAI_RunStats *rstats);
 
 #endif /* SRC_SATTS_H_ */

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -9,190 +9,174 @@
 
 #include "tensor.h"
 #include "err.h"
-#include "tensor_struct.h"
-#include <stddef.h>
-#include <strings.h>
-#include <string.h>
+#include "redisai.h"
 #include "rmutil/alloc.h"
+#include "tensor_struct.h"
 #include "util/dict.h"
 #include <assert.h>
-#include "redisai.h"
 #include <pthread.h>
+#include <stddef.h>
+#include <string.h>
+#include <strings.h>
 
 RedisModuleType *RedisAI_TensorType = NULL;
 
-DLDataType RAI_TensorDataTypeFromString(const char* typestr){
-  if (strcasecmp(typestr, RAI_DATATYPE_STR_FLOAT) == 0){
-    return (DLDataType){ .code = kDLFloat, .bits = 32, .lanes = 1};
-  }
-  if (strcasecmp(typestr, RAI_DATATYPE_STR_DOUBLE) == 0) {
-    return (DLDataType){ .code = kDLFloat, .bits = 64, .lanes = 1};
-  }
-  if (strncasecmp(typestr, "INT", 3) == 0) {
-    const char *bitstr = typestr + 3;
-    if (strcmp(bitstr, "8") == 0){
-      return (DLDataType){.code = kDLInt, .bits = 8, .lanes = 1};
+DLDataType RAI_TensorDataTypeFromString(const char *typestr) {
+    if (strcasecmp(typestr, RAI_DATATYPE_STR_FLOAT) == 0) {
+        return (DLDataType){.code = kDLFloat, .bits = 32, .lanes = 1};
     }
-    if (strcmp(bitstr, "16") == 0){
-      return (DLDataType){.code = kDLInt, .bits = 16, .lanes = 1};
+    if (strcasecmp(typestr, RAI_DATATYPE_STR_DOUBLE) == 0) {
+        return (DLDataType){.code = kDLFloat, .bits = 64, .lanes = 1};
     }
-    if (strcmp(bitstr, "32") == 0){
-      return (DLDataType){.code = kDLInt, .bits = 32, .lanes = 1};
+    if (strncasecmp(typestr, "INT", 3) == 0) {
+        const char *bitstr = typestr + 3;
+        if (strcmp(bitstr, "8") == 0) {
+            return (DLDataType){.code = kDLInt, .bits = 8, .lanes = 1};
+        }
+        if (strcmp(bitstr, "16") == 0) {
+            return (DLDataType){.code = kDLInt, .bits = 16, .lanes = 1};
+        }
+        if (strcmp(bitstr, "32") == 0) {
+            return (DLDataType){.code = kDLInt, .bits = 32, .lanes = 1};
+        }
+        if (strcmp(bitstr, "64") == 0) {
+            return (DLDataType){.code = kDLInt, .bits = 64, .lanes = 1};
+        }
     }
-    if (strcmp(bitstr, "64") == 0){
-      return (DLDataType){.code = kDLInt, .bits = 64, .lanes = 1};
+    if (strncasecmp(typestr, "UINT", 4) == 0) {
+        const char *bitstr = typestr + 4;
+        if (strcmp(bitstr, "8") == 0) {
+            return (DLDataType){.code = kDLUInt, .bits = 8, .lanes = 1};
+        }
+        if (strcmp(bitstr, "16") == 0) {
+            return (DLDataType){.code = kDLUInt, .bits = 16, .lanes = 1};
+        }
     }
-  }
-  if (strncasecmp(typestr, "UINT", 4) == 0) {
-    const char *bitstr = typestr + 4;
-    if (strcmp(bitstr, "8") == 0){
-      return (DLDataType){.code = kDLUInt, .bits = 8, .lanes = 1};
-    }
-    if (strcmp(bitstr, "16") == 0){
-      return (DLDataType){.code = kDLUInt, .bits = 16, .lanes = 1};
-    }
-  }
-  return (DLDataType){.bits = 0};
+    return (DLDataType){.bits = 0};
 }
 
-static size_t Tensor_DataTypeSize(DLDataType dtype) {
-  return dtype.bits / 8;
-}
+static size_t Tensor_DataTypeSize(DLDataType dtype) { return dtype.bits / 8; }
 
 int Tensor_DataTypeStr(DLDataType dtype, char **dtypestr) {
-  int result = REDISMODULE_ERR;
-  *dtypestr = RedisModule_Calloc(8, sizeof(char));
-  if (dtype.code == kDLFloat) {
-    if (dtype.bits == 32) {
-      strcpy(*dtypestr, RAI_DATATYPE_STR_FLOAT);
-      result = REDISMODULE_OK;
+    int result = REDISMODULE_ERR;
+    *dtypestr = RedisModule_Calloc(8, sizeof(char));
+    if (dtype.code == kDLFloat) {
+        if (dtype.bits == 32) {
+            strcpy(*dtypestr, RAI_DATATYPE_STR_FLOAT);
+            result = REDISMODULE_OK;
+        } else if (dtype.bits == 64) {
+            strcpy(*dtypestr, RAI_DATATYPE_STR_DOUBLE);
+            result = REDISMODULE_OK;
+        } else {
+            RedisModule_Free(*dtypestr);
+            *dtypestr = NULL;
+        }
+    } else if (dtype.code == kDLInt) {
+        if (dtype.bits == 8) {
+            strcpy(*dtypestr, RAI_DATATYPE_STR_INT8);
+            result = REDISMODULE_OK;
+        } else if (dtype.bits == 16) {
+            strcpy(*dtypestr, RAI_DATATYPE_STR_INT16);
+            result = REDISMODULE_OK;
+        } else if (dtype.bits == 32) {
+            strcpy(*dtypestr, RAI_DATATYPE_STR_INT32);
+            result = REDISMODULE_OK;
+        } else if (dtype.bits == 64) {
+            strcpy(*dtypestr, RAI_DATATYPE_STR_INT64);
+            result = REDISMODULE_OK;
+        } else {
+            RedisModule_Free(*dtypestr);
+            *dtypestr = NULL;
+        }
+    } else if (dtype.code == kDLUInt) {
+        if (dtype.bits == 8) {
+            strcpy(*dtypestr, RAI_DATATYPE_STR_UINT8);
+            result = REDISMODULE_OK;
+        } else if (dtype.bits == 16) {
+            strcpy(*dtypestr, RAI_DATATYPE_STR_UINT16);
+            result = REDISMODULE_OK;
+        } else {
+            RedisModule_Free(*dtypestr);
+            *dtypestr = NULL;
+        }
     }
-    else if (dtype.bits == 64) {
-      strcpy(*dtypestr, RAI_DATATYPE_STR_DOUBLE);
-      result = REDISMODULE_OK;
-    }
-    else {
-      RedisModule_Free(*dtypestr);
-      *dtypestr = NULL;
-    }
-  }
-  else if (dtype.code == kDLInt) {
-    if (dtype.bits == 8) {
-      strcpy(*dtypestr, RAI_DATATYPE_STR_INT8);
-      result = REDISMODULE_OK;
-    }
-    else if (dtype.bits == 16) {
-      strcpy(*dtypestr, RAI_DATATYPE_STR_INT16);
-      result = REDISMODULE_OK;
-    }
-    else if (dtype.bits == 32) {
-      strcpy(*dtypestr, RAI_DATATYPE_STR_INT32);
-      result = REDISMODULE_OK;
-    }
-    else if (dtype.bits == 64) {
-      strcpy(*dtypestr, RAI_DATATYPE_STR_INT64);
-      result = REDISMODULE_OK;
-    }
-    else {
-      RedisModule_Free(*dtypestr);
-      *dtypestr = NULL;
-    }
-  }
-  else if (dtype.code == kDLUInt) {
-    if (dtype.bits == 8) {
-      strcpy(*dtypestr, RAI_DATATYPE_STR_UINT8);
-      result = REDISMODULE_OK;
-    }
-    else if (dtype.bits == 16) {
-      strcpy(*dtypestr, RAI_DATATYPE_STR_UINT16);
-      result = REDISMODULE_OK;
-    }
-    else {
-      RedisModule_Free(*dtypestr);
-      *dtypestr = NULL;
-    }
-  }
-  return result;
+    return result;
 }
 
-static void* RAI_Tensor_RdbLoad(struct RedisModuleIO *io, int encver) {
-  // if (encver != RAI_ENC_VER) {
-  //   /* We should actually log an error here, or try to implement
-  //      the ability to load older versions of our data structure. */
-  //   return NULL;
-  // }
+static void *RAI_Tensor_RdbLoad(struct RedisModuleIO *io, int encver) {
+    // if (encver != RAI_ENC_VER) {
+    //   /* We should actually log an error here, or try to implement
+    //      the ability to load older versions of our data structure. */
+    //   return NULL;
+    // }
 
-  DLContext ctx;
-  ctx.device_type = RedisModule_LoadUnsigned(io);
-  ctx.device_id = RedisModule_LoadUnsigned(io);
+    DLContext ctx;
+    ctx.device_type = RedisModule_LoadUnsigned(io);
+    ctx.device_id = RedisModule_LoadUnsigned(io);
 
-  // For now we only support CPU tensors (except during model and script run)
-  assert(ctx.device_type == kDLCPU);
-  assert(ctx.device_id == 0);
+    // For now we only support CPU tensors (except during model and script run)
+    assert(ctx.device_type == kDLCPU);
+    assert(ctx.device_id == 0);
 
-  DLDataType dtype;
-  dtype.bits = RedisModule_LoadUnsigned(io);
-  dtype.code = RedisModule_LoadUnsigned(io);
-  dtype.lanes = RedisModule_LoadUnsigned(io);
+    DLDataType dtype;
+    dtype.bits = RedisModule_LoadUnsigned(io);
+    dtype.code = RedisModule_LoadUnsigned(io);
+    dtype.lanes = RedisModule_LoadUnsigned(io);
 
-  size_t ndims = RedisModule_LoadUnsigned(io);
+    size_t ndims = RedisModule_LoadUnsigned(io);
 
-  RAI_Tensor *ret = RedisModule_Calloc(1, sizeof(*ret));
+    RAI_Tensor *ret = RedisModule_Calloc(1, sizeof(*ret));
 
-  int64_t* shape = RedisModule_Calloc(ndims, sizeof(*shape));
-  int64_t* strides = RedisModule_Calloc(ndims, sizeof(*strides));
-  for (size_t i = 0 ; i < ndims ; ++i){
-    shape[i] = RedisModule_LoadUnsigned(io);
-  }
+    int64_t *shape = RedisModule_Calloc(ndims, sizeof(*shape));
+    int64_t *strides = RedisModule_Calloc(ndims, sizeof(*strides));
+    for (size_t i = 0; i < ndims; ++i) {
+        shape[i] = RedisModule_LoadUnsigned(io);
+    }
 
-  for (size_t i = 0 ; i < ndims ; ++i){
-    strides[i] = RedisModule_LoadUnsigned(io);
-  }
+    for (size_t i = 0; i < ndims; ++i) {
+        strides[i] = RedisModule_LoadUnsigned(io);
+    }
 
-  size_t byte_offset = RedisModule_LoadUnsigned(io);
-  
-  size_t len;
-  char *data = RedisModule_LoadStringBuffer(io, &len);
+    size_t byte_offset = RedisModule_LoadUnsigned(io);
 
-  ret->tensor = (DLManagedTensor){
-    .dl_tensor = (DLTensor){
-      .ctx = ctx,
-      .data = data,
-      .ndim = ndims,
-      .dtype = dtype,
-      .shape = shape,
-      .strides = strides,
-      .byte_offset = 0
-    },
-    .manager_ctx = NULL,
-    .deleter = NULL
-  };
+    size_t len;
+    char *data = RedisModule_LoadStringBuffer(io, &len);
 
-  ret->refCount = 1;
-  return ret;
+    ret->tensor = (DLManagedTensor){.dl_tensor = (DLTensor){.ctx = ctx,
+                                                            .data = data,
+                                                            .ndim = ndims,
+                                                            .dtype = dtype,
+                                                            .shape = shape,
+                                                            .strides = strides,
+                                                            .byte_offset = 0},
+                                    .manager_ctx = NULL,
+                                    .deleter = NULL};
+
+    ret->refCount = 1;
+    return ret;
 }
 
 static void RAI_Tensor_RdbSave(RedisModuleIO *io, void *value) {
-  RAI_Tensor *tensor = (RAI_Tensor*)value;
+    RAI_Tensor *tensor = (RAI_Tensor *)value;
 
-  size_t ndim = tensor->tensor.dl_tensor.ndim;
+    size_t ndim = tensor->tensor.dl_tensor.ndim;
 
-  RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.ctx.device_type);
-  RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.ctx.device_id);
-  RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.dtype.bits);
-  RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.dtype.code);
-  RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.dtype.lanes);
-  RedisModule_SaveUnsigned(io, ndim);
-  for (size_t i=0; i<ndim; i++) {
-    RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.shape[i]);
-  }
-  for (size_t i=0; i<ndim; i++) {
-    RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.strides[i]);
-  }
-  RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.byte_offset);
-  size_t size = RAI_TensorByteSize(tensor);
+    RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.ctx.device_type);
+    RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.ctx.device_id);
+    RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.dtype.bits);
+    RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.dtype.code);
+    RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.dtype.lanes);
+    RedisModule_SaveUnsigned(io, ndim);
+    for (size_t i = 0; i < ndim; i++) {
+        RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.shape[i]);
+    }
+    for (size_t i = 0; i < ndim; i++) {
+        RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.strides[i]);
+    }
+    RedisModule_SaveUnsigned(io, tensor->tensor.dl_tensor.byte_offset);
+    size_t size = RAI_TensorByteSize(tensor);
 
-  RedisModule_SaveStringBuffer(io, tensor->tensor.dl_tensor.data, size);
+    RedisModule_SaveStringBuffer(io, tensor->tensor.dl_tensor.data, size);
 }
 
 #define RAI_SPLICE_SHAPE_1(x) x[0]
@@ -207,112 +191,105 @@ static void RAI_Tensor_RdbSave(RedisModuleIO *io, void *value) {
 // AI.TENSORSET tensor_key data_type shape1 shape2 ... BLOB data
 
 static void RAI_Tensor_AofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *value) {
-  RAI_Tensor *tensor = (RAI_Tensor*)value;
+    RAI_Tensor *tensor = (RAI_Tensor *)value;
 
-  char *dtypestr = NULL;
-  Tensor_DataTypeStr(RAI_TensorDataType(tensor), &dtypestr);
+    char *dtypestr = NULL;
+    Tensor_DataTypeStr(RAI_TensorDataType(tensor), &dtypestr);
 
-  char *data = RAI_TensorData(tensor);
-  long long size = RAI_TensorByteSize(tensor);
+    char *data = RAI_TensorData(tensor);
+    long long size = RAI_TensorByteSize(tensor);
 
-  long long ndims = RAI_TensorNumDims(tensor);
+    long long ndims = RAI_TensorNumDims(tensor);
 
-  RedisModuleString* dims[ndims];
+    RedisModuleString *dims[ndims];
 
-  for (long long i=0; i<ndims; i++) {
-    dims[i] = RedisModule_CreateStringFromLongLong(RedisModule_GetContextFromIO(aof), RAI_TensorDim(tensor, i));
-  }
+    for (long long i = 0; i < ndims; i++) {
+        dims[i] = RedisModule_CreateStringFromLongLong(RedisModule_GetContextFromIO(aof),
+                                                       RAI_TensorDim(tensor, i));
+    }
 
-  RedisModule_EmitAOF(aof, "AI.TENSORSET", "scvcb", key, dtypestr, dims, ndims, "BLOB", data, size);
- 
-  RedisModule_Free(dtypestr);
+    RedisModule_EmitAOF(aof, "AI.TENSORSET", "scvcb", key, dtypestr, dims, ndims, "BLOB", data,
+                        size);
+
+    RedisModule_Free(dtypestr);
 }
 
-static void RAI_Tensor_DTFree(void *value) {
-  RAI_TensorFree(value);
+static void RAI_Tensor_DTFree(void *value) { RAI_TensorFree(value); }
+
+int RAI_TensorInit(RedisModuleCtx *ctx) {
+    RedisModuleTypeMethods tmTensor = {
+        .version = REDISMODULE_TYPE_METHOD_VERSION,
+        .rdb_load = RAI_Tensor_RdbLoad,
+        .rdb_save = RAI_Tensor_RdbSave,
+        .aof_rewrite = RAI_Tensor_AofRewrite,
+        .mem_usage = NULL,
+        .free = RAI_Tensor_DTFree,
+        .digest = NULL,
+    };
+    RedisAI_TensorType = RedisModule_CreateDataType(ctx, "AI_TENSOR", RAI_ENC_VER_MM, &tmTensor);
+    return RedisAI_TensorType != NULL;
 }
 
-int RAI_TensorInit(RedisModuleCtx* ctx){
-  RedisModuleTypeMethods tmTensor = {
-      .version = REDISMODULE_TYPE_METHOD_VERSION,
-      .rdb_load = RAI_Tensor_RdbLoad,
-      .rdb_save = RAI_Tensor_RdbSave,
-      .aof_rewrite = RAI_Tensor_AofRewrite,
-      .mem_usage = NULL,
-      .free = RAI_Tensor_DTFree,
-      .digest = NULL,
-  };
-  RedisAI_TensorType = RedisModule_CreateDataType(ctx, "AI_TENSOR", RAI_ENC_VER_MM, &tmTensor);
-  return RedisAI_TensorType != NULL;
+RAI_Tensor *RAI_TensorCreateWithDLDataType(DLDataType dtype, long long *dims, int ndims,
+                                           int tensorAllocMode) {
+    const size_t dtypeSize = Tensor_DataTypeSize(dtype);
+    if (dtypeSize == 0) {
+        return NULL;
+    }
+
+    RAI_Tensor *ret = RedisModule_Alloc(sizeof(*ret));
+    int64_t *shape = RedisModule_Alloc(ndims * sizeof(*shape));
+    int64_t *strides = RedisModule_Alloc(ndims * sizeof(*strides));
+
+    size_t len = 1;
+    for (int64_t i = 0; i < ndims; ++i) {
+        shape[i] = dims[i];
+        strides[i] = 1;
+        len *= dims[i];
+    }
+    for (int64_t i = ndims - 2; i >= 0; --i) {
+        strides[i] *= strides[i + 1] * shape[i + 1];
+    }
+
+    DLContext ctx = (DLContext){.device_type = kDLCPU, .device_id = 0};
+    void *data = NULL;
+    switch (tensorAllocMode) {
+    case TENSORALLOC_ALLOC:
+        data = RedisModule_Alloc(len * dtypeSize);
+        break;
+    case TENSORALLOC_CALLOC:
+        data = RedisModule_Calloc(len, dtypeSize);
+        break;
+    case TENSORALLOC_NONE:
+        /* shallow copy no alloc */
+    default:
+        /* assume TENSORALLOC_NONE
+        shallow copy no alloc */
+        break;
+    }
+
+    if (tensorAllocMode != TENSORALLOC_NONE && data == NULL) {
+        RedisModule_Free(ret);
+        return NULL;
+    }
+
+    ret->tensor = (DLManagedTensor){.dl_tensor = (DLTensor){.ctx = ctx,
+                                                            .data = data,
+                                                            .ndim = ndims,
+                                                            .dtype = dtype,
+                                                            .shape = shape,
+                                                            .strides = strides,
+                                                            .byte_offset = 0},
+                                    .manager_ctx = NULL,
+                                    .deleter = NULL};
+
+    ret->refCount = 1;
+    return ret;
 }
 
-RAI_Tensor* RAI_TensorCreateWithDLDataType(DLDataType dtype, long long* dims, int ndims, int tensorAllocMode) {
-  const size_t dtypeSize = Tensor_DataTypeSize(dtype);
-  if ( dtypeSize == 0){
-    return NULL;
-  }
-
-  RAI_Tensor* ret = RedisModule_Alloc(sizeof(*ret));
-  int64_t* shape = RedisModule_Alloc(ndims*sizeof(*shape));
-  int64_t* strides = RedisModule_Alloc(ndims*sizeof(*strides));
-
-  size_t len = 1;
-  for (int64_t i = 0 ; i < ndims ; ++i){
-    shape[i] = dims[i];
-    strides[i] = 1;
-    len *= dims[i];
-  }
-  for (int64_t i = ndims-2 ; i >= 0 ; --i) {
-    strides[i] *= strides[i+1] * shape[i+1];
-  }
-
-  DLContext ctx = (DLContext){
-      .device_type = kDLCPU,
-      .device_id = 0
-  };
-  void *data = NULL;
-  switch (tensorAllocMode)
-  {
-  case TENSORALLOC_ALLOC:
-    data = RedisModule_Alloc(len * dtypeSize);
-    break;
-  case TENSORALLOC_CALLOC:
-    data = RedisModule_Calloc(len, dtypeSize);
-    break;
-  case TENSORALLOC_NONE:
-    /* shallow copy no alloc */
-  default:
-    /* assume TENSORALLOC_NONE
-    shallow copy no alloc */
-    break;
-  }
-
-  if (tensorAllocMode != TENSORALLOC_NONE && data == NULL){
-    RedisModule_Free(ret);
-    return NULL;
-  }
-
-  ret->tensor = (DLManagedTensor){
-    .dl_tensor = (DLTensor){
-      .ctx = ctx,
-      .data = data,
-      .ndim = ndims,
-      .dtype = dtype,
-      .shape = shape,
-      .strides = strides,
-      .byte_offset = 0
-    },
-    .manager_ctx = NULL,
-    .deleter = NULL
-  };
-
-  ret->refCount = 1;
-  return ret;
-}
-
-RAI_Tensor* RAI_TensorCreate(const char* dataType, long long* dims, int ndims, int hasdata) {
-  DLDataType dtype = RAI_TensorDataTypeFromString(dataType);
-  return RAI_TensorCreateWithDLDataType(dtype, dims, ndims, TENSORALLOC_ALLOC);
+RAI_Tensor *RAI_TensorCreate(const char *dataType, long long *dims, int ndims, int hasdata) {
+    DLDataType dtype = RAI_TensorDataTypeFromString(dataType);
+    return RAI_TensorCreateWithDLDataType(dtype, dims, ndims, TENSORALLOC_ALLOC);
 }
 
 #if 0
@@ -332,74 +309,76 @@ void RAI_TensorMoveFrom(RAI_Tensor* dst, RAI_Tensor* src) {
 }
 #endif
 
-RAI_Tensor* RAI_TensorCreateByConcatenatingTensors(RAI_Tensor** ts, long long n) {
+RAI_Tensor *RAI_TensorCreateByConcatenatingTensors(RAI_Tensor **ts, long long n) {
 
-  if (n == 0) {
-    return NULL;
-  }
+    if (n == 0) {
+        return NULL;
+    }
 
-  long long total_batch_size = 0;
-  long long batch_sizes[n];
-  long long batch_offsets[n];
+    long long total_batch_size = 0;
+    long long batch_sizes[n];
+    long long batch_offsets[n];
 
-  const long long ndims = RAI_TensorNumDims(ts[0]);
-  long long dims[ndims];
+    const long long ndims = RAI_TensorNumDims(ts[0]);
+    long long dims[ndims];
 
-  // TODO check that all tensors have compatible dims
+    // TODO check that all tensors have compatible dims
 
-  for (long long i=0; i<n; i++) {
-    batch_sizes[i] = RAI_TensorDim(ts[i], 0);
-    total_batch_size += batch_sizes[i];
-  }
+    for (long long i = 0; i < n; i++) {
+        batch_sizes[i] = RAI_TensorDim(ts[i], 0);
+        total_batch_size += batch_sizes[i];
+    }
 
-  batch_offsets[0] = 0;
-  for (long long i=1; i<n; i++) {
-    batch_offsets[i] = batch_offsets[i-1] + batch_sizes[i-1];
-  }
+    batch_offsets[0] = 0;
+    for (long long i = 1; i < n; i++) {
+        batch_offsets[i] = batch_offsets[i - 1] + batch_sizes[i - 1];
+    }
 
-  long long sample_size = 1;
+    long long sample_size = 1;
 
-  for (long long i=1; i<ndims; i++) {
-    dims[i] = RAI_TensorDim(ts[0], i);
-    sample_size *= dims[i];
-  }
-  dims[0] = total_batch_size;
+    for (long long i = 1; i < ndims; i++) {
+        dims[i] = RAI_TensorDim(ts[0], i);
+        sample_size *= dims[i];
+    }
+    dims[0] = total_batch_size;
 
-  const long long dtype_size = RAI_TensorDataSize(ts[0]);
+    const long long dtype_size = RAI_TensorDataSize(ts[0]);
 
-  DLDataType dtype = RAI_TensorDataType(ts[0]);
+    DLDataType dtype = RAI_TensorDataType(ts[0]);
 
-  RAI_Tensor* ret = RAI_TensorCreateWithDLDataType(dtype, dims, ndims, TENSORALLOC_ALLOC);
+    RAI_Tensor *ret = RAI_TensorCreateWithDLDataType(dtype, dims, ndims, TENSORALLOC_ALLOC);
 
-  for (long long i=0; i<n; i++) {
-    memcpy(RAI_TensorData(ret) + batch_offsets[i] * sample_size * dtype_size, RAI_TensorData(ts[i]), RAI_TensorByteSize(ts[i]));
-  }
+    for (long long i = 0; i < n; i++) {
+        memcpy(RAI_TensorData(ret) + batch_offsets[i] * sample_size * dtype_size,
+               RAI_TensorData(ts[i]), RAI_TensorByteSize(ts[i]));
+    }
 
-  return ret;
+    return ret;
 }
 
-RAI_Tensor* RAI_TensorCreateBySlicingTensor(RAI_Tensor* t, long long offset, long long len) {
+RAI_Tensor *RAI_TensorCreateBySlicingTensor(RAI_Tensor *t, long long offset, long long len) {
 
-  const long long ndims = RAI_TensorNumDims(t);
-  long long dims[ndims];
+    const long long ndims = RAI_TensorNumDims(t);
+    long long dims[ndims];
 
-  const long long dtype_size = RAI_TensorDataSize(t);
-  long long sample_size = 1;
+    const long long dtype_size = RAI_TensorDataSize(t);
+    long long sample_size = 1;
 
-  for (long long i=1; i<ndims; i++) {
-    dims[i] = RAI_TensorDim(t, i);
-    sample_size *= dims[i];
-  }
+    for (long long i = 1; i < ndims; i++) {
+        dims[i] = RAI_TensorDim(t, i);
+        sample_size *= dims[i];
+    }
 
-  dims[0] = len;
+    dims[0] = len;
 
-  DLDataType dtype = RAI_TensorDataType(t);
+    DLDataType dtype = RAI_TensorDataType(t);
 
-  RAI_Tensor* ret = RAI_TensorCreateWithDLDataType(dtype, dims, ndims, TENSORALLOC_ALLOC);
+    RAI_Tensor *ret = RAI_TensorCreateWithDLDataType(dtype, dims, ndims, TENSORALLOC_ALLOC);
 
-  memcpy(RAI_TensorData(ret), RAI_TensorData(t) + offset * sample_size * dtype_size, len * sample_size * dtype_size);
+    memcpy(RAI_TensorData(ret), RAI_TensorData(t) + offset * sample_size * dtype_size,
+           len * sample_size * dtype_size);
 
-  return ret;
+    return ret;
 }
 
 /**
@@ -409,683 +388,668 @@ RAI_Tensor* RAI_TensorCreateBySlicingTensor(RAI_Tensor* t, long long offset, lon
  * @return 0 on success, or 1 if the copy failed
  * failed.
  */
-int RAI_TensorDeepCopy(RAI_Tensor* t, RAI_Tensor** dest) {
-  const long long ndims = RAI_TensorNumDims(t);
-  long long dims[ndims];
+int RAI_TensorDeepCopy(RAI_Tensor *t, RAI_Tensor **dest) {
+    const long long ndims = RAI_TensorNumDims(t);
+    long long dims[ndims];
 
-  const long long dtype_size = RAI_TensorDataSize(t);
-  long long sample_size = 1;
+    const long long dtype_size = RAI_TensorDataSize(t);
+    long long sample_size = 1;
 
-  for (long long i=0; i<ndims; i++) {
-    dims[i] = RAI_TensorDim(t, i);
-    sample_size *= dims[i];
-  }
+    for (long long i = 0; i < ndims; i++) {
+        dims[i] = RAI_TensorDim(t, i);
+        sample_size *= dims[i];
+    }
 
-  DLDataType dtype = RAI_TensorDataType(t);
+    DLDataType dtype = RAI_TensorDataType(t);
 
-  RAI_Tensor* ret = RAI_TensorCreateWithDLDataType(dtype, dims, ndims, TENSORALLOC_ALLOC);
+    RAI_Tensor *ret = RAI_TensorCreateWithDLDataType(dtype, dims, ndims, TENSORALLOC_ALLOC);
 
-  memcpy(RAI_TensorData(ret), RAI_TensorData(t), sample_size * dtype_size);
-  *dest = ret;
-  return 0;
+    memcpy(RAI_TensorData(ret), RAI_TensorData(t), sample_size * dtype_size);
+    *dest = ret;
+    return 0;
 }
 
 // Beware: this will take ownership of dltensor
-RAI_Tensor* RAI_TensorCreateFromDLTensor(DLManagedTensor* dl_tensor) {
+RAI_Tensor *RAI_TensorCreateFromDLTensor(DLManagedTensor *dl_tensor) {
 
-  RAI_Tensor* ret = RedisModule_Calloc(1, sizeof(*ret));
+    RAI_Tensor *ret = RedisModule_Calloc(1, sizeof(*ret));
 
-  ret->tensor = (DLManagedTensor){
-    .dl_tensor = (DLTensor){
-      .ctx = dl_tensor->dl_tensor.ctx,
-      .data = dl_tensor->dl_tensor.data,
-      .ndim = dl_tensor->dl_tensor.ndim,
-      .dtype = dl_tensor->dl_tensor.dtype,
-      .shape = dl_tensor->dl_tensor.shape,
-      .strides = dl_tensor->dl_tensor.strides,
-      .byte_offset = dl_tensor->dl_tensor.byte_offset
-    },
-    .manager_ctx = dl_tensor->manager_ctx,
-    .deleter  = dl_tensor->deleter
-  };
+    ret->tensor =
+        (DLManagedTensor){.dl_tensor = (DLTensor){.ctx = dl_tensor->dl_tensor.ctx,
+                                                  .data = dl_tensor->dl_tensor.data,
+                                                  .ndim = dl_tensor->dl_tensor.ndim,
+                                                  .dtype = dl_tensor->dl_tensor.dtype,
+                                                  .shape = dl_tensor->dl_tensor.shape,
+                                                  .strides = dl_tensor->dl_tensor.strides,
+                                                  .byte_offset = dl_tensor->dl_tensor.byte_offset},
+                          .manager_ctx = dl_tensor->manager_ctx,
+                          .deleter = dl_tensor->deleter};
 
-  ret->refCount = 1;
-  return ret;
+    ret->refCount = 1;
+    return ret;
 }
 
-DLDataType RAI_TensorDataType(RAI_Tensor* t) {
-  return t->tensor.dl_tensor.dtype;
+DLDataType RAI_TensorDataType(RAI_Tensor *t) { return t->tensor.dl_tensor.dtype; }
+
+int RAI_TensorIsDataTypeEqual(RAI_Tensor *t1, RAI_Tensor *t2) {
+    return t1->tensor.dl_tensor.dtype.bits == t2->tensor.dl_tensor.dtype.bits &&
+           t1->tensor.dl_tensor.dtype.code == t2->tensor.dl_tensor.dtype.code &&
+           t1->tensor.dl_tensor.dtype.lanes == t2->tensor.dl_tensor.dtype.lanes;
 }
 
-int RAI_TensorIsDataTypeEqual(RAI_Tensor* t1, RAI_Tensor* t2) {
-  return t1->tensor.dl_tensor.dtype.bits == t2->tensor.dl_tensor.dtype.bits &&
-         t1->tensor.dl_tensor.dtype.code == t2->tensor.dl_tensor.dtype.code &&
-         t1->tensor.dl_tensor.dtype.lanes == t2->tensor.dl_tensor.dtype.lanes;
+size_t RAI_TensorLength(RAI_Tensor *t) {
+    int64_t *shape = t->tensor.dl_tensor.shape;
+    size_t len = 1;
+    for (size_t i = 0; i < t->tensor.dl_tensor.ndim; ++i) {
+        len *= shape[i];
+    }
+    return len;
 }
 
-size_t RAI_TensorLength(RAI_Tensor* t) {
-  int64_t* shape = t->tensor.dl_tensor.shape;
-  size_t len = 1;
-  for (size_t i = 0 ; i < t->tensor.dl_tensor.ndim; ++i){
-    len *= shape[i];
-  }
-  return len;
+size_t RAI_TensorDataSize(RAI_Tensor *t) { return Tensor_DataTypeSize(RAI_TensorDataType(t)); }
+
+size_t RAI_TensorDataSizeFromString(const char *dataTypeStr) {
+    DLDataType dtype = RAI_TensorDataTypeFromString(dataTypeStr);
+    return Tensor_DataTypeSize(dtype);
 }
 
-size_t RAI_TensorDataSize(RAI_Tensor* t) {
-  return Tensor_DataTypeSize(RAI_TensorDataType(t));
-}
-
-size_t RAI_TensorDataSizeFromString(const char* dataTypeStr) {
-  DLDataType dtype = RAI_TensorDataTypeFromString(dataTypeStr);
-  return Tensor_DataTypeSize(dtype);
-}
-
-size_t RAI_TensorDataSizeFromDLDataType(DLDataType dtype) {
-  return Tensor_DataTypeSize(dtype);
-}
+size_t RAI_TensorDataSizeFromDLDataType(DLDataType dtype) { return Tensor_DataTypeSize(dtype); }
 
 void RAI_TensorFree(RAI_Tensor *t) {
-  if (t) {
-    if (__atomic_sub_fetch(&t->refCount, 1, __ATOMIC_RELAXED)  <= 0) {
-      if (t->tensor.deleter) {
-        t->tensor.deleter(&t->tensor);
-      } else {
-        if (t->tensor.dl_tensor.shape) {
-          RedisModule_Free(t->tensor.dl_tensor.shape);
+    if (t) {
+        if (__atomic_sub_fetch(&t->refCount, 1, __ATOMIC_RELAXED) <= 0) {
+            if (t->tensor.deleter) {
+                t->tensor.deleter(&t->tensor);
+            } else {
+                if (t->tensor.dl_tensor.shape) {
+                    RedisModule_Free(t->tensor.dl_tensor.shape);
+                }
+                if (t->tensor.dl_tensor.strides) {
+                    RedisModule_Free(t->tensor.dl_tensor.strides);
+                }
+                if (t->tensor.dl_tensor.data) {
+                    RedisModule_Free(t->tensor.dl_tensor.data);
+                }
+                RedisModule_Free(t);
+            }
         }
-        if (t->tensor.dl_tensor.strides) {
-          RedisModule_Free(t->tensor.dl_tensor.strides);
+    }
+}
+
+int RAI_TensorSetData(RAI_Tensor *t, const char *data, size_t len) {
+    memcpy(t->tensor.dl_tensor.data, data, len);
+    return 1;
+}
+
+int RAI_TensorSetValueFromLongLong(RAI_Tensor *t, long long i, long long val) {
+    DLDataType dtype = t->tensor.dl_tensor.dtype;
+    void *data = t->tensor.dl_tensor.data;
+
+    if (dtype.code == kDLInt) {
+        switch (dtype.bits) {
+        case 8:
+            ((int8_t *)data)[i] = val;
+            break;
+            break;
+        case 16:
+            ((int16_t *)data)[i] = val;
+            break;
+            break;
+        case 32:
+            ((int32_t *)data)[i] = val;
+            break;
+            break;
+        case 64:
+            ((int64_t *)data)[i] = val;
+            break;
+            break;
+        default:
+            return 0;
         }
-        if (t->tensor.dl_tensor.data) {
-          RedisModule_Free(t->tensor.dl_tensor.data);
+    } else if (dtype.code == kDLUInt) {
+        switch (dtype.bits) {
+        case 8:
+            ((uint8_t *)data)[i] = val;
+            break;
+            break;
+        case 16:
+            ((uint16_t *)data)[i] = val;
+            break;
+            break;
+        case 32:
+            ((uint32_t *)data)[i] = val;
+            break;
+            break;
+        case 64:
+            ((uint64_t *)data)[i] = val;
+            break;
+            break;
+        default:
+            return 0;
         }
-        RedisModule_Free(t);
-      }
-    }
-  }
-}
-
-int RAI_TensorSetData(RAI_Tensor* t, const char* data, size_t len){
-  memcpy(t->tensor.dl_tensor.data, data, len);
-  return 1;
-}
-
-int RAI_TensorSetValueFromLongLong(RAI_Tensor* t, long long i, long long val){
-  DLDataType dtype = t->tensor.dl_tensor.dtype;
-  void* data = t->tensor.dl_tensor.data;
-
-  if (dtype.code == kDLInt) {
-    switch (dtype.bits) {
-      case 8:
-        ((int8_t *)data)[i] = val; break;
-        break;
-      case 16:
-        ((int16_t *)data)[i] = val; break;
-        break;
-      case 32:
-        ((int32_t *)data)[i] = val; break;
-        break;
-      case 64:
-        ((int64_t *)data)[i] = val; break;
-        break;
-      default:
+    } else {
         return 0;
     }
-  }
-  else if (dtype.code == kDLUInt) {
-    switch (dtype.bits) {
-      case 8:
-        ((uint8_t *)data)[i] = val; break;
-        break;
-      case 16:
-        ((uint16_t *)data)[i] = val; break;
-        break;
-      case 32:
-        ((uint32_t *)data)[i] = val; break;
-        break;
-      case 64:
-        ((uint64_t *)data)[i] = val; break;
-        break;
-      default:
+    return 1;
+}
+
+int RAI_TensorSetValueFromDouble(RAI_Tensor *t, long long i, double val) {
+    DLDataType dtype = t->tensor.dl_tensor.dtype;
+    void *data = t->tensor.dl_tensor.data;
+
+    if (dtype.code == kDLFloat) {
+        switch (dtype.bits) {
+        case 32:
+            ((float *)data)[i] = val;
+            break;
+        case 64:
+            ((double *)data)[i] = val;
+            break;
+        default:
+            return 0;
+        }
+    } else {
         return 0;
     }
-  }
-  else {
-    return 0;
-  }
-  return 1;
+    return 1;
 }
 
-int RAI_TensorSetValueFromDouble(RAI_Tensor* t, long long i, double val){
-  DLDataType dtype = t->tensor.dl_tensor.dtype;
-  void* data = t->tensor.dl_tensor.data;
+int RAI_TensorGetValueAsDouble(RAI_Tensor *t, long long i, double *val) {
+    DLDataType dtype = t->tensor.dl_tensor.dtype;
+    void *data = t->tensor.dl_tensor.data;
 
-  if (dtype.code == kDLFloat) {
-    switch (dtype.bits) {
-      case 32:
-        ((float *)data)[i] = val; break;
-      case 64:
-        ((double *)data)[i] = val; break;
-      default:
+    // TODO: check i is in bound
+    if (dtype.code == kDLFloat) {
+        switch (dtype.bits) {
+        case 32:
+            *val = ((float *)data)[i];
+            break;
+        case 64:
+            *val = ((double *)data)[i];
+            break;
+        default:
+            return 0;
+        }
+    } else {
         return 0;
     }
-  }
-  else {
-    return 0;
-  }
-  return 1;
+    return 1;
 }
 
-int RAI_TensorGetValueAsDouble(RAI_Tensor* t, long long i, double* val) {
-  DLDataType dtype = t->tensor.dl_tensor.dtype;
-  void* data = t->tensor.dl_tensor.data;
+int RAI_TensorGetValueAsLongLong(RAI_Tensor *t, long long i, long long *val) {
+    DLDataType dtype = t->tensor.dl_tensor.dtype;
+    void *data = t->tensor.dl_tensor.data;
 
-  // TODO: check i is in bound
-  if (dtype.code == kDLFloat) {
-    switch (dtype.bits) {
-      case 32:
-        *val = ((float *)data)[i]; break;
-      case 64:
-        *val = ((double *)data)[i]; break;
-      default:
+    // TODO: check i is in bound
+
+    if (dtype.code == kDLInt) {
+        switch (dtype.bits) {
+        case 8:
+            *val = ((int8_t *)data)[i];
+            break;
+        case 16:
+            *val = ((int16_t *)data)[i];
+            break;
+        case 32:
+            *val = ((int32_t *)data)[i];
+            break;
+        case 64:
+            *val = ((int64_t *)data)[i];
+            break;
+        default:
+            return 0;
+        }
+    } else if (dtype.code == kDLUInt) {
+        switch (dtype.bits) {
+        case 8:
+            *val = ((uint8_t *)data)[i];
+            break;
+        case 16:
+            *val = ((uint16_t *)data)[i];
+            break;
+        case 32:
+            *val = ((uint32_t *)data)[i];
+            break;
+        case 64:
+            *val = ((uint64_t *)data)[i];
+            break;
+        default:
+            return 0;
+        }
+    } else {
         return 0;
     }
-  }
-  else {
-    return 0;
-  }
-  return 1;
+    return 1;
 }
 
-int RAI_TensorGetValueAsLongLong(RAI_Tensor* t, long long i, long long* val) {
-  DLDataType dtype = t->tensor.dl_tensor.dtype;
-  void* data = t->tensor.dl_tensor.data;
-
-  // TODO: check i is in bound
-
-  if (dtype.code == kDLInt) {
-    switch (dtype.bits) {
-      case 8:
-        *val = ((int8_t *)data)[i]; break;
-      case 16:
-        *val = ((int16_t *)data)[i]; break;
-      case 32:
-        *val = ((int32_t *)data)[i]; break;
-      case 64:
-        *val = ((int64_t *)data)[i]; break;
-      default:
-        return 0;
-    }
-  }
-  else if (dtype.code == kDLUInt) {
-    switch (dtype.bits) {
-      case 8:
-        *val = ((uint8_t *)data)[i]; break;
-      case 16:
-        *val = ((uint16_t *)data)[i]; break;
-      case 32:
-        *val = ((uint32_t *)data)[i]; break;
-      case 64:
-        *val = ((uint64_t *)data)[i]; break;
-      default:
-        return 0;
-    }
-  }
-  else {
-    return 0;
-  }
-  return 1;
+RAI_Tensor *RAI_TensorGetShallowCopy(RAI_Tensor *t) {
+    __atomic_fetch_add(&t->refCount, 1, __ATOMIC_RELAXED);
+    return t;
 }
 
-RAI_Tensor* RAI_TensorGetShallowCopy(RAI_Tensor* t){
-  __atomic_fetch_add(&t->refCount, 1, __ATOMIC_RELAXED);
-  return t;
+int RAI_TensorNumDims(RAI_Tensor *t) { return t->tensor.dl_tensor.ndim; }
+
+long long RAI_TensorDim(RAI_Tensor *t, int i) { return t->tensor.dl_tensor.shape[i]; }
+
+size_t RAI_TensorByteSize(RAI_Tensor *t) {
+    // TODO: as per dlpack it should be
+    //   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
+    return Tensor_DataTypeSize(RAI_TensorDataType(t)) * RAI_TensorLength(t);
 }
 
-int RAI_TensorNumDims(RAI_Tensor* t){
-  return t->tensor.dl_tensor.ndim;
-}
-
-long long RAI_TensorDim(RAI_Tensor* t, int i){
-  return t->tensor.dl_tensor.shape[i];
-}
-
-size_t RAI_TensorByteSize(RAI_Tensor* t){
-  // TODO: as per dlpack it should be
-  //   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
-  return Tensor_DataTypeSize(RAI_TensorDataType(t)) * RAI_TensorLength(t);
-}
-
-char* RAI_TensorData(RAI_Tensor* t){
-  return t->tensor.dl_tensor.data;
-}
+char *RAI_TensorData(RAI_Tensor *t) { return t->tensor.dl_tensor.data; }
 
 /* Return REDISMODULE_ERR if is the key not associated with a tensor type.
  * Return REDISMODULE_OK otherwise. */
-int RAI_OpenKey_Tensor(RedisModuleCtx *ctx, RedisModuleString *keyName,
-                              RedisModuleKey **key,
-                              int mode) {
-  *key = RedisModule_OpenKey(ctx, keyName, mode);
-  if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) { 
+int RAI_OpenKey_Tensor(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key,
+                       int mode) {
+    *key = RedisModule_OpenKey(ctx, keyName, mode);
+    if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) {
+        return REDISMODULE_OK;
+    }
+    if (RedisModule_ModuleTypeGetType(*key) != RedisAI_TensorType) {
+        RedisModule_CloseKey(*key);
+        RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        return REDISMODULE_ERR;
+    }
     return REDISMODULE_OK;
-  }
-  if (RedisModule_ModuleTypeGetType(*key) != RedisAI_TensorType) {
-    RedisModule_CloseKey(*key);
-    RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-    return REDISMODULE_ERR;
-  }
-  return REDISMODULE_OK;
 }
 
 /* Return REDISMODULE_ERR if there was an error getting the Tensor.
  * Return REDISMODULE_OK if the tensor value stored at key was correctly
  * returned and available at *tensor variable. */
-int RAI_GetTensorFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName,
-                               RedisModuleKey **key, RAI_Tensor **tensor,
-                               int mode) {
-  *key = RedisModule_OpenKey(ctx, keyName, mode);
-  if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) {
-    RedisModule_CloseKey(*key);
-    RedisModule_ReplyWithError(ctx, "ERR tensor key is empty");
-    return REDISMODULE_ERR;
-  }
-  if (RedisModule_ModuleTypeGetType(*key) != RedisAI_TensorType) {
-    RedisModule_CloseKey(*key);
-    RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-    return REDISMODULE_ERR;
-  }
-  *tensor = RedisModule_ModuleTypeGetValue(*key);
-  return REDISMODULE_OK;
+int RAI_GetTensorFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key,
+                              RAI_Tensor **tensor, int mode) {
+    *key = RedisModule_OpenKey(ctx, keyName, mode);
+    if (RedisModule_KeyType(*key) == REDISMODULE_KEYTYPE_EMPTY) {
+        RedisModule_CloseKey(*key);
+        RedisModule_ReplyWithError(ctx, "ERR tensor key is empty");
+        return REDISMODULE_ERR;
+    }
+    if (RedisModule_ModuleTypeGetType(*key) != RedisAI_TensorType) {
+        RedisModule_CloseKey(*key);
+        RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        return REDISMODULE_ERR;
+    }
+    *tensor = RedisModule_ModuleTypeGetValue(*key);
+    return REDISMODULE_OK;
 }
 
 /* Return REDISMODULE_ERR if there was an error getting the Tensor.
- * Return REDISMODULE_OK if the tensor value is present at the localContextDict. */
-int RAI_getTensorFromLocalContext(RedisModuleCtx *ctx,
-                                  AI_dict *localContextDict,
-                                  const char *localContextKey,
-                                  RAI_Tensor **tensor, RAI_Error *error) {
-  int result = REDISMODULE_ERR;
-  AI_dictEntry *tensor_entry = AI_dictFind(localContextDict, localContextKey);
-  if (tensor_entry) {
-    *tensor = AI_dictGetVal(tensor_entry);
-    result = REDISMODULE_OK;
-  } else{
-    if (ctx == NULL) {
-      RAI_SetError(error, RAI_ETENSORGET,
-                    "ERR tensor key is empty");
+ * Return REDISMODULE_OK if the tensor value is present at the localContextDict.
+ */
+int RAI_getTensorFromLocalContext(RedisModuleCtx *ctx, AI_dict *localContextDict,
+                                  const char *localContextKey, RAI_Tensor **tensor,
+                                  RAI_Error *error) {
+    int result = REDISMODULE_ERR;
+    AI_dictEntry *tensor_entry = AI_dictFind(localContextDict, localContextKey);
+    if (tensor_entry) {
+        *tensor = AI_dictGetVal(tensor_entry);
+        result = REDISMODULE_OK;
     } else {
-      RedisModule_ReplyWithError(
-          ctx, "ERR tensor key is empty");
+        if (ctx == NULL) {
+            RAI_SetError(error, RAI_ETENSORGET, "ERR tensor key is empty");
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR tensor key is empty");
+        }
     }
-  }
-  return result;
+    return result;
 }
 
 void RedisAI_ReplicateTensorSet(RedisModuleCtx *ctx, RedisModuleString *key, RAI_Tensor *t) {
-  long long ndims = RAI_TensorNumDims(t);
+    long long ndims = RAI_TensorNumDims(t);
 
-  char *dtypestr = NULL;
-  Tensor_DataTypeStr(RAI_TensorDataType(t), &dtypestr);
+    char *dtypestr = NULL;
+    Tensor_DataTypeStr(RAI_TensorDataType(t), &dtypestr);
 
-  assert(dtypestr);
+    assert(dtypestr);
 
-  char *data = RAI_TensorData(t);
-  long long size = RAI_TensorByteSize(t);
+    char *data = RAI_TensorData(t);
+    long long size = RAI_TensorByteSize(t);
 
-  RedisModuleString* dims[ndims];
+    RedisModuleString *dims[ndims];
 
-  for (long long i=0; i<ndims; i++) {
-    dims[i] = RedisModule_CreateStringFromLongLong(ctx, RAI_TensorDim(t, i));
-  }
+    for (long long i = 0; i < ndims; i++) {
+        dims[i] = RedisModule_CreateStringFromLongLong(ctx, RAI_TensorDim(t, i));
+    }
 
-  RedisModule_Replicate(ctx, "AI.TENSORSET", "scvcb", key, dtypestr,
-                        dims, ndims, "BLOB", data, size);
+    RedisModule_Replicate(ctx, "AI.TENSORSET", "scvcb", key, dtypestr, dims, ndims, "BLOB", data,
+                          size);
 
-  for (long long i=0; i<ndims; i++) {
-    RedisModule_FreeString(ctx,dims[i]);
-  }
+    for (long long i = 0; i < ndims; i++) {
+        RedisModule_FreeString(ctx, dims[i]);
+    }
 
-  RedisModule_Free(dtypestr);
+    RedisModule_Free(dtypestr);
 }
 
-int RAI_parseTensorSetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RAI_Tensor **t, int enforceArity, RAI_Error *error)
-{
-  if (argc < 4) {
-    RedisModule_WrongArity(ctx);
-    return -1;
-  } 
-  // get the tensor datatype
-  const char* typestr = RedisModule_StringPtrLen(argv[2], NULL);
-  size_t datasize = RAI_TensorDataSizeFromString(typestr);
-  if (!datasize){
-    if(ctx==NULL){
-      RAI_SetError(error, RAI_ETENSORSET, "ERR invalid data type");
-    }else{
-      RedisModule_ReplyWithError(ctx, "ERR invalid data type");
+int RAI_parseTensorSetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RAI_Tensor **t,
+                           int enforceArity, RAI_Error *error) {
+    if (argc < 4) {
+        RedisModule_WrongArity(ctx);
+        return -1;
     }
-    return -1;
-  }
-  const char* fmtstr;
-  int datafmt = REDISAI_DATA_NONE;
-  int tensorAllocMode = TENSORALLOC_CALLOC;
-  size_t ndims = 0;
-  long long len = 1;
-  long long* dims = (long long*)array_new(long long,1);
-  size_t argpos = 3;
-  long long remaining_args = argc-1;
-  size_t expected_nvalues = 0;
-  size_t current_nvalues = 0;
+    // get the tensor datatype
+    const char *typestr = RedisModule_StringPtrLen(argv[2], NULL);
+    size_t datasize = RAI_TensorDataSizeFromString(typestr);
+    if (!datasize) {
+        if (ctx == NULL) {
+            RAI_SetError(error, RAI_ETENSORSET, "ERR invalid data type");
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR invalid data type");
+        }
+        return -1;
+    }
+    const char *fmtstr;
+    int datafmt = REDISAI_DATA_NONE;
+    int tensorAllocMode = TENSORALLOC_CALLOC;
+    size_t ndims = 0;
+    long long len = 1;
+    long long *dims = (long long *)array_new(long long, 1);
+    size_t argpos = 3;
+    long long remaining_args = argc - 1;
+    size_t expected_nvalues = 0;
+    size_t current_nvalues = 0;
 
-  for (; argpos <= argc - 1; argpos++) {
-    const char *opt = RedisModule_StringPtrLen(argv[argpos], NULL);
-    remaining_args = argc - 1 - argpos;
-    if (!strcasecmp(opt, "BLOB")) {
-      datafmt = REDISAI_DATA_BLOB;
-      tensorAllocMode = TENSORALLOC_CALLOC;
-      // if we've found the dataformat there are no more dimensions
-      // check right away if the arity is correct
-      if (remaining_args != 1 && enforceArity == 1) {
-        array_free(dims);
-        if (ctx == NULL) {
-          RAI_SetError(
-              error, RAI_ETENSORSET,
-              "ERR wrong number of arguments for 'AI.TENSORSET' command");
+    for (; argpos <= argc - 1; argpos++) {
+        const char *opt = RedisModule_StringPtrLen(argv[argpos], NULL);
+        remaining_args = argc - 1 - argpos;
+        if (!strcasecmp(opt, "BLOB")) {
+            datafmt = REDISAI_DATA_BLOB;
+            tensorAllocMode = TENSORALLOC_CALLOC;
+            // if we've found the dataformat there are no more dimensions
+            // check right away if the arity is correct
+            if (remaining_args != 1 && enforceArity == 1) {
+                array_free(dims);
+                if (ctx == NULL) {
+                    RAI_SetError(error, RAI_ETENSORSET,
+                                 "ERR wrong number of arguments for 'AI.TENSORSET' command");
+                } else {
+                    RedisModule_WrongArity(ctx);
+                }
+                return -1;
+            }
+            argpos++;
+            break;
+        } else if (!strcasecmp(opt, "VALUES")) {
+            datafmt = REDISAI_DATA_VALUES;
+            tensorAllocMode = TENSORALLOC_CALLOC;
+            // if we've found the dataformat there are no more dimensions
+            // check right away if the arity is correct
+            if (remaining_args != len && enforceArity == 1) {
+                array_free(dims);
+                if (ctx == NULL) {
+                    RAI_SetError(error, RAI_ETENSORSET,
+                                 "ERR wrong number of arguments for 'AI.TENSORSET' command");
+                } else {
+                    RedisModule_WrongArity(ctx);
+                }
+                return -1;
+            }
+            argpos++;
+            break;
         } else {
-          RedisModule_WrongArity(ctx);
+            long long dimension;
+            const int retval = RedisModule_StringToLongLong(argv[argpos], &dimension);
+            if (retval != REDISMODULE_OK || dimension <= 0) {
+                array_free(dims);
+                if (ctx == NULL) {
+                    RAI_SetError(error, RAI_ETENSORSET,
+                                 "ERR invalid or negative value found in tensor shape");
+                } else {
+                    RedisModule_ReplyWithError(
+                        ctx, "ERR invalid or negative value found in tensor shape");
+                }
+                return -1;
+            }
+            ndims++;
+            dims = array_append(dims, dimension);
+            len *= dimension;
         }
-        return -1;
-      }
-      argpos++;
-      break;
-    } else if (!strcasecmp(opt, "VALUES")) {
-      datafmt = REDISAI_DATA_VALUES;
-      tensorAllocMode = TENSORALLOC_CALLOC;
-      // if we've found the dataformat there are no more dimensions
-      // check right away if the arity is correct
-      if (remaining_args != len && enforceArity == 1) {
-        array_free(dims);
-        if (ctx == NULL) {
-          RAI_SetError(
-              error, RAI_ETENSORSET,
-              "ERR wrong number of arguments for 'AI.TENSORSET' command");
-        } else {
-          RedisModule_WrongArity(ctx);
-        }
-        return -1;
-      }
-      argpos++;
-      break;
-    } else {
-      long long dimension;
-      const int retval = RedisModule_StringToLongLong(argv[argpos], &dimension);
-      if (retval != REDISMODULE_OK || dimension <= 0) {
-        array_free(dims);
-        if (ctx == NULL) {
-          RAI_SetError(error, RAI_ETENSORSET,
-                       "ERR invalid or negative value found in tensor shape");
-        } else {
-          RedisModule_ReplyWithError(
-              ctx, "ERR invalid or negative value found in tensor shape");
-        }
-        return -1;
-      }
-      ndims++;
-      dims = array_append(dims, dimension);
-      len *= dimension;
     }
-  }
 
-  const long long nbytes = len * datasize;
-  size_t datalen;
-  const char *data;
-  DLDataType datatype = RAI_TensorDataTypeFromString(typestr);
-  *t = RAI_TensorCreateWithDLDataType(datatype, dims, ndims, tensorAllocMode);
-  if (!t){
-    array_free(dims);
-    if (ctx == NULL) {
-      RAI_SetError(error, RAI_ETENSORSET,
-                    "ERR could not create tensor");
-    } else {
-      RedisModule_ReplyWithError(
-          ctx, "ERR could not create tensor");
-    }
-    return -1;
-  }
-  long i = 0;
-  switch (datafmt){
-    case REDISAI_DATA_BLOB:
-    {
-      const char*blob = RedisModule_StringPtrLen(argv[argpos],&datalen);
-      if (datalen != nbytes){
-        RAI_TensorFree(*t);
+    const long long nbytes = len * datasize;
+    size_t datalen;
+    const char *data;
+    DLDataType datatype = RAI_TensorDataTypeFromString(typestr);
+    *t = RAI_TensorCreateWithDLDataType(datatype, dims, ndims, tensorAllocMode);
+    if (!t) {
         array_free(dims);
         if (ctx == NULL) {
-          RAI_SetError(error, RAI_ETENSORSET,
-                        "ERR data length does not match tensor shape and type");
+            RAI_SetError(error, RAI_ETENSORSET, "ERR could not create tensor");
         } else {
-          RedisModule_ReplyWithError(ctx, "ERR data length does not match tensor shape and type");
+            RedisModule_ReplyWithError(ctx, "ERR could not create tensor");
         }
         return -1;
-      }
-      RAI_TensorSetData(*t,blob,datalen);
     }
-      break;
+    long i = 0;
+    switch (datafmt) {
+    case REDISAI_DATA_BLOB: {
+        const char *blob = RedisModule_StringPtrLen(argv[argpos], &datalen);
+        if (datalen != nbytes) {
+            RAI_TensorFree(*t);
+            array_free(dims);
+            if (ctx == NULL) {
+                RAI_SetError(error, RAI_ETENSORSET,
+                             "ERR data length does not match tensor shape and type");
+            } else {
+                RedisModule_ReplyWithError(ctx,
+                                           "ERR data length does not match tensor shape and type");
+            }
+            return -1;
+        }
+        RAI_TensorSetData(*t, blob, datalen);
+    } break;
     case REDISAI_DATA_VALUES:
-      for (; (argpos <= argc-1) && (i < len); argpos++){
-        if (datatype.code == kDLFloat){
-          double val;
-          const int retval = RedisModule_StringToDouble(argv[argpos],&val);
-          if (retval != REDISMODULE_OK) {
-            RAI_TensorFree(*t);
-            array_free(dims);
-            if (ctx == NULL) {
-              RAI_SetError(error, RAI_ETENSORSET,
-                            "ERR invalid value");
+        for (; (argpos <= argc - 1) && (i < len); argpos++) {
+            if (datatype.code == kDLFloat) {
+                double val;
+                const int retval = RedisModule_StringToDouble(argv[argpos], &val);
+                if (retval != REDISMODULE_OK) {
+                    RAI_TensorFree(*t);
+                    array_free(dims);
+                    if (ctx == NULL) {
+                        RAI_SetError(error, RAI_ETENSORSET, "ERR invalid value");
+                    } else {
+                        RedisModule_ReplyWithError(ctx, "ERR invalid value");
+                    }
+                    return -1;
+                }
+                const int retset = RAI_TensorSetValueFromDouble(*t, i, val);
+                if (retset == -1) {
+                    RAI_TensorFree(*t);
+                    array_free(dims);
+                    if (ctx == NULL) {
+                        RAI_SetError(error, RAI_ETENSORSET,
+                                     "ERR cannot specify values for this datatype");
+                    } else {
+                        RedisModule_ReplyWithError(ctx,
+                                                   "ERR cannot specify values for this datatype");
+                    }
+                    return -1;
+                }
             } else {
-              RedisModule_ReplyWithError(ctx, "ERR invalid value");
+                long long val;
+                const int retval = RedisModule_StringToLongLong(argv[argpos], &val);
+                if (retval != REDISMODULE_OK) {
+                    RAI_TensorFree(*t);
+                    array_free(dims);
+                    if (ctx == NULL) {
+                        RAI_SetError(error, RAI_ETENSORSET, "ERR invalid value");
+                    } else {
+                        RedisModule_ReplyWithError(ctx, "ERR invalid value");
+                    }
+                    return -1;
+                }
+                const int retset = RAI_TensorSetValueFromLongLong(*t, i, val);
+                if (retset == -1) {
+                    RAI_TensorFree(*t);
+                    array_free(dims);
+                    if (ctx == NULL) {
+                        RAI_SetError(error, RAI_ETENSORSET,
+                                     "ERR cannot specify values for this datatype");
+                    } else {
+                        RedisModule_ReplyWithError(ctx,
+                                                   "ERR cannot specify values for this datatype");
+                    }
+                    return -1;
+                }
             }
-            return -1;
-          }
-          const int retset = RAI_TensorSetValueFromDouble(*t, i, val);
-          if (retset == -1){
-            RAI_TensorFree(*t);
-            array_free(dims);
-            if (ctx == NULL) {
-              RAI_SetError(error, RAI_ETENSORSET,
-                            "ERR cannot specify values for this datatype");
-            } else {
-              RedisModule_ReplyWithError(ctx, "ERR cannot specify values for this datatype");
-            }
-            return -1;
-          }
+            i++;
         }
-        else{
-          long long val;
-          const int retval = RedisModule_StringToLongLong(argv[argpos],&val);
-          if (retval != REDISMODULE_OK) {
-            RAI_TensorFree(*t);
-            array_free(dims);
-            if (ctx == NULL) {
-              RAI_SetError(error, RAI_ETENSORSET,
-                            "ERR invalid value");
-            } else {
-              RedisModule_ReplyWithError(ctx, "ERR invalid value");
-            }
-            return -1;
-          }
-          const int retset = RAI_TensorSetValueFromLongLong(*t, i, val);
-          if (retset == -1){
-            RAI_TensorFree(*t);
-            array_free(dims);
-            if (ctx == NULL) {
-              RAI_SetError(error, RAI_ETENSORSET,
-                            "ERR cannot specify values for this datatype");
-            } else {
-              RedisModule_ReplyWithError(ctx, "ERR cannot specify values for this datatype");
-            }
-            return -1;
-          }
-        }
-        i++;
-      }
-      break;
+        break;
     default:
-      // default does not require tensor data setting since calloc setted it to 0
-      break;
-  }
-  array_free(dims);
-  return argpos;
+        // default does not require tensor data setting since calloc setted it to 0
+        break;
+    }
+    array_free(dims);
+    return argpos;
 }
 
-int RAI_TensorReplyWithValues(RedisModuleCtx *ctx, RAI_Tensor* t) {
-  long long ndims = RAI_TensorNumDims(t);
-  long long len = 1;
-  long long i;
-  for (i=0; i<ndims; i++) {
-    len *= RAI_TensorDim(t, i);
-  }
-
-  DLDataType dtype = RAI_TensorDataType(t);
-
-  RedisModule_ReplyWithArray(ctx, len);
-
-  if (dtype.code == kDLFloat) {
-    double val;
-    for (i=0; i<len; i++) {
-      int ret = RAI_TensorGetValueAsDouble(t, i, &val);
-      if (!ret) {
-        RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
-        return -1;
-      }
-      RedisModule_ReplyWithDouble(ctx, val);
+int RAI_TensorReplyWithValues(RedisModuleCtx *ctx, RAI_Tensor *t) {
+    long long ndims = RAI_TensorNumDims(t);
+    long long len = 1;
+    long long i;
+    for (i = 0; i < ndims; i++) {
+        len *= RAI_TensorDim(t, i);
     }
-  }
-  else {
-    long long val;
-    for (i=0; i<len; i++) {
-      int ret = RAI_TensorGetValueAsLongLong(t, i, &val);
-      if (!ret) {
-        RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
-        return -1;
-      }
-      RedisModule_ReplyWithLongLong(ctx, val);
-    }
-  }
 
-  return 0;
-}
+    DLDataType dtype = RAI_TensorDataType(t);
 
-int RAI_parseTensorGetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RAI_Tensor *t){
-  if (argc < 2 || argc > 4) {
-    RedisModule_WrongArity(ctx);
-    return -1;
-  }
+    RedisModule_ReplyWithArray(ctx, len);
 
-  int datafmt;
-  int meta = 0;
-  int blob = 0;
-  int values = 0;
-  int fmt_error = 0;
-  for (int i=2; i<argc; i++) {
-    const char *fmtstr = RedisModule_StringPtrLen(argv[i], NULL);
-    if (!strcasecmp(fmtstr, "BLOB")) {
-      blob = 1;
-      datafmt = REDISAI_DATA_BLOB;
-    } else if (!strcasecmp(fmtstr, "VALUES")) {
-      values = 1;
-      datafmt = REDISAI_DATA_VALUES;
-    } else if (!strcasecmp(fmtstr, "META")) {
-      meta = 1;
-      datafmt = REDISAI_DATA_NONE;
+    if (dtype.code == kDLFloat) {
+        double val;
+        for (i = 0; i < len; i++) {
+            int ret = RAI_TensorGetValueAsDouble(t, i, &val);
+            if (!ret) {
+                RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
+                return -1;
+            }
+            RedisModule_ReplyWithDouble(ctx, val);
+        }
     } else {
-      fmt_error = 1;
+        long long val;
+        for (i = 0; i < len; i++) {
+            int ret = RAI_TensorGetValueAsLongLong(t, i, &val);
+            if (!ret) {
+                RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
+                return -1;
+            }
+            RedisModule_ReplyWithLongLong(ctx, val);
+        }
     }
-  }
 
-  if (fmt_error) {
-    RedisModule_ReplyWithError(ctx, "ERR unsupported data format");
-    return -1;
-  }
-
-  if (blob && values) {
-    RedisModule_ReplyWithError(ctx, "ERR both BLOB and VALUES specified");
-    return -1;
-  }
-
-  if (!meta && !blob && !values) {
-    RedisModule_ReplyWithError(ctx, "ERR no META, BLOB or VALUES specified");
-    return -1;
-  }
-
-  if (!meta && blob) {
-    long long size = RAI_TensorByteSize(t);
-    char *data = RAI_TensorData(t);
-    int ret = RedisModule_ReplyWithStringBuffer(ctx, data, size);
-    if (ret == -1) {
-      return -1;
-    }
-    return argc;
-  }
-
-  if (!meta && values) {
-    int ret = RAI_TensorReplyWithValues(ctx, t);
-    if (ret == -1) {
-      return -1;
-    }
-    return argc;
-  }
-
-  long long resplen = 4;
-
-  if (blob || values) {
-    resplen += 2;
-  }
-
-  const long long ndims = RAI_TensorNumDims(t);
-  
-  char *dtypestr = NULL;
-  const int dtypestr_result = Tensor_DataTypeStr(RAI_TensorDataType(t), &dtypestr);
-  if(dtypestr_result==REDISMODULE_ERR){
-    RedisModule_ReplyWithError(ctx, "ERR unsupported dtype");
-    return -1;
-  }
-
-  RedisModule_ReplyWithArray(ctx, resplen);
-
-  RedisModule_ReplyWithCString(ctx, "dtype");
-  RedisModule_ReplyWithCString(ctx, dtypestr);
-
-  RedisModule_ReplyWithCString(ctx, "shape");
-  RedisModule_ReplyWithArray(ctx, ndims);
-  for (long long i=0; i<ndims; i++) {
-    const long long dim = RAI_TensorDim(t, i);
-    RedisModule_ReplyWithLongLong(ctx, dim);
-  }
-
-  if (blob) {
-    long long size = RAI_TensorByteSize(t);
-    char *data = RAI_TensorData(t);
-
-    RedisModule_ReplyWithCString(ctx, "blob");
-    int ret = RedisModule_ReplyWithStringBuffer(ctx, data, size);
-
-    if (ret != REDISMODULE_OK) {
-      return -1;
-    }
-  }
-  else if (values) {
-    RedisModule_ReplyWithCString(ctx, "values");
-    int ret = RAI_TensorReplyWithValues(ctx, t);
-    if (ret != REDISMODULE_OK) {
-      return -1;
-    }
-  }
-
-  // return command arity as the number of processed args
-  return argc;
+    return 0;
 }
 
-RedisModuleType *RAI_TensorRedisType(void) {
-    return RedisAI_TensorType;
+int RAI_parseTensorGetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RAI_Tensor *t) {
+    if (argc < 2 || argc > 4) {
+        RedisModule_WrongArity(ctx);
+        return -1;
+    }
+
+    int datafmt;
+    int meta = 0;
+    int blob = 0;
+    int values = 0;
+    int fmt_error = 0;
+    for (int i = 2; i < argc; i++) {
+        const char *fmtstr = RedisModule_StringPtrLen(argv[i], NULL);
+        if (!strcasecmp(fmtstr, "BLOB")) {
+            blob = 1;
+            datafmt = REDISAI_DATA_BLOB;
+        } else if (!strcasecmp(fmtstr, "VALUES")) {
+            values = 1;
+            datafmt = REDISAI_DATA_VALUES;
+        } else if (!strcasecmp(fmtstr, "META")) {
+            meta = 1;
+            datafmt = REDISAI_DATA_NONE;
+        } else {
+            fmt_error = 1;
+        }
+    }
+
+    if (fmt_error) {
+        RedisModule_ReplyWithError(ctx, "ERR unsupported data format");
+        return -1;
+    }
+
+    if (blob && values) {
+        RedisModule_ReplyWithError(ctx, "ERR both BLOB and VALUES specified");
+        return -1;
+    }
+
+    if (!meta && !blob && !values) {
+        RedisModule_ReplyWithError(ctx, "ERR no META, BLOB or VALUES specified");
+        return -1;
+    }
+
+    if (!meta && blob) {
+        long long size = RAI_TensorByteSize(t);
+        char *data = RAI_TensorData(t);
+        int ret = RedisModule_ReplyWithStringBuffer(ctx, data, size);
+        if (ret == -1) {
+            return -1;
+        }
+        return argc;
+    }
+
+    if (!meta && values) {
+        int ret = RAI_TensorReplyWithValues(ctx, t);
+        if (ret == -1) {
+            return -1;
+        }
+        return argc;
+    }
+
+    long long resplen = 4;
+
+    if (blob || values) {
+        resplen += 2;
+    }
+
+    const long long ndims = RAI_TensorNumDims(t);
+
+    char *dtypestr = NULL;
+    const int dtypestr_result = Tensor_DataTypeStr(RAI_TensorDataType(t), &dtypestr);
+    if (dtypestr_result == REDISMODULE_ERR) {
+        RedisModule_ReplyWithError(ctx, "ERR unsupported dtype");
+        return -1;
+    }
+
+    RedisModule_ReplyWithArray(ctx, resplen);
+
+    RedisModule_ReplyWithCString(ctx, "dtype");
+    RedisModule_ReplyWithCString(ctx, dtypestr);
+
+    RedisModule_ReplyWithCString(ctx, "shape");
+    RedisModule_ReplyWithArray(ctx, ndims);
+    for (long long i = 0; i < ndims; i++) {
+        const long long dim = RAI_TensorDim(t, i);
+        RedisModule_ReplyWithLongLong(ctx, dim);
+    }
+
+    if (blob) {
+        long long size = RAI_TensorByteSize(t);
+        char *data = RAI_TensorData(t);
+
+        RedisModule_ReplyWithCString(ctx, "blob");
+        int ret = RedisModule_ReplyWithStringBuffer(ctx, data, size);
+
+        if (ret != REDISMODULE_OK) {
+            return -1;
+        }
+    } else if (values) {
+        RedisModule_ReplyWithCString(ctx, "values");
+        int ret = RAI_TensorReplyWithValues(ctx, t);
+        if (ret != REDISMODULE_OK) {
+            return -1;
+        }
+    }
+
+    // return command arity as the number of processed args
+    return argc;
 }
+
+RedisModuleType *RAI_TensorRedisType(void) { return RedisAI_TensorType; }

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -17,22 +17,22 @@
 #include "tensor_struct.h"
 #include "util/dict.h"
 
-#define TENSORALLOC_NONE 0
-#define TENSORALLOC_ALLOC 1
+#define TENSORALLOC_NONE   0
+#define TENSORALLOC_ALLOC  1
 #define TENSORALLOC_CALLOC 2
 
 // Numeric data type of tensor elements, one of FLOAT, DOUBLE, INT8, INT16,
 // INT32, INT64, UINT8, UINT16
-static const char* RAI_DATATYPE_STR_FLOAT = "FLOAT";
-static const char* RAI_DATATYPE_STR_DOUBLE = "DOUBLE";
-static const char* RAI_DATATYPE_STR_INT8 = "INT8";
-static const char* RAI_DATATYPE_STR_INT16 = "INT16";
-static const char* RAI_DATATYPE_STR_INT32 = "INT32";
-static const char* RAI_DATATYPE_STR_INT64 = "INT64";
-static const char* RAI_DATATYPE_STR_UINT8 = "UINT8";
-static const char* RAI_DATATYPE_STR_UINT16 = "UINT16";
+static const char *RAI_DATATYPE_STR_FLOAT = "FLOAT";
+static const char *RAI_DATATYPE_STR_DOUBLE = "DOUBLE";
+static const char *RAI_DATATYPE_STR_INT8 = "INT8";
+static const char *RAI_DATATYPE_STR_INT16 = "INT16";
+static const char *RAI_DATATYPE_STR_INT32 = "INT32";
+static const char *RAI_DATATYPE_STR_INT64 = "INT64";
+static const char *RAI_DATATYPE_STR_UINT8 = "UINT8";
+static const char *RAI_DATATYPE_STR_UINT16 = "UINT16";
 
-extern RedisModuleType* RedisAI_TensorType;
+extern RedisModuleType *RedisAI_TensorType;
 
 /**
  * Helper method to register the tensor type exported by the module.
@@ -40,7 +40,7 @@ extern RedisModuleType* RedisAI_TensorType;
  * @param ctx Context in which Redis modules operate
  * @return
  */
-int RAI_TensorInit(RedisModuleCtx* ctx);
+int RAI_TensorInit(RedisModuleCtx *ctx);
 
 /**
  * Allocate the memory and initialise the RAI_Tensor. Creates a tensor based on
@@ -54,8 +54,7 @@ int RAI_TensorInit(RedisModuleCtx* ctx);
  * @return allocated RAI_Tensor on success, or NULL if the allocation
  * failed.
  */
-RAI_Tensor* RAI_TensorCreate(const char* dataType, long long* dims, int ndims,
-                             int hasdata);
+RAI_Tensor *RAI_TensorCreate(const char *dataType, long long *dims, int ndims, int hasdata);
 
 /**
  * Allocate the memory and initialise the RAI_Tensor. Creates a tensor based on
@@ -71,8 +70,8 @@ RAI_Tensor* RAI_TensorCreate(const char* dataType, long long* dims, int ndims,
  * @return allocated RAI_Tensor on success, or NULL if the allocation
  * failed.
  */
-RAI_Tensor* RAI_TensorCreateWithDLDataType(DLDataType dtype, long long* dims,
-                                           int ndims, int tensorAllocMode);
+RAI_Tensor *RAI_TensorCreateWithDLDataType(DLDataType dtype, long long *dims, int ndims,
+                                           int tensorAllocMode);
 
 /**
  * Allocate the memory for a new Tensor and copy data fom a tensor to it.
@@ -82,7 +81,7 @@ RAI_Tensor* RAI_TensorCreateWithDLDataType(DLDataType dtype, long long* dims,
  * @return 0 on success, or 1 if the copy failed
  * failed.
  */
-int RAI_TensorDeepCopy(RAI_Tensor* t, RAI_Tensor** dest);
+int RAI_TensorDeepCopy(RAI_Tensor *t, RAI_Tensor **dest);
 
 /**
  * Allocate the memory and initialise the RAI_Tensor, performing a shallow copy
@@ -94,7 +93,7 @@ int RAI_TensorDeepCopy(RAI_Tensor* t, RAI_Tensor** dest);
  * @return allocated RAI_Tensor on success, or NULL if the allocation
  * failed.
  */
-RAI_Tensor* RAI_TensorCreateFromDLTensor(DLManagedTensor* dl_tensor);
+RAI_Tensor *RAI_TensorCreateFromDLTensor(DLManagedTensor *dl_tensor);
 
 /**
  * Allocate the memory and initialise the RAI_Tensor, performing a deep copy of
@@ -105,8 +104,7 @@ RAI_Tensor* RAI_TensorCreateFromDLTensor(DLManagedTensor* dl_tensor);
  * @return allocated RAI_Tensor on success, or NULL if the allocation and deep
  * copy failed failed.
  */
-RAI_Tensor* RAI_TensorCreateByConcatenatingTensors(RAI_Tensor** ts,
-                                                   long long n);
+RAI_Tensor *RAI_TensorCreateByConcatenatingTensors(RAI_Tensor **ts, long long n);
 
 /**
  * Allocate the memory and initialise the RAI_Tensor, performing a deep copy of
@@ -118,8 +116,7 @@ RAI_Tensor* RAI_TensorCreateByConcatenatingTensors(RAI_Tensor** ts,
  * @return allocated RAI_Tensor on success, or NULL if the allocation and deep
  * copy failed failed.
  */
-RAI_Tensor* RAI_TensorCreateBySlicingTensor(RAI_Tensor* t, long long offset,
-                                            long long len);
+RAI_Tensor *RAI_TensorCreateBySlicingTensor(RAI_Tensor *t, long long offset, long long len);
 
 /**
  * Returns the length of the input tensor
@@ -127,7 +124,7 @@ RAI_Tensor* RAI_TensorCreateBySlicingTensor(RAI_Tensor* t, long long offset,
  * @param t input tensor
  * @return the length of the input tensor
  */
-size_t RAI_TensorLength(RAI_Tensor* t);
+size_t RAI_TensorLength(RAI_Tensor *t);
 
 /**
  * Returns the size in bytes of each element of the tensor
@@ -135,7 +132,7 @@ size_t RAI_TensorLength(RAI_Tensor* t);
  * @param t input tensor
  * @return size in bytes of each the underlying tensor data type
  */
-size_t RAI_TensorDataSize(RAI_Tensor* t);
+size_t RAI_TensorDataSize(RAI_Tensor *t);
 
 /**
  * Returns the size in bytes of the given DLDataType
@@ -152,7 +149,7 @@ size_t RAI_TensorDataSizeFromDLDataType(DLDataType dtype);
  * @param dataType
  * @return size in bytes of each the underlying tensor data type
  */
-size_t RAI_TensorDataSizeFromString(const char* dataType);
+size_t RAI_TensorDataSizeFromString(const char *dataType);
 
 /**
  * Get the associated `DLDataType` for the given input tensor
@@ -160,7 +157,7 @@ size_t RAI_TensorDataSizeFromString(const char* dataType);
  * @param t input tensor
  * @return the associated `DLDataType` for the given input tensor
  */
-DLDataType RAI_TensorDataType(RAI_Tensor* t);
+DLDataType RAI_TensorDataType(RAI_Tensor *t);
 
 /**
  * Check whether two tensors have the same data type
@@ -169,7 +166,7 @@ DLDataType RAI_TensorDataType(RAI_Tensor* t);
  * @param t2 input tensor
  * @return 1 if data types match, 0 otherwise
  */
-int RAI_TensorIsDataTypeEqual(RAI_Tensor* t1, RAI_Tensor* t2);
+int RAI_TensorIsDataTypeEqual(RAI_Tensor *t1, RAI_Tensor *t2);
 
 /**
  * Returns the DLDataType represented by the input string
@@ -177,7 +174,7 @@ int RAI_TensorIsDataTypeEqual(RAI_Tensor* t1, RAI_Tensor* t2);
  * @param dataType
  * @return the DLDataType represented by the input string
  */
-DLDataType RAI_TensorDataTypeFromString(const char* dataType);
+DLDataType RAI_TensorDataTypeFromString(const char *dataType);
 
 /**
  * sets in dtypestr the string representing the associated DLDataType
@@ -187,7 +184,7 @@ DLDataType RAI_TensorDataTypeFromString(const char* dataType);
  * DLDataType
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR if failed
  */
-int Tensor_DataTypeStr(DLDataType dtype, char** dtypestr);
+int Tensor_DataTypeStr(DLDataType dtype, char **dtypestr);
 
 /**
  * Frees the memory of the RAI_Tensor when the tensor reference count reaches 0.
@@ -195,7 +192,7 @@ int Tensor_DataTypeStr(DLDataType dtype, char** dtypestr);
  *
  * @param t tensor
  */
-void RAI_TensorFree(RAI_Tensor* t);
+void RAI_TensorFree(RAI_Tensor *t);
 
 /**
  * Sets the associated data to the deep learning tensor via deep copying the
@@ -206,7 +203,7 @@ void RAI_TensorFree(RAI_Tensor* t);
  * @param len input data length
  * @return 1 on success
  */
-int RAI_TensorSetData(RAI_Tensor* t, const char* data, size_t len);
+int RAI_TensorSetData(RAI_Tensor *t, const char *data, size_t len);
 
 /**
  * Sets the long value for the given tensor, at the given array data pointer
@@ -217,7 +214,7 @@ int RAI_TensorSetData(RAI_Tensor* t, const char* data, size_t len);
  * @param val value to set the data from
  * @return 0 on success, or 1 if the setting failed
  */
-int RAI_TensorSetValueFromLongLong(RAI_Tensor* t, long long i, long long val);
+int RAI_TensorSetValueFromLongLong(RAI_Tensor *t, long long i, long long val);
 
 /**
  * Sets the double value for the given tensor, at the given array data pointer
@@ -228,7 +225,7 @@ int RAI_TensorSetValueFromLongLong(RAI_Tensor* t, long long i, long long val);
  * @param val value to set the data from
  * @return 0 on success, or 1 if the setting failed
  */
-int RAI_TensorSetValueFromDouble(RAI_Tensor* t, long long i, double val);
+int RAI_TensorSetValueFromDouble(RAI_Tensor *t, long long i, double val);
 
 /**
  * Gets the double value from the given input tensor, at the given array data
@@ -239,7 +236,7 @@ int RAI_TensorSetValueFromDouble(RAI_Tensor* t, long long i, double val);
  * @param val value to set the data to
  * @return 0 on success, or 1 if getting the data failed
  */
-int RAI_TensorGetValueAsDouble(RAI_Tensor* t, long long i, double* val);
+int RAI_TensorGetValueAsDouble(RAI_Tensor *t, long long i, double *val);
 
 /**
  * Gets the long value from the given input tensor, at the given array data
@@ -250,7 +247,7 @@ int RAI_TensorGetValueAsDouble(RAI_Tensor* t, long long i, double* val);
  * @param val value to set the data to
  * @return 0 on success, or 1 if getting the data failed
  */
-int RAI_TensorGetValueAsLongLong(RAI_Tensor* t, long long i, long long* val);
+int RAI_TensorGetValueAsLongLong(RAI_Tensor *t, long long i, long long *val);
 
 /**
  * Every call to this function, will make the RAI_Tensor 't' requiring an
@@ -260,7 +257,7 @@ int RAI_TensorGetValueAsLongLong(RAI_Tensor* t, long long i, long long* val);
  * @param t input tensor
  * @return shallow copy of the tensor
  */
-RAI_Tensor* RAI_TensorGetShallowCopy(RAI_Tensor* t);
+RAI_Tensor *RAI_TensorGetShallowCopy(RAI_Tensor *t);
 
 /**
  * Returns the number of dimensions for the given input tensor
@@ -268,7 +265,7 @@ RAI_Tensor* RAI_TensorGetShallowCopy(RAI_Tensor* t);
  * @param t input tensor
  * @return number of dimensions for the given input tensor
  */
-int RAI_TensorNumDims(RAI_Tensor* t);
+int RAI_TensorNumDims(RAI_Tensor *t);
 
 /**
  * Returns the dimension length for the given input tensor and dimension
@@ -277,7 +274,7 @@ int RAI_TensorNumDims(RAI_Tensor* t);
  * @param dim dimension
  * @return the dimension length
  */
-long long RAI_TensorDim(RAI_Tensor* t, int dim);
+long long RAI_TensorDim(RAI_Tensor *t, int dim);
 
 /**
  * Returns the size in bytes of the underlying deep learning tensor data
@@ -285,7 +282,7 @@ long long RAI_TensorDim(RAI_Tensor* t, int dim);
  * @param t input tensor
  * @return the size in bytes of the underlying deep learning tensor data
  */
-size_t RAI_TensorByteSize(RAI_Tensor* t);
+size_t RAI_TensorByteSize(RAI_Tensor *t);
 
 /**
  * Return the pointer the the deep learning tensor data
@@ -293,7 +290,7 @@ size_t RAI_TensorByteSize(RAI_Tensor* t);
  * @param t input tensor
  * @return direct access to the array data pointer
  */
-char* RAI_TensorData(RAI_Tensor* t);
+char *RAI_TensorData(RAI_Tensor *t);
 
 /**
  * Helper method to open a key handler for the tensor data type
@@ -307,8 +304,8 @@ char* RAI_TensorData(RAI_Tensor* t);
  * the tensor type, or REDISMODULE_ERR if is the key not associated with a
  * tensor type.
  */
-int RAI_OpenKey_Tensor(RedisModuleCtx* ctx, RedisModuleString* keyName,
-                       RedisModuleKey** key, int mode);
+int RAI_OpenKey_Tensor(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key,
+                       int mode);
 
 /**
  * Helper method to get Tensor from keyspace. In the case of failure the key is
@@ -324,9 +321,8 @@ int RAI_OpenKey_Tensor(RedisModuleCtx* ctx, RedisModuleString* keyName,
  * returned and available at *tensor variable, or REDISMODULE_ERR if there was
  * an error getting the Tensor
  */
-int RAI_GetTensorFromKeyspace(RedisModuleCtx* ctx, RedisModuleString* keyName,
-                              RedisModuleKey** key, RAI_Tensor** tensor,
-                              int mode);
+int RAI_GetTensorFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName, RedisModuleKey **key,
+                              RAI_Tensor **tensor, int mode);
 
 /**
  * Helper method to get Tensor from local context ( no keyspace access )
@@ -340,10 +336,9 @@ int RAI_GetTensorFromKeyspace(RedisModuleCtx* ctx, RedisModuleString* keyName,
  * failure
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR if failed
  */
-int RAI_getTensorFromLocalContext(RedisModuleCtx* ctx,
-                                  AI_dict* localContextDict,
-                                  const char* localContextKey,
-                                  RAI_Tensor** tensor, RAI_Error* error);
+int RAI_getTensorFromLocalContext(RedisModuleCtx *ctx, AI_dict *localContextDict,
+                                  const char *localContextKey, RAI_Tensor **tensor,
+                                  RAI_Error *error);
 
 /**
  * Helper method to replicate a tensor via an AI.TENSORSET command to the
@@ -356,8 +351,7 @@ int RAI_getTensorFromLocalContext(RedisModuleCtx* ctx,
  * @param key Destination key name
  * @param t source tensor
  */
-void RedisAI_ReplicateTensorSet(RedisModuleCtx* ctx, RedisModuleString* key,
-                                RAI_Tensor* t);
+void RedisAI_ReplicateTensorSet(RedisModuleCtx *ctx, RedisModuleString *key, RAI_Tensor *t);
 
 /**
  * Helper method to parse AI.TENSORGET arguments
@@ -371,9 +365,8 @@ void RedisAI_ReplicateTensorSet(RedisModuleCtx* ctx, RedisModuleString* key,
  * parsing failures
  * @return processed number of arguments on success, or -1 if the parsing failed
  */
-int RAI_parseTensorSetArgs(RedisModuleCtx* ctx, RedisModuleString** argv,
-                           int argc, RAI_Tensor** t, int enforceArity,
-                           RAI_Error* error);
+int RAI_parseTensorSetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RAI_Tensor **t,
+                           int enforceArity, RAI_Error *error);
 
 /**
  * Helper method to parse AI.TENSORGET arguments
@@ -384,8 +377,7 @@ int RAI_parseTensorSetArgs(RedisModuleCtx* ctx, RedisModuleString** argv,
  * @param t Destination tensor to store the parsed data
  * @return processed number of arguments on success, or -1 if the parsing failed
  */
-int RAI_parseTensorGetArgs(RedisModuleCtx* ctx, RedisModuleString** argv,
-                           int argc, RAI_Tensor* t);
+int RAI_parseTensorGetArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RAI_Tensor *t);
 
 /**
  * @brief  Returns the redis module type representing a tensor.

--- a/src/tensor_struct.h
+++ b/src/tensor_struct.h
@@ -5,8 +5,8 @@
 #include "dlpack/dlpack.h"
 
 typedef struct RAI_Tensor {
-  DLManagedTensor tensor;
-  long long refCount;
+    DLManagedTensor tensor;
+    long long refCount;
 } RAI_Tensor;
 
 #endif /* SRC_TENSOR_STRUCT_H_ */

--- a/src/util/arr.h
+++ b/src/util/arr.h
@@ -32,18 +32,18 @@
  * to those of the RM_ family
  */
 #ifndef array_alloc_fn
-#define array_alloc_fn malloc
+#define array_alloc_fn   malloc
 #define array_realloc_fn realloc
-#define array_free_fn free
+#define array_free_fn    free
 #endif
 
 typedef struct {
-  uint32_t len;
-  // TODO: optimize memory by making cap a 16-bit delta from len, and elem_sz 16 bit as well. This
-  // makes the whole header fit in 64 bit
-  uint32_t cap;
-  uint32_t elem_sz;
-  char buf[];
+    uint32_t len;
+    // TODO: optimize memory by making cap a 16-bit delta from len, and elem_sz 16 bit as well. This
+    // makes the whole header fit in 64 bit
+    uint32_t cap;
+    uint32_t elem_sz;
+    char buf[];
 } array_hdr_t;
 
 typedef void *array_t;
@@ -57,11 +57,11 @@ typedef void *array_t;
 /* Initialize a new array with a given element size and capacity. Should not be used directly - use
  * array_new instead */
 static array_t array_new_sz(uint32_t elem_sz, uint32_t cap, uint32_t len) {
-  array_hdr_t *hdr = array_alloc_fn(sizeof(array_hdr_t) + cap * elem_sz);
-  hdr->cap = cap;
-  hdr->elem_sz = elem_sz;
-  hdr->len = len;
-  return (array_t)(hdr->buf);
+    array_hdr_t *hdr = array_alloc_fn(sizeof(array_hdr_t) + cap * elem_sz);
+    hdr->cap = cap;
+    hdr->elem_sz = elem_sz;
+    hdr->len = len;
+    return (array_t)(hdr->buf);
 }
 
 /* Initialize an array for a given type T with a given capacity and zero length. The array should be
@@ -79,47 +79,45 @@ static array_t array_new_sz(uint32_t elem_sz, uint32_t cap, uint32_t len) {
 #define array_newlen(T, len) (array_new_sz(sizeof(T), len, len))
 
 static inline array_t array_ensure_cap(array_t arr, uint32_t cap) {
-  array_hdr_t *hdr = array_hdr(arr);
-  if (cap > hdr->cap) {
-    hdr->cap = MAX(hdr->cap * 2, cap);
-    hdr = array_realloc_fn(hdr, array_sizeof(hdr));
-  }
-  return (array_t)hdr->buf;
+    array_hdr_t *hdr = array_hdr(arr);
+    if (cap > hdr->cap) {
+        hdr->cap = MAX(hdr->cap * 2, cap);
+        hdr = array_realloc_fn(hdr, array_sizeof(hdr));
+    }
+    return (array_t)hdr->buf;
 }
 
 /* Ensure capacity for the array to grow by one */
 static inline array_t array_grow(array_t arr) {
-  return array_ensure_cap(arr, ++array_hdr(arr)->len);
+    return array_ensure_cap(arr, ++array_hdr(arr)->len);
 }
 
 /* get the last element in the array */
 #define array_tail(arr) (arr[array_hdr(arr)->len - 1])
 
 /* Append an element to the array, returning the array which may have been reallocated */
-#define array_append(arr, x)   \
-  ({                           \
-    (arr) = array_grow((arr)); \
-    array_tail((arr)) = (x);   \
-    (arr);                     \
-  })
+#define array_append(arr, x)                                                                       \
+    ({                                                                                             \
+        (arr) = array_grow((arr));                                                                 \
+        array_tail((arr)) = (x);                                                                   \
+        (arr);                                                                                     \
+    })
 
 /* Get the length of the array */
-static inline uint32_t array_len(array_t arr) {
-  return arr ? array_hdr(arr)->len : 0;
-}
+static inline uint32_t array_len(array_t arr) { return arr ? array_hdr(arr)->len : 0; }
 
 static inline void *array_trimm(array_t arr, uint32_t len, uint32_t cap) {
-  array_hdr_t *arr_hdr = array_hdr(arr);
-  assert(len >= 0 && "trimming len is negative");
-  assert((cap == -1 || cap > 0 || len == cap) && "trimming capacity is illegal");
-  assert((cap == -1 || cap >= len) && "trimming len is greater then capacity");
-  assert((len <= arr_hdr->len) && "trimming len is greater then current len");
-  arr_hdr->len = len;
-  if (cap != -1) {
-    arr_hdr->cap = cap;
-    arr_hdr = array_realloc_fn(arr_hdr, array_sizeof(arr_hdr));
-  }
-  return arr_hdr->buf;
+    array_hdr_t *arr_hdr = array_hdr(arr);
+    assert(len >= 0 && "trimming len is negative");
+    assert((cap == -1 || cap > 0 || len == cap) && "trimming capacity is illegal");
+    assert((cap == -1 || cap >= len) && "trimming len is greater then capacity");
+    assert((len <= arr_hdr->len) && "trimming len is greater then current len");
+    arr_hdr->len = len;
+    if (cap != -1) {
+        arr_hdr->cap = cap;
+        arr_hdr = array_realloc_fn(arr_hdr, array_sizeof(arr_hdr));
+    }
+    return arr_hdr->buf;
 }
 
 #define array_trimm_len(arr, len) array_trimm(arr, len, -1)
@@ -128,9 +126,7 @@ static inline void *array_trimm(array_t arr, uint32_t len, uint32_t cap) {
 #define array_clear(arr) array_hdr(arr)->len = 0
 
 /* Free the array, without dealing with individual elements */
-static void array_free(array_t arr) {
-  array_free_fn(array_hdr(arr));
-}
+static void array_free(array_t arr) { array_free_fn(array_hdr(arr)); }
 
 /* Repeate the code in "blk" for each element in the array, and give it the name of "as".
  * e.g:
@@ -138,31 +134,31 @@ static void array_free(array_t arr) {
  *  arr = array_append(arr, 1);
  *  array_foreach(arr, i, printf("%d\n", i));
  */
-#define array_foreach(arr, as, blk)                 \
-  ({                                                \
-    for (uint32_t i = 0; i < array_len(arr); i++) { \
-      typeof(*arr) as = arr[i];                     \
-      blk;                                          \
-    }                                               \
-  })
+#define array_foreach(arr, as, blk)                                                                \
+    ({                                                                                             \
+        for (uint32_t i = 0; i < array_len(arr); i++) {                                            \
+            typeof(*arr) as = arr[i];                                                              \
+            blk;                                                                                   \
+        }                                                                                          \
+    })
 
 /* Free the array, freeing individual elements with free_cb */
-#define array_free_ex(arr, blk)                       \
-  ({                                                  \
-    if (arr) {                                        \
-      for (uint32_t i = 0; i < array_len(arr); i++) { \
-        void *ptr = &arr[i];                          \
-        { blk; }                                      \
-      }                                               \
-      array_free(arr);                                \
-    }                                                 \
-  })
+#define array_free_ex(arr, blk)                                                                    \
+    ({                                                                                             \
+        if (arr) {                                                                                 \
+            for (uint32_t i = 0; i < array_len(arr); i++) {                                        \
+                void *ptr = &arr[i];                                                               \
+                { blk; }                                                                           \
+            }                                                                                      \
+            array_free(arr);                                                                       \
+        }                                                                                          \
+    })
 
 /* Pop the top element from the array, reduce the size and return it */
-#define array_pop(arr)               \
-  ({                                 \
-    assert(array_hdr(arr)->len > 0); \
-    arr[--(array_hdr(arr)->len)];    \
-  })
+#define array_pop(arr)                                                                             \
+    ({                                                                                             \
+        assert(array_hdr(arr)->len > 0);                                                           \
+        arr[--(array_hdr(arr)->len)];                                                              \
+    })
 
 #endif

--- a/src/util/arr_rm_alloc.h
+++ b/src/util/arr_rm_alloc.h
@@ -8,9 +8,9 @@
 #include "redismodule.h"
 
 /* Define the allcation functions before including arr.h */
-#define array_alloc_fn RedisModule_Alloc
+#define array_alloc_fn   RedisModule_Alloc
 #define array_realloc_fn RedisModule_Realloc
-#define array_free_fn RedisModule_Free
+#define array_free_fn    RedisModule_Free
 
 #include "arr.h"
 

--- a/src/util/dict.c
+++ b/src/util/dict.c
@@ -49,41 +49,37 @@
 
 #include "siphash.c.inc"
 
-static uint64_t stringsHashFunction(const void *key){
-    return AI_dictGenHashFunction(key, strlen((char*)key));
+static uint64_t stringsHashFunction(const void *key) {
+    return AI_dictGenHashFunction(key, strlen((char *)key));
 }
 
-static int stringsKeyCompare(void *privdata, const void *key1, const void *key2){
-    const char* strKey1 = key1;
-    const char* strKey2 = key2;
+static int stringsKeyCompare(void *privdata, const void *key1, const void *key2) {
+    const char *strKey1 = key1;
+    const char *strKey2 = key2;
 
     return strcmp(strKey1, strKey2) == 0;
 }
 
-static void stringsKeyDestructor(void *privdata, void *key){
-    RA_FREE(key);
-}
+static void stringsKeyDestructor(void *privdata, void *key) { RA_FREE(key); }
 
-static void* stringsKeyDup(void *privdata, const void *key){
-    return RA_STRDUP((char*)key);
-}
+static void *stringsKeyDup(void *privdata, const void *key) { return RA_STRDUP((char *)key); }
 
 AI_dictType AI_dictTypeHeapStringsVals = {
-        .hashFunction = stringsHashFunction,
-        .keyDup = stringsKeyDup,
-        .valDup = NULL,
-        .keyCompare = stringsKeyCompare,
-        .keyDestructor = stringsKeyDestructor,
-        .valDestructor = stringsKeyDestructor,
+    .hashFunction = stringsHashFunction,
+    .keyDup = stringsKeyDup,
+    .valDup = NULL,
+    .keyCompare = stringsKeyCompare,
+    .keyDestructor = stringsKeyDestructor,
+    .valDestructor = stringsKeyDestructor,
 };
 
 AI_dictType AI_dictTypeHeapStrings = {
-        .hashFunction = stringsHashFunction,
-        .keyDup = stringsKeyDup,
-        .valDup = NULL,
-        .keyCompare = stringsKeyCompare,
-        .keyDestructor = stringsKeyDestructor,
-        .valDestructor = NULL,
+    .hashFunction = stringsHashFunction,
+    .keyDup = stringsKeyDup,
+    .valDup = NULL,
+    .keyCompare = stringsKeyCompare,
+    .keyDestructor = stringsKeyDestructor,
+    .valDestructor = NULL,
 };
 
 /* Using dictEnableResize() / dictDisableResize() we make possible to
@@ -109,12 +105,10 @@ static int _AI_dictInit(AI_dict *ht, AI_dictType *type, void *privDataPtr);
 static uint8_t dict_hash_function_seed[16];
 
 void AI_dictSetHashFunctionSeed(uint8_t *seed) {
-    memcpy(dict_hash_function_seed,seed,sizeof(dict_hash_function_seed));
+    memcpy(dict_hash_function_seed, seed, sizeof(dict_hash_function_seed));
 }
 
-uint8_t *AI_dictGetHashFunctionSeed(void) {
-    return dict_hash_function_seed;
-}
+uint8_t *AI_dictGetHashFunctionSeed(void) { return dict_hash_function_seed; }
 
 /* The default hashing function uses SipHash implementation
  * in _AI_siphash.c. */
@@ -123,19 +117,18 @@ uint64_t _AI_siphash(const uint8_t *in, const size_t inlen, const uint8_t *k);
 uint64_t _AI_siphash_nocase(const uint8_t *in, const size_t inlen, const uint8_t *k);
 
 uint64_t AI_dictGenHashFunction(const void *key, int len) {
-    return _AI_siphash(key,len,dict_hash_function_seed);
+    return _AI_siphash(key, len, dict_hash_function_seed);
 }
 
 uint64_t AI_dictGenCaseHashFunction(const unsigned char *buf, int len) {
-    return _AI_siphash_nocase(buf,len,dict_hash_function_seed);
+    return _AI_siphash_nocase(buf, len, dict_hash_function_seed);
 }
 
 /* ----------------------------- API implementation ------------------------- */
 
 /* Reset a hash table already initialized with ht_init().
  * NOTE: This function should only be called by ht_destroy(). */
-static void _AI_dictReset(AI_dictht *ht)
-{
+static void _AI_dictReset(AI_dictht *ht) {
     ht->table = NULL;
     ht->size = 0;
     ht->sizemask = 0;
@@ -143,19 +136,15 @@ static void _AI_dictReset(AI_dictht *ht)
 }
 
 /* Create a new hash table */
-AI_dict *AI_dictCreate(AI_dictType *type,
-                             void *privDataPtr)
-{
+AI_dict *AI_dictCreate(AI_dictType *type, void *privDataPtr) {
     AI_dict *d = RA_ALLOC(sizeof(*d));
 
-    _AI_dictInit(d,type,privDataPtr);
+    _AI_dictInit(d, type, privDataPtr);
     return d;
 }
 
 /* Initialize the hash table */
-int _AI_dictInit(AI_dict *d, AI_dictType *type,
-              void *privDataPtr)
-{
+int _AI_dictInit(AI_dict *d, AI_dictType *type, void *privDataPtr) {
     _AI_dictReset(&d->ht[0]);
     _AI_dictReset(&d->ht[1]);
     d->type = type;
@@ -167,11 +156,11 @@ int _AI_dictInit(AI_dict *d, AI_dictType *type,
 
 /* Resize the table to the minimal size that contains all the elements,
  * but with the invariant of a USED/BUCKETS ratio near to <= 1 */
-int AI_dictResize(AI_dict *d)
-{
+int AI_dictResize(AI_dict *d) {
     int minimal;
 
-    if (!dict_can_resize || AI_dictIsRehashing(d)) return DICT_ERR;
+    if (!dict_can_resize || AI_dictIsRehashing(d))
+        return DICT_ERR;
     minimal = d->ht[0].used;
     if (minimal < DICT_HT_INITIAL_SIZE)
         minimal = DICT_HT_INITIAL_SIZE;
@@ -179,8 +168,7 @@ int AI_dictResize(AI_dict *d)
 }
 
 /* Expand or create the hash table */
-int AI_dictExpand(AI_dict *d, unsigned long size)
-{
+int AI_dictExpand(AI_dict *d, unsigned long size) {
     /* the size is invalid if it is smaller than the number of
      * elements already inside the hash table */
     if (AI_dictIsRehashing(d) || d->ht[0].used > size)
@@ -190,12 +178,13 @@ int AI_dictExpand(AI_dict *d, unsigned long size)
     unsigned long realsize = _AI_dictNextPower(size);
 
     /* Rehashing to the same table size is not useful. */
-    if (realsize == d->ht[0].size) return DICT_ERR;
+    if (realsize == d->ht[0].size)
+        return DICT_ERR;
 
     /* Allocate the new hash table and initialize all pointers to NULL */
     n.size = realsize;
-    n.sizemask = realsize-1;
-    n.table = RA_CALLOC(realsize, sizeof(AI_dictEntry*));
+    n.sizemask = realsize - 1;
+    n.table = RA_CALLOC(realsize, sizeof(AI_dictEntry *));
     n.used = 0;
 
     /* Is this the first initialization? If so it's not really a rehashing
@@ -221,22 +210,24 @@ int AI_dictExpand(AI_dict *d, unsigned long size)
  * will visit at max N*10 empty buckets in total, otherwise the amount of
  * work it does would be unbound and the function may block for a long time. */
 int AI_dictRehash(AI_dict *d, int n) {
-    int empty_visits = n*10; /* Max number of empty buckets to visit. */
-    if (!AI_dictIsRehashing(d)) return 0;
+    int empty_visits = n * 10; /* Max number of empty buckets to visit. */
+    if (!AI_dictIsRehashing(d))
+        return 0;
 
-    while(n-- && d->ht[0].used != 0) {
+    while (n-- && d->ht[0].used != 0) {
         AI_dictEntry *de, *nextde;
 
         /* Note that rehashidx can't overflow as we are sure there are more
          * elements because ht[0].used != 0 */
         assert(d->ht[0].size > (unsigned long)d->rehashidx);
-        while(d->ht[0].table[d->rehashidx] == NULL) {
+        while (d->ht[0].table[d->rehashidx] == NULL) {
             d->rehashidx++;
-            if (--empty_visits == 0) return 1;
+            if (--empty_visits == 0)
+                return 1;
         }
         de = d->ht[0].table[d->rehashidx];
         /* Move all the keys in this bucket from the old to the new hash HT */
-        while(de) {
+        while (de) {
             uint64_t h;
 
             nextde = de->next;
@@ -268,8 +259,8 @@ int AI_dictRehash(AI_dict *d, int n) {
 long long timeInMilliseconds(void) {
     struct timeval tv;
 
-    gettimeofday(&tv,NULL);
-    return (((long long)tv.tv_sec)*1000)+(tv.tv_usec/1000);
+    gettimeofday(&tv, NULL);
+    return (((long long)tv.tv_sec) * 1000) + (tv.tv_usec / 1000);
 }
 
 /* Rehash for an amount of time between ms milliseconds and ms+1 milliseconds */
@@ -277,9 +268,10 @@ int AI_dictRehashMilliseconds(AI_dict *d, int ms) {
     long long start = timeInMilliseconds();
     int rehashes = 0;
 
-    while(AI_dictRehash(d,100)) {
+    while (AI_dictRehash(d, 100)) {
         rehashes += 100;
-        if (timeInMilliseconds()-start > ms) break;
+        if (timeInMilliseconds() - start > ms)
+            break;
     }
     return rehashes;
 }
@@ -293,7 +285,8 @@ int AI_dictRehashMilliseconds(AI_dict *d, int ms) {
  * dictionary so that the hash table automatically migrates from H1 to H2
  * while it is actively used. */
 static void _AI_dictRehashStep(AI_dict *d) {
-    if (d->iterators == 0) AI_dictRehash(d,1);
+    if (d->iterators == 0)
+        AI_dictRehash(d, 1);
 }
 
 /**
@@ -301,11 +294,11 @@ static void _AI_dictRehashStep(AI_dict *d) {
  * @return 0 on success, or 1 if the insertion failed
  * failed.
  */
-int AI_dictAdd(AI_dict *d, void *key, void *val)
-{
-    AI_dictEntry *entry = AI_dictAddRaw(d,key,NULL);
+int AI_dictAdd(AI_dict *d, void *key, void *val) {
+    AI_dictEntry *entry = AI_dictAddRaw(d, key, NULL);
 
-    if (!entry) return DICT_ERR;
+    if (!entry)
+        return DICT_ERR;
     AI_dictSetVal(d, entry, val);
     return DICT_OK;
 }
@@ -328,17 +321,17 @@ int AI_dictAdd(AI_dict *d, void *key, void *val)
  *
  * If key was added, the hash entry is returned to be manipulated by the caller.
  */
-AI_dictEntry *AI_dictAddRaw(AI_dict *d, void *key, AI_dictEntry **existing)
-{
+AI_dictEntry *AI_dictAddRaw(AI_dict *d, void *key, AI_dictEntry **existing) {
     long index;
     AI_dictEntry *entry;
     AI_dictht *ht;
 
-    if (AI_dictIsRehashing(d))_AI_dictRehashStep(d);
+    if (AI_dictIsRehashing(d))
+        _AI_dictRehashStep(d);
 
     /* Get the index of the new element, or -1 if
      * the element already exists. */
-    if ((index = _AI_dictKeyIndex(d, key, AI_dictHashKey(d,key), existing)) == -1)
+    if ((index = _AI_dictKeyIndex(d, key, AI_dictHashKey(d, key), existing)) == -1)
         return NULL;
 
     /* Allocate the memory and store the new entry.
@@ -361,13 +354,12 @@ AI_dictEntry *AI_dictAddRaw(AI_dict *d, void *key, AI_dictEntry **existing)
  * Return 1 if the key was added from scratch, 0 if there was already an
  * element with such key and dictReplace() just performed a value update
  * operation. */
-int AI_dictReplace(AI_dict *d, void *key, void *val)
-{
+int AI_dictReplace(AI_dict *d, void *key, void *val) {
     AI_dictEntry *entry, *existing, auxentry;
 
     /* Try to add the element. If the key
      * does not exists dictAdd will succeed. */
-    entry = AI_dictAddRaw(d,key,&existing);
+    entry = AI_dictAddRaw(d, key, &existing);
     if (entry) {
         AI_dictSetVal(d, entry, val);
         return 1;
@@ -393,7 +385,7 @@ int AI_dictReplace(AI_dict *d, void *key, void *val)
  * See dictAddRaw() for more information. */
 AI_dictEntry *AI_dictAddOrFind(AI_dict *d, void *key) {
     AI_dictEntry *entry, *existing;
-    entry = AI_dictAddRaw(d,key,&existing);
+    entry = AI_dictAddRaw(d, key, &existing);
     return entry ? entry : existing;
 }
 
@@ -405,17 +397,19 @@ static AI_dictEntry *dictGenericDelete(AI_dict *d, const void *key, int nofree) 
     AI_dictEntry *he, *prevHe;
     int table;
 
-    if (d->ht[0].used == 0 && d->ht[1].used == 0) return NULL;
+    if (d->ht[0].used == 0 && d->ht[1].used == 0)
+        return NULL;
 
-    if (AI_dictIsRehashing(d))_AI_dictRehashStep(d);
+    if (AI_dictIsRehashing(d))
+        _AI_dictRehashStep(d);
     h = AI_dictHashKey(d, key);
 
     for (table = 0; table <= 1; table++) {
         idx = h & d->ht[table].sizemask;
         he = d->ht[table].table[idx];
         prevHe = NULL;
-        while(he) {
-            if (key==he->key || AI_dictCompareKeys(d, key, he->key)) {
+        while (he) {
+            if (key == he->key || AI_dictCompareKeys(d, key, he->key)) {
                 /* Unlink the element from the list */
                 if (prevHe)
                     prevHe->next = he->next;
@@ -432,7 +426,8 @@ static AI_dictEntry *dictGenericDelete(AI_dict *d, const void *key, int nofree) 
             prevHe = he;
             he = he->next;
         }
-        if (!AI_dictIsRehashing(d)) break;
+        if (!AI_dictIsRehashing(d))
+            break;
     }
     return NULL; /* not found */
 }
@@ -440,7 +435,7 @@ static AI_dictEntry *dictGenericDelete(AI_dict *d, const void *key, int nofree) 
 /* Remove an element, returning DICT_OK on success or DICT_ERR if the
  * element was not found. */
 int AI_dictDelete(AI_dict *ht, const void *key) {
-    return dictGenericDelete(ht,key,0) ? DICT_OK : DICT_ERR;
+    return dictGenericDelete(ht, key, 0) ? DICT_OK : DICT_ERR;
 }
 
 /* Remove an element from the table, but without actually releasing
@@ -464,14 +459,13 @@ int AI_dictDelete(AI_dict *ht, const void *key) {
  * // Do something with entry
  * dictFreeUnlinkedEntry(entry); // <- This does not need to lookup again.
  */
-AI_dictEntry *AI_dictUnlink(AI_dict *ht, const void *key) {
-    return dictGenericDelete(ht,key,1);
-}
+AI_dictEntry *AI_dictUnlink(AI_dict *ht, const void *key) { return dictGenericDelete(ht, key, 1); }
 
 /* You need to call this function to really free the entry after a call
  * to dictUnlink(). It's safe to call this function with 'he' = NULL. */
 void AI_dictFreeUnlinkedEntry(AI_dict *d, AI_dictEntry *he) {
-    if (he == NULL) return;
+    if (he == NULL)
+        return;
     AI_dictFreeKey(d, he);
     AI_dictFreeVal(d, he);
     RA_FREE(he);
@@ -485,10 +479,12 @@ static int AI_dictClear(AI_dict *d, AI_dictht *ht, void(callback)(void *)) {
     for (i = 0; i < ht->size && ht->used > 0; i++) {
         AI_dictEntry *he, *nextHe;
 
-        if (callback && (i & 65535) == 0) callback(d->privdata);
+        if (callback && (i & 65535) == 0)
+            callback(d->privdata);
 
-        if ((he = ht->table[i]) == NULL) continue;
-        while(he) {
+        if ((he = ht->table[i]) == NULL)
+            continue;
+        while (he) {
             nextHe = he->next;
             AI_dictFreeKey(d, he);
             AI_dictFreeVal(d, he);
@@ -505,30 +501,31 @@ static int AI_dictClear(AI_dict *d, AI_dictht *ht, void(callback)(void *)) {
 }
 
 /* Clear & Release the hash table */
-void AI_dictRelease(AI_dict *d)
-{
-    AI_dictClear(d,&d->ht[0],NULL);
-    AI_dictClear(d,&d->ht[1],NULL);
+void AI_dictRelease(AI_dict *d) {
+    AI_dictClear(d, &d->ht[0], NULL);
+    AI_dictClear(d, &d->ht[1], NULL);
     RA_FREE(d);
 }
 
-AI_dictEntry *AI_dictFind(AI_dict *d, const void *key)
-{
+AI_dictEntry *AI_dictFind(AI_dict *d, const void *key) {
     AI_dictEntry *he;
     uint64_t h, idx, table;
 
-    if (d->ht[0].used + d->ht[1].used == 0) return NULL; /* dict is empty */
-    if (AI_dictIsRehashing(d))_AI_dictRehashStep(d);
+    if (d->ht[0].used + d->ht[1].used == 0)
+        return NULL; /* dict is empty */
+    if (AI_dictIsRehashing(d))
+        _AI_dictRehashStep(d);
     h = AI_dictHashKey(d, key);
     for (table = 0; table <= 1; table++) {
         idx = h & d->ht[table].sizemask;
         he = d->ht[table].table[idx];
-        while(he) {
-            if (key==he->key || AI_dictCompareKeys(d, key, he->key))
+        while (he) {
+            if (key == he->key || AI_dictCompareKeys(d, key, he->key))
                 return he;
             he = he->next;
         }
-        if (!AI_dictIsRehashing(d)) return NULL;
+        if (!AI_dictIsRehashing(d))
+            return NULL;
     }
     return NULL;
 }
@@ -536,7 +533,7 @@ AI_dictEntry *AI_dictFind(AI_dict *d, const void *key)
 void *AI_dictFetchValue(AI_dict *d, const void *key) {
     AI_dictEntry *he;
 
-    he = AI_dictFind(d,key);
+    he = AI_dictFind(d, key);
     return he ? AI_dictGetVal(he) : NULL;
 }
 
@@ -550,10 +547,10 @@ static long long dictFingerprint(AI_dict *d) {
     long long integers[6], hash = 0;
     int j;
 
-    integers[0] = (long) d->ht[0].table;
+    integers[0] = (long)d->ht[0].table;
     integers[1] = d->ht[0].size;
     integers[2] = d->ht[0].used;
-    integers[3] = (long) d->ht[1].table;
+    integers[3] = (long)d->ht[1].table;
     integers[4] = d->ht[1].size;
     integers[5] = d->ht[1].used;
 
@@ -578,8 +575,7 @@ static long long dictFingerprint(AI_dict *d) {
     return hash;
 }
 
-AI_dictIterator *AI_dictGetIterator(AI_dict *d)
-{
+AI_dictIterator *AI_dictGetIterator(AI_dict *d) {
     AI_dictIterator *iter = RA_ALLOC(sizeof(*iter));
 
     iter->d = d;
@@ -598,8 +594,7 @@ AI_dictIterator *AI_dictGetSafeIterator(AI_dict *d) {
     return i;
 }
 
-AI_dictEntry *AI_dictNext(AI_dictIterator *iter)
-{
+AI_dictEntry *AI_dictNext(AI_dictIterator *iter) {
     while (1) {
         if (iter->entry == NULL) {
             AI_dictht *ht = &iter->d->ht[iter->table];
@@ -610,7 +605,7 @@ AI_dictEntry *AI_dictNext(AI_dictIterator *iter)
                     iter->fingerprint = dictFingerprint(iter->d);
             }
             iter->index++;
-            if (iter->index >= (long) ht->size) {
+            if (iter->index >= (long)ht->size) {
                 if (AI_dictIsRehashing(iter->d) && iter->table == 0) {
                     iter->table++;
                     iter->index = 0;
@@ -633,8 +628,7 @@ AI_dictEntry *AI_dictNext(AI_dictIterator *iter)
     return NULL;
 }
 
-void AI_dictReleaseIterator(AI_dictIterator *iter)
-{
+void AI_dictReleaseIterator(AI_dictIterator *iter) {
     if (!(iter->index == -1 && iter->table == 0)) {
         if (iter->safe)
             iter->d->iterators--;
@@ -646,29 +640,27 @@ void AI_dictReleaseIterator(AI_dictIterator *iter)
 
 /* Return a random entry from the hash table. Useful to
  * implement randomized algorithms */
-AI_dictEntry *AI_dictGetRandomKey(AI_dict *d)
-{
+AI_dictEntry *AI_dictGetRandomKey(AI_dict *d) {
     AI_dictEntry *he, *orighe;
     unsigned long h;
     int listlen, listele;
 
-    if (AI_dictSize(d) == 0) return NULL;
-    if (AI_dictIsRehashing(d))_AI_dictRehashStep(d);
+    if (AI_dictSize(d) == 0)
+        return NULL;
+    if (AI_dictIsRehashing(d))
+        _AI_dictRehashStep(d);
     if (AI_dictIsRehashing(d)) {
         do {
             /* We are sure there are no elements in indexes from 0
              * to rehashidx-1 */
-            h = d->rehashidx + (random() % (d->ht[0].size +
-                                            d->ht[1].size -
-                                            d->rehashidx));
-            he = (h >= d->ht[0].size) ? d->ht[1].table[h - d->ht[0].size] :
-                 d->ht[0].table[h];
-        } while(he == NULL);
+            h = d->rehashidx + (random() % (d->ht[0].size + d->ht[1].size - d->rehashidx));
+            he = (h >= d->ht[0].size) ? d->ht[1].table[h - d->ht[0].size] : d->ht[0].table[h];
+        } while (he == NULL);
     } else {
         do {
             h = random() & d->ht[0].sizemask;
             he = d->ht[0].table[h];
-        } while(he == NULL);
+        } while (he == NULL);
     }
 
     /* Now we found a non empty bucket, but it is a linked
@@ -677,13 +669,14 @@ AI_dictEntry *AI_dictGetRandomKey(AI_dict *d)
      * select a random index. */
     listlen = 0;
     orighe = he;
-    while(he) {
+    while (he) {
         he = he->next;
         listlen++;
     }
     listele = random() % listlen;
     he = orighe;
-    while(listele--) he = he->next;
+    while (listele--)
+        he = he->next;
     return he;
 }
 
@@ -710,18 +703,19 @@ AI_dictEntry *AI_dictGetRandomKey(AI_dict *d)
  * statistics. However the function is much faster than dictGetRandomKey()
  * at producing N elements. */
 unsigned int AI_dictGetSomeKeys(AI_dict *d, AI_dictEntry **des, unsigned int count) {
-    unsigned long j; /* internal hash table id, 0 or 1. */
+    unsigned long j;      /* internal hash table id, 0 or 1. */
     unsigned long tables; /* 1 or 2 tables? */
     unsigned long stored = 0, maxsizemask;
     unsigned long maxsteps;
 
-    if (AI_dictSize(d) < count) count = AI_dictSize(d);
-    maxsteps = count*10;
+    if (AI_dictSize(d) < count)
+        count = AI_dictSize(d);
+    maxsteps = count * 10;
 
     /* Try to do a rehashing work proportional to 'count'. */
     for (j = 0; j < count; j++) {
         if (AI_dictIsRehashing(d))
-           _AI_dictRehashStep(d);
+            _AI_dictRehashStep(d);
         else
             break;
     }
@@ -734,12 +728,12 @@ unsigned int AI_dictGetSomeKeys(AI_dict *d, AI_dictEntry **des, unsigned int cou
     /* Pick a random point inside the larger table. */
     unsigned long i = random() & maxsizemask;
     unsigned long emptylen = 0; /* Continuous empty entries so far. */
-    while(stored < count && maxsteps--) {
+    while (stored < count && maxsteps--) {
         for (j = 0; j < tables; j++) {
             /* Invariant of the dict.c rehashing: up to the indexes already
              * visited in ht[0] during the rehashing, there are no populated
              * buckets, so we can skip ht[0] for indexes between 0 and idx-1. */
-            if (tables == 2 && j == 0 && i < (unsigned long) d->rehashidx) {
+            if (tables == 2 && j == 0 && i < (unsigned long)d->rehashidx) {
                 /* Moreover, if we are currently out of range in the second
                  * table, there will be no elements in both tables up to
                  * the current rehashing index, so we jump if possible.
@@ -749,7 +743,8 @@ unsigned int AI_dictGetSomeKeys(AI_dict *d, AI_dictEntry **des, unsigned int cou
                 else
                     continue;
             }
-            if (i >= d->ht[j].size) continue; /* Out of range for this table. */
+            if (i >= d->ht[j].size)
+                continue; /* Out of range for this table. */
             AI_dictEntry *he = d->ht[j].table[i];
 
             /* Count contiguous empty buckets, and jump to other
@@ -769,11 +764,12 @@ unsigned int AI_dictGetSomeKeys(AI_dict *d, AI_dictEntry **des, unsigned int cou
                     des++;
                     he = he->next;
                     stored++;
-                    if (stored == count) return stored;
+                    if (stored == count)
+                        return stored;
                 }
             }
         }
-        i = (i+1) & maxsizemask;
+        i = (i + 1) & maxsizemask;
     }
     return stored;
 }
@@ -874,24 +870,22 @@ static unsigned long rev(unsigned long v) {
  * 3) The reverse cursor is somewhat hard to understand at first, but this
  *    comment is supposed to help.
  */
-unsigned long AI_dictScan(AI_dict *d,
-                             unsigned long v,
-                             AI_dictScanFunction *fn,
-                             AI_dictScanBucketFunction* bucketfn,
-                             void *privdata)
-{
+unsigned long AI_dictScan(AI_dict *d, unsigned long v, AI_dictScanFunction *fn,
+                          AI_dictScanBucketFunction *bucketfn, void *privdata) {
     AI_dictht *t0, *t1;
     const AI_dictEntry *de, *next;
     unsigned long m0, m1;
 
-    if (AI_dictSize(d) == 0) return 0;
+    if (AI_dictSize(d) == 0)
+        return 0;
 
     if (!AI_dictIsRehashing(d)) {
         t0 = &(d->ht[0]);
         m0 = t0->sizemask;
 
         /* Emit entries at cursor */
-        if (bucketfn) bucketfn(privdata, &t0->table[v & m0]);
+        if (bucketfn)
+            bucketfn(privdata, &t0->table[v & m0]);
         de = t0->table[v & m0];
         while (de) {
             next = de->next;
@@ -922,7 +916,8 @@ unsigned long AI_dictScan(AI_dict *d,
         m1 = t1->sizemask;
 
         /* Emit entries at cursor */
-        if (bucketfn) bucketfn(privdata, &t0->table[v & m0]);
+        if (bucketfn)
+            bucketfn(privdata, &t0->table[v & m0]);
         de = t0->table[v & m0];
         while (de) {
             next = de->next;
@@ -934,7 +929,8 @@ unsigned long AI_dictScan(AI_dict *d,
          * of the index pointed to by the cursor in the smaller table */
         do {
             /* Emit entries at cursor */
-            if (bucketfn) bucketfn(privdata, &t1->table[v & m1]);
+            if (bucketfn)
+                bucketfn(privdata, &t1->table[v & m1]);
             de = t1->table[v & m1];
             while (de) {
                 next = de->next;
@@ -958,34 +954,33 @@ unsigned long AI_dictScan(AI_dict *d,
 /* ------------------------- private functions ------------------------------ */
 
 /* Expand the hash table if needed */
-static int _AI_dictExpandIfNeeded(AI_dict *d)
-{
+static int _AI_dictExpandIfNeeded(AI_dict *d) {
     /* Incremental rehashing already in progress. Return. */
-    if (AI_dictIsRehashing(d)) return DICT_OK;
+    if (AI_dictIsRehashing(d))
+        return DICT_OK;
 
     /* If the hash table is empty expand it to the initial size. */
-    if (d->ht[0].size == 0) return AI_dictExpand(d, DICT_HT_INITIAL_SIZE);
+    if (d->ht[0].size == 0)
+        return AI_dictExpand(d, DICT_HT_INITIAL_SIZE);
 
     /* If we reached the 1:1 ratio, and we are allowed to resize the hash
      * table (global setting) or we should avoid it but the ratio between
      * elements/buckets is over the "safe" threshold, we resize doubling
      * the number of buckets. */
     if (d->ht[0].used >= d->ht[0].size &&
-        (dict_can_resize ||
-         d->ht[0].used/d->ht[0].size > dict_force_resize_ratio))
-    {
-        return AI_dictExpand(d, d->ht[0].used*2);
+        (dict_can_resize || d->ht[0].used / d->ht[0].size > dict_force_resize_ratio)) {
+        return AI_dictExpand(d, d->ht[0].used * 2);
     }
     return DICT_OK;
 }
 
 /* Our hash table capability is a power of two */
-static unsigned long _AI_dictNextPower(unsigned long size)
-{
+static unsigned long _AI_dictNextPower(unsigned long size) {
     unsigned long i = DICT_HT_INITIAL_SIZE;
 
-    if (size >= LONG_MAX) return LONG_MAX + 1LU;
-    while(1) {
+    if (size >= LONG_MAX)
+        return LONG_MAX + 1LU;
+    while (1) {
         if (i >= size)
             return i;
         i *= 2;
@@ -999,11 +994,11 @@ static unsigned long _AI_dictNextPower(unsigned long size)
  *
  * Note that if we are in the process of rehashing the hash table, the
  * index is always returned in the context of the second (new) hash table. */
-static long _AI_dictKeyIndex(AI_dict *d, const void *key, uint64_t hash, AI_dictEntry **existing)
-{
+static long _AI_dictKeyIndex(AI_dict *d, const void *key, uint64_t hash, AI_dictEntry **existing) {
     unsigned long idx, table;
     AI_dictEntry *he;
-    if (existing) *existing = NULL;
+    if (existing)
+        *existing = NULL;
 
     /* Expand the hash table if needed */
     if (_AI_dictExpandIfNeeded(d) == DICT_ERR)
@@ -1012,36 +1007,32 @@ static long _AI_dictKeyIndex(AI_dict *d, const void *key, uint64_t hash, AI_dict
         idx = hash & d->ht[table].sizemask;
         /* Search if this slot does not already contain the given key */
         he = d->ht[table].table[idx];
-        while(he) {
-            if (key==he->key || AI_dictCompareKeys(d, key, he->key)) {
-                if (existing) *existing = he;
+        while (he) {
+            if (key == he->key || AI_dictCompareKeys(d, key, he->key)) {
+                if (existing)
+                    *existing = he;
                 return -1;
             }
             he = he->next;
         }
-        if (!AI_dictIsRehashing(d)) break;
+        if (!AI_dictIsRehashing(d))
+            break;
     }
     return idx;
 }
 
-void AI_dictEmpty(AI_dict *d, void(callback)(void*)) {
-    AI_dictClear(d,&d->ht[0],callback);
-    AI_dictClear(d,&d->ht[1],callback);
+void AI_dictEmpty(AI_dict *d, void(callback)(void *)) {
+    AI_dictClear(d, &d->ht[0], callback);
+    AI_dictClear(d, &d->ht[1], callback);
     d->rehashidx = -1;
     d->iterators = 0;
 }
 
-void AI_dictEnableResize(void) {
-    dict_can_resize = 1;
-}
+void AI_dictEnableResize(void) { dict_can_resize = 1; }
 
-void AI_dictDisableResize(void) {
-    dict_can_resize = 0;
-}
+void AI_dictDisableResize(void) { dict_can_resize = 0; }
 
-uint64_t AI_dictGetHash(AI_dict *d, const void *key) {
-    return AI_dictHashKey(d, key);
-}
+uint64_t AI_dictGetHash(AI_dict *d, const void *key) { return AI_dictHashKey(d, key); }
 
 /* Finds the dictEntry reference by using pointer and pre-calculated hash.
  * oldkey is a dead pointer and should not be accessed.
@@ -1052,18 +1043,20 @@ AI_dictEntry **AI_dictFindEntryRefByPtrAndHash(AI_dict *d, const void *oldptr, u
     AI_dictEntry *he, **heref;
     unsigned long idx, table;
 
-    if (d->ht[0].used + d->ht[1].used == 0) return NULL; /* dict is empty */
+    if (d->ht[0].used + d->ht[1].used == 0)
+        return NULL; /* dict is empty */
     for (table = 0; table <= 1; table++) {
         idx = hash & d->ht[table].sizemask;
         heref = &d->ht[table].table[idx];
         he = *heref;
-        while(he) {
-            if (oldptr==he->key)
+        while (he) {
+            if (oldptr == he->key)
                 return heref;
             heref = &he->next;
             he = *heref;
         }
-        if (!AI_dictIsRehashing(d)) return NULL;
+        if (!AI_dictIsRehashing(d))
+            return NULL;
     }
     return NULL;
 }
@@ -1078,12 +1071,12 @@ static size_t _AI_dictGetStatsHt(char *buf, size_t bufsize, AI_dictht *ht, int t
     size_t l = 0;
 
     if (ht->used == 0) {
-        return snprintf(buf,bufsize,
-                        "No stats available for empty dictionaries\n");
+        return snprintf(buf, bufsize, "No stats available for empty dictionaries\n");
     }
 
     /* Compute stats. */
-    for (i = 0; i < DICT_STATS_VECTLEN; i++) clvector[i] = 0;
+    for (i = 0; i < DICT_STATS_VECTLEN; i++)
+        clvector[i] = 0;
     for (i = 0; i < ht->size; i++) {
         AI_dictEntry *he;
 
@@ -1095,40 +1088,43 @@ static size_t _AI_dictGetStatsHt(char *buf, size_t bufsize, AI_dictht *ht, int t
         /* For each hash entry on this slot... */
         chainlen = 0;
         he = ht->table[i];
-        while(he) {
+        while (he) {
             chainlen++;
             he = he->next;
         }
-        clvector[(chainlen < DICT_STATS_VECTLEN) ? chainlen : (DICT_STATS_VECTLEN-1)]++;
-        if (chainlen > maxchainlen) maxchainlen = chainlen;
+        clvector[(chainlen < DICT_STATS_VECTLEN) ? chainlen : (DICT_STATS_VECTLEN - 1)]++;
+        if (chainlen > maxchainlen)
+            maxchainlen = chainlen;
         totchainlen += chainlen;
     }
 
     /* Generate human readable stats. */
-    l += snprintf(buf+l,bufsize-l,
-                  "Hash table %d stats (%s):\n"
-                  " table size: %ld\n"
-                  " number of elements: %ld\n"
-                  " different slots: %ld\n"
-                  " max chain length: %ld\n"
-                  " avg chain length (counted): %.02f\n"
-                  " avg chain length (computed): %.02f\n"
-                  " Chain length distribution:\n",
-                  tableid, (tableid == 0) ? "main hash table" : "rehashing target",
-                  ht->size, ht->used, slots, maxchainlen,
-                  (float)totchainlen/slots, (float)ht->used/slots);
+    l +=
+        snprintf(buf + l, bufsize - l,
+                 "Hash table %d stats (%s):\n"
+                 " table size: %ld\n"
+                 " number of elements: %ld\n"
+                 " different slots: %ld\n"
+                 " max chain length: %ld\n"
+                 " avg chain length (counted): %.02f\n"
+                 " avg chain length (computed): %.02f\n"
+                 " Chain length distribution:\n",
+                 tableid, (tableid == 0) ? "main hash table" : "rehashing target", ht->size,
+                 ht->used, slots, maxchainlen, (float)totchainlen / slots, (float)ht->used / slots);
 
-    for (i = 0; i < DICT_STATS_VECTLEN-1; i++) {
-        if (clvector[i] == 0) continue;
-        if (l >= bufsize) break;
-        l += snprintf(buf+l,bufsize-l,
-                      "   %s%ld: %ld (%.02f%%)\n",
-                      (i == DICT_STATS_VECTLEN-1)?">= ":"",
-                      i, clvector[i], ((float)clvector[i]/ht->size)*100);
+    for (i = 0; i < DICT_STATS_VECTLEN - 1; i++) {
+        if (clvector[i] == 0)
+            continue;
+        if (l >= bufsize)
+            break;
+        l += snprintf(buf + l, bufsize - l, "   %s%ld: %ld (%.02f%%)\n",
+                      (i == DICT_STATS_VECTLEN - 1) ? ">= " : "", i, clvector[i],
+                      ((float)clvector[i] / ht->size) * 100);
     }
 
     /* Unlike snprintf(), teturn the number of characters actually written. */
-    if (bufsize) buf[bufsize-1] = '\0';
+    if (bufsize)
+        buf[bufsize - 1] = '\0';
     return strlen(buf);
 }
 
@@ -1137,14 +1133,15 @@ void AI_dictGetStats(char *buf, size_t bufsize, AI_dict *d) {
     char *orig_buf = buf;
     size_t orig_bufsize = bufsize;
 
-    l =_AI_dictGetStatsHt(buf,bufsize,&d->ht[0],0);
+    l = _AI_dictGetStatsHt(buf, bufsize, &d->ht[0], 0);
     buf += l;
     bufsize -= l;
     if (AI_dictIsRehashing(d) && bufsize > 0) {
-       _AI_dictGetStatsHt(buf,bufsize,&d->ht[1],1);
+        _AI_dictGetStatsHt(buf, bufsize, &d->ht[1], 1);
     }
     /* Make sure there is a NULL term at the end. */
-    if (orig_bufsize) orig_buf[orig_bufsize-1] = '\0';
+    if (orig_bufsize)
+        orig_buf[orig_bufsize - 1] = '\0';
 }
 
 /* ------------------------------- Benchmark ---------------------------------*/
@@ -1154,16 +1151,17 @@ void AI_dictGetStats(char *buf, size_t bufsize, AI_dict *d) {
 #include "sds.h"
 
 uint64_t hashCallback(const void *key) {
-    return AI_dictGenHashFunction((unsigned char*)key, sdslen((char*)key));
+    return AI_dictGenHashFunction((unsigned char *)key, sdslen((char *)key));
 }
 
 int compareCallback(void *privdata, const void *key1, const void *key2) {
-    int l1,l2;
+    int l1, l2;
     DICT_NOTUSED(privdata);
 
     l1 = sdslen((sds)key1);
     l2 = sdslen((sds)key2);
-    if (l1 != l2) return 0;
+    if (l1 != l2)
+        return 0;
     return memcmp(key1, key2, l1) == 0;
 }
 
@@ -1173,37 +1171,31 @@ void freeCallback(void *privdata, void *val) {
     sdsfree(val);
 }
 
-AI_dictType BenchmarkDictType = {
-    hashCallback,
-    NULL,
-    NULL,
-    compareCallback,
-    freeCallback,
-    NULL
-};
+AI_dictType BenchmarkDictType = {hashCallback, NULL, NULL, compareCallback, freeCallback, NULL};
 
 #define start_benchmark() start = timeInMilliseconds()
-#define end_benchmark(msg) do { \
-    elapsed = timeInMilliseconds()-start; \
-    printf(msg ": %ld items in %lld ms\n", count, elapsed); \
-} while(0);
+#define end_benchmark(msg)                                                                         \
+    do {                                                                                           \
+        elapsed = timeInMilliseconds() - start;                                                    \
+        printf(msg ": %ld items in %lld ms\n", count, elapsed);                                    \
+    } while (0);
 
 /* dict-benchmark [count] */
 int main(int argc, char **argv) {
     long j;
     long long start, elapsed;
-    AI_dict *AI_dict = AI_dictCreate(&BenchmarkDictType,NULL);
+    AI_dict *AI_dict = AI_dictCreate(&BenchmarkDictType, NULL);
     long count = 0;
 
     if (argc == 2) {
-        count = strtol(argv[1],NULL,10);
+        count = strtol(argv[1], NULL, 10);
     } else {
         count = 5000000;
     }
 
     start_benchmark();
     for (j = 0; j < count; j++) {
-        int retval = AI_dictAdd(AI_dict,sdsfromlonglong(j),(void*)j);
+        int retval = AI_dictAdd(AI_dict, sdsfromlonglong(j), (void *)j);
         assert(retval == DICT_OK);
     }
     end_benchmark("Inserting");
@@ -1211,13 +1203,13 @@ int main(int argc, char **argv) {
 
     /* Wait for rehashing. */
     while (AI_dictIsRehashing(AI_dict)) {
-        AI_dictRehashMilliseconds(AI_dict,100);
+        AI_dictRehashMilliseconds(AI_dict, 100);
     }
 
     start_benchmark();
     for (j = 0; j < count; j++) {
         sds key = sdsfromlonglong(j);
-        AI_dictEntry *de = AI_dictFind(AI_dict,key);
+        AI_dictEntry *de = AI_dictFind(AI_dict, key);
         assert(de != NULL);
         sdsfree(key);
     }
@@ -1226,7 +1218,7 @@ int main(int argc, char **argv) {
     start_benchmark();
     for (j = 0; j < count; j++) {
         sds key = sdsfromlonglong(j);
-        AI_dictEntry *de = AI_dictFind(AI_dict,key);
+        AI_dictEntry *de = AI_dictFind(AI_dict, key);
         assert(de != NULL);
         sdsfree(key);
     }
@@ -1235,7 +1227,7 @@ int main(int argc, char **argv) {
     start_benchmark();
     for (j = 0; j < count; j++) {
         sds key = sdsfromlonglong(rand() % count);
-        AI_dictEntry *de = AI_dictFind(AI_dict,key);
+        AI_dictEntry *de = AI_dictFind(AI_dict, key);
         assert(de != NULL);
         sdsfree(key);
     }
@@ -1245,7 +1237,7 @@ int main(int argc, char **argv) {
     for (j = 0; j < count; j++) {
         sds key = sdsfromlonglong(rand() % count);
         key[0] = 'X';
-        AI_dictEntry *de = AI_dictFind(AI_dict,key);
+        AI_dictEntry *de = AI_dictFind(AI_dict, key);
         assert(de == NULL);
         sdsfree(key);
     }
@@ -1254,10 +1246,10 @@ int main(int argc, char **argv) {
     start_benchmark();
     for (j = 0; j < count; j++) {
         sds key = sdsfromlonglong(j);
-        int retval = AI_dictDelete(AI_dict,key);
+        int retval = AI_dictDelete(AI_dict, key);
         assert(retval == DICT_OK);
         key[0] += 17; /* Change first number to letter. */
-        retval = AI_dictAdd(AI_dict,key,(void*)j);
+        retval = AI_dictAdd(AI_dict, key, (void *)j);
         assert(retval == DICT_OK);
     }
     end_benchmark("Removing and adding");

--- a/src/util/dict.h
+++ b/src/util/dict.h
@@ -39,11 +39,11 @@
 #ifndef __DICT_H
 #define __DICT_H
 
-#define DICT_OK 0
+#define DICT_OK  0
 #define DICT_ERR 1
 
 /* Unused arguments generate annoying warnings... */
-#define DICT_NOTUSED(V) ((void) V)
+#define DICT_NOTUSED(V) ((void)V)
 
 typedef struct AI_dictEntry {
     void *key;
@@ -78,7 +78,7 @@ typedef struct AI_dict {
     AI_dictType *type;
     void *privdata;
     AI_dictht ht[2];
-    long rehashidx; /* rehashing not in progress if rehashidx == -1 */
+    long rehashidx;          /* rehashing not in progress if rehashidx == -1 */
     unsigned long iterators; /* number of iterators currently running */
 } AI_dict;
 
@@ -95,58 +95,64 @@ typedef struct AI_dictIterator {
     long long fingerprint;
 } AI_dictIterator;
 
-typedef void (AI_dictScanFunction)(void *privdata, const AI_dictEntry *de);
-typedef void (AI_dictScanBucketFunction)(void *privdata, AI_dictEntry **bucketref);
+typedef void(AI_dictScanFunction)(void *privdata, const AI_dictEntry *de);
+typedef void(AI_dictScanBucketFunction)(void *privdata, AI_dictEntry **bucketref);
 
 /* This is the initial size of every hash table */
-#define DICT_HT_INITIAL_SIZE     4
+#define DICT_HT_INITIAL_SIZE 4
 
 /* ------------------------------- Macros ------------------------------------*/
-#define AI_dictFreeVal(d, entry) \
-    if ((d)->type->valDestructor) \
-        (d)->type->valDestructor((d)->privdata, (entry)->v.val)
+#define AI_dictFreeVal(d, entry)                                                                   \
+    if ((d)->type->valDestructor)                                                                  \
+    (d)->type->valDestructor((d)->privdata, (entry)->v.val)
 
-#define AI_dictSetVal(d, entry, _val_) do { \
-    if ((d)->type->valDup) \
-        (entry)->v.val = (d)->type->valDup((d)->privdata, _val_); \
-    else \
-        (entry)->v.val = (_val_); \
-} while(0)
+#define AI_dictSetVal(d, entry, _val_)                                                             \
+    do {                                                                                           \
+        if ((d)->type->valDup)                                                                     \
+            (entry)->v.val = (d)->type->valDup((d)->privdata, _val_);                              \
+        else                                                                                       \
+            (entry)->v.val = (_val_);                                                              \
+    } while (0)
 
-#define AI_dictSetSignedIntegerVal(entry, _val_) \
-    do { (entry)->v.s64 = _val_; } while(0)
+#define AI_dictSetSignedIntegerVal(entry, _val_)                                                   \
+    do {                                                                                           \
+        (entry)->v.s64 = _val_;                                                                    \
+    } while (0)
 
-#define AI_dictSetUnsignedIntegerVal(entry, _val_) \
-    do { (entry)->v.u64 = _val_; } while(0)
+#define AI_dictSetUnsignedIntegerVal(entry, _val_)                                                 \
+    do {                                                                                           \
+        (entry)->v.u64 = _val_;                                                                    \
+    } while (0)
 
-#define AI_dictSetDoubleVal(entry, _val_) \
-    do { (entry)->v.d = _val_; } while(0)
+#define AI_dictSetDoubleVal(entry, _val_)                                                          \
+    do {                                                                                           \
+        (entry)->v.d = _val_;                                                                      \
+    } while (0)
 
-#define AI_dictFreeKey(d, entry) \
-    if ((d)->type->keyDestructor) \
-        (d)->type->keyDestructor((d)->privdata, (entry)->key)
+#define AI_dictFreeKey(d, entry)                                                                   \
+    if ((d)->type->keyDestructor)                                                                  \
+    (d)->type->keyDestructor((d)->privdata, (entry)->key)
 
-#define AI_dictSetKey(d, entry, _key_) do { \
-    if ((d)->type->keyDup) \
-        (entry)->key = (d)->type->keyDup((d)->privdata, _key_); \
-    else \
-        (entry)->key = (_key_); \
-} while(0)
+#define AI_dictSetKey(d, entry, _key_)                                                             \
+    do {                                                                                           \
+        if ((d)->type->keyDup)                                                                     \
+            (entry)->key = (d)->type->keyDup((d)->privdata, _key_);                                \
+        else                                                                                       \
+            (entry)->key = (_key_);                                                                \
+    } while (0)
 
-#define AI_dictCompareKeys(d, key1, key2) \
-    (((d)->type->keyCompare) ? \
-        (d)->type->keyCompare((d)->privdata, key1, key2) : \
-        (key1) == (key2))
+#define AI_dictCompareKeys(d, key1, key2)                                                          \
+    (((d)->type->keyCompare) ? (d)->type->keyCompare((d)->privdata, key1, key2) : (key1) == (key2))
 
-#define AI_dictHashKey(d, key) (d)->type->hashFunction(key)
-#define AI_dictGetKey(he) ((he)->key)
-#define AI_dictGetVal(he) ((he)->v.val)
-#define AI_dictGetSignedIntegerVal(he) ((he)->v.s64)
+#define AI_dictHashKey(d, key)           (d)->type->hashFunction(key)
+#define AI_dictGetKey(he)                ((he)->key)
+#define AI_dictGetVal(he)                ((he)->v.val)
+#define AI_dictGetSignedIntegerVal(he)   ((he)->v.s64)
 #define AI_dictGetUnsignedIntegerVal(he) ((he)->v.u64)
-#define AI_dictGetDoubleVal(he) ((he)->v.d)
-#define AI_dictSlots(d) ((d)->ht[0].size+(d)->ht[1].size)
-#define AI_dictSize(d) ((d)->ht[0].used+(d)->ht[1].used)
-#define AI_dictIsRehashing(d) ((d)->rehashidx != -1)
+#define AI_dictGetDoubleVal(he)          ((he)->v.d)
+#define AI_dictSlots(d)                  ((d)->ht[0].size + (d)->ht[1].size)
+#define AI_dictSize(d)                   ((d)->ht[0].used + (d)->ht[1].used)
+#define AI_dictIsRehashing(d)            ((d)->rehashidx != -1)
 
 /* API */
 AI_dict *AI_dictCreate(AI_dictType *type, void *privDataPtr);
@@ -159,7 +165,7 @@ int AI_dictDelete(AI_dict *d, const void *key);
 AI_dictEntry *AI_dictUnlink(AI_dict *ht, const void *key);
 void AI_dictFreeUnlinkedEntry(AI_dict *d, AI_dictEntry *he);
 void AI_dictRelease(AI_dict *d);
-AI_dictEntry * AI_dictFind(AI_dict *d, const void *key);
+AI_dictEntry *AI_dictFind(AI_dict *d, const void *key);
 void *AI_dictFetchValue(AI_dict *d, const void *key);
 int AI_dictResize(AI_dict *d);
 AI_dictIterator *AI_dictGetIterator(AI_dict *d);
@@ -171,17 +177,17 @@ unsigned int AI_dictGetSomeKeys(AI_dict *d, AI_dictEntry **des, unsigned int cou
 void AI_dictGetStats(char *buf, size_t bufsize, AI_dict *d);
 uint64_t AI_dictGenHashFunction(const void *key, int len);
 uint64_t AI_dictGenCaseHashFunction(const unsigned char *buf, int len);
-void AI_dictEmpty(AI_dict *d, void(callback)(void*));
+void AI_dictEmpty(AI_dict *d, void(callback)(void *));
 void AI_dictEnableResize(void);
 void AI_dictDisableResize(void);
 int AI_dictRehash(AI_dict *d, int n);
 int AI_dictRehashMilliseconds(AI_dict *d, int ms);
 void AI_dictSetHashFunctionSeed(uint8_t *seed);
 uint8_t *AI_dictGetHashFunctionSeed(void);
-unsigned long AI_dictScan(AI_dict *d, unsigned long v, AI_dictScanFunction *fn, AI_dictScanBucketFunction *bucketfn, void *privdata);
+unsigned long AI_dictScan(AI_dict *d, unsigned long v, AI_dictScanFunction *fn,
+                          AI_dictScanBucketFunction *bucketfn, void *privdata);
 uint64_t AI_dictGetHash(AI_dict *d, const void *key);
 AI_dictEntry **AI_dictFindEntryRefByPtrAndHash(AI_dict *d, const void *oldptr, uint64_t hash);
-
 
 extern AI_dictType AI_dictTypeHeapStrings;
 extern AI_dictType AI_dictTypeHeapStringsVals;

--- a/src/util/queue.c
+++ b/src/util/queue.c
@@ -7,68 +7,71 @@
 #include "redismodule.h"
 
 queue *queueCreate(void) {
-  struct queue *queue;
+    struct queue *queue;
 
-  if ((queue = RedisModule_Calloc(1, sizeof(*queue))) == NULL) return NULL;
+    if ((queue = RedisModule_Calloc(1, sizeof(*queue))) == NULL)
+        return NULL;
 
-  queue->front = queue->back = NULL;
-  queue->len = 0;
-  queue->free = NULL;
-  return queue;
+    queue->front = queue->back = NULL;
+    queue->len = 0;
+    queue->free = NULL;
+    return queue;
 }
 
 void queuePush(queue *queue, void *value) {
-  queueItem *item;
+    queueItem *item;
 
-  if ((item = RedisModule_Calloc(1, sizeof(*item))) == NULL) return;
-  item->value = value;
-  item->next = NULL;
-  item->prev = NULL;
+    if ((item = RedisModule_Calloc(1, sizeof(*item))) == NULL)
+        return;
+    item->value = value;
+    item->next = NULL;
+    item->prev = NULL;
 
-  if (queue->len == 0) {
-    queue->front = queue->back = item;
-  } else {
-    queue->back->next = item;
-    item->prev = queue->back;
-    queue->back = item;
-  }
-  queue->len++;
+    if (queue->len == 0) {
+        queue->front = queue->back = item;
+    } else {
+        queue->back->next = item;
+        item->prev = queue->back;
+        queue->back = item;
+    }
+    queue->len++;
 }
 
 void queuePushFront(queue *queue, void *value) {
-  queueItem *item;
+    queueItem *item;
 
-  if ((item = RedisModule_Calloc(1, sizeof(*item))) == NULL) return;
-  item->value = value;
-  item->next = NULL;
-  item->prev = NULL;
+    if ((item = RedisModule_Calloc(1, sizeof(*item))) == NULL)
+        return;
+    item->value = value;
+    item->next = NULL;
+    item->prev = NULL;
 
-  if (queue->len == 0) {
-    queue->front = queue->back = item;
-  } else {
-    queue->front->prev = item;
-    item->next = queue->front;
-    queue->front = item;
-  }
-  queue->len++;
+    if (queue->len == 0) {
+        queue->front = queue->back = item;
+    } else {
+        queue->front->prev = item;
+        item->next = queue->front;
+        queue->front = item;
+    }
+    queue->len++;
 }
 
 queueItem *queuePop(queue *queue) {
-  queueItem *item = queue->front;
-  if (item == NULL) {
-    return NULL;
-  }
-  queue->front = item->next;
-  if (queue->front != NULL) {
-    queue->front->prev = NULL;
-  }
-  if (item == queue->back) {
-    queue->back = NULL;
-  }
-  item->next = NULL;
-  item->prev = NULL;
-  queue->len--;
-  return item;
+    queueItem *item = queue->front;
+    if (item == NULL) {
+        return NULL;
+    }
+    queue->front = item->next;
+    if (queue->front != NULL) {
+        queue->front->prev = NULL;
+    }
+    if (item == queue->back) {
+        queue->back = NULL;
+    }
+    item->next = NULL;
+    item->prev = NULL;
+    queue->len--;
+    return item;
 }
 
 queueItem *queueFront(queue *queue) { return queue->front; }
@@ -76,34 +79,35 @@ queueItem *queueFront(queue *queue) { return queue->front; }
 queueItem *queueNext(queueItem *item) { return item->next; }
 
 queueItem *queueEvict(queue *queue, queueItem *item) {
-  if (item == queue->front) {
-    return queuePop(queue);
-  } else if (item == queue->back) {
-    queue->back = item->prev;
-    queue->back->next = NULL;
-  } else {
-    item->prev->next = item->next;
-    item->next->prev = item->prev;
-  }
+    if (item == queue->front) {
+        return queuePop(queue);
+    } else if (item == queue->back) {
+        queue->back = item->prev;
+        queue->back->next = NULL;
+    } else {
+        item->prev->next = item->next;
+        item->next->prev = item->prev;
+    }
 
-  item->next = NULL;
-  item->prev = NULL;
-  queue->len--;
-  return item;
+    item->next = NULL;
+    item->prev = NULL;
+    queue->len--;
+    return item;
 }
 
 long long queueLength(queue *queue) { return queue->len; }
 
 void queueRelease(queue *queue) {
-  unsigned long len;
-  queueItem *current;
+    unsigned long len;
+    queueItem *current;
 
-  len = queue->len;
-  while (len--) {
-    current = queuePop(queue);
-    if (current && queue->free) queue->free(current->value);
-    RedisModule_Free(current);
-  }
-  queue->front = queue->back = NULL;
-  queue->len = 0;
+    len = queue->len;
+    while (len--) {
+        current = queuePop(queue);
+        if (current && queue->free)
+            queue->free(current->value);
+        RedisModule_Free(current);
+    }
+    queue->front = queue->back = NULL;
+    queue->len = 0;
 }

--- a/src/util/queue.h
+++ b/src/util/queue.h
@@ -10,16 +10,16 @@
 #define __QUEUE_H
 
 typedef struct queueItem {
-  struct queueItem *next;
-  struct queueItem *prev;
-  void *value;
+    struct queueItem *next;
+    struct queueItem *prev;
+    void *value;
 } queueItem;
 
 typedef struct queue {
-  queueItem *front;
-  queueItem *back;
-  void (*free)(void *ptr);
-  unsigned long len;
+    queueItem *front;
+    queueItem *back;
+    void (*free)(void *ptr);
+    unsigned long len;
 } queue;
 
 queue *queueCreate(void);


### PR DESCRIPTION
This is a maintenance PR to ensure that feature PRs are not mixed with formatting ones.
- The formatting rules are the ones present in RedisTimeSeries plus the addition of `AlignConsecutiveMacros: true` given that clang-format v10 and v11 handle that rule differently by default. 
- It enables:
  - [x] clang-format installation into system-setup.py. @rafie can you check the steps I've added per OS. 
  - [x] clang-format check into CI config.yml. To fail faster it will only start other build variants after the lint check ( in 30secs we can lint the project and fail if required vs spending 40min of compute power ) 
  - [x] clang-formatting/linting via Makefile. Added machine and docker variants, namely `format` and `format-docker`, `lint` and `lint-docker`
