### PR TITLE
Return an error when trying to run MODELRUN/SCRIPTRUN/DAGRUN through multi or lua

### DIFF
--- a/src/dag.c
+++ b/src/dag.c
@@ -1312,6 +1312,11 @@ void DAG_ReplyAndUnblock(RedisAI_OnFinishCtx ctx, void *private_data) {
 int RedisAI_ProcessDagRunCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                  int dagMode) {
 
+    int flags = RedisModule_GetContextFlags(ctx);
+    bool blocking_not_allowed = (flags & (REDISMODULE_CTX_FLAGS_MULTI | REDISMODULE_CTX_FLAGS_LUA));
+    if (blocking_not_allowed)
+        return RedisModule_ReplyWithError(
+            ctx, "ERR Cannot run RedisAI command within a transaction or a LUA script");
     RedisAI_RunInfo *rinfo = NULL;
     if (RAI_InitRunInfo(&rinfo) == REDISMODULE_ERR) {
         RedisModule_ReplyWithError(

--- a/tests/flow/tests_common.py
+++ b/tests/flow/tests_common.py
@@ -307,7 +307,7 @@ def test_lua_multi(env):
     con = env.getConnection()
     ret = con.execute_command('MULTI')
     env.assertEqual(ret, b'OK')
-    ret = con.execute_command('AI.MODELRUN', "no_model", "INPUTS", "no_input", "OUTPUTS", "no_output")
+    ret = con.execute_command('AI.MODELRUN', "no_model{1}", "INPUTS", "no_input{1}", "OUTPUTS", "no_output{1}")
     env.assertEqual(ret, b'QUEUED')
     try:
         ret = con.execute_command('EXEC')
@@ -316,8 +316,8 @@ def test_lua_multi(env):
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
         env.assertEqual("ERR Cannot run RedisAI command within a transaction or a LUA script", exception.__str__())
     try:
-        ret = con.execute_command('EVAL', "return redis.pcall('AI.MODELRUN', 'no_model', 'INPUTS', 'NO_INPUT',"
-                                          " 'OUTPUTS', 'NO_OUTPUT')", 0)
+        ret = con.execute_command('EVAL', "return redis.pcall('AI.MODELRUN', 'no_model{1}', 'INPUTS', 'NO_INPUT{1}',"
+                                          " 'OUTPUTS', 'NO_OUTPUT{1}')", 0)
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)


### PR DESCRIPTION
This is a temporary solution until we support non-blocking execution of these commands, since soon redis will not support client blocking through multi/lua (it will crash).