### PR TITLE
Expose Redis/RedisAI main thread cpu usage via modules info

### DIFF
--- a/src/redisai.c
+++ b/src/redisai.c
@@ -1052,7 +1052,7 @@ void RAI_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
                 struct timespec ts;
                 clockid_t cid;
                 sds queue_used_cpu_total = sdscatprintf(
-                    sdsempty(), "queue_%s_bthread_#%d_used_cpu_total", queue_name, i + 1);
+                    sdsempty(), "queue_%s_bthread_n%d_used_cpu_total", queue_name, i + 1);
                 sds bthread_used_cpu_total = sdsempty();
 #if (!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || defined(_DARWIN_C_SOURCE) ||         \
     defined(__cplusplus)
@@ -1068,7 +1068,7 @@ void RAI_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
                     } else {
                         bthread_used_cpu_total =
                             sdscatprintf(bthread_used_cpu_total, "%ld.%06ld", (long)ts.tv_sec,
-                                         (long)(ts.tv_nsec / 1000000));
+                                         (long)(ts.tv_nsec / 1000));
                     }
                 }
                 RedisModule_InfoAddFieldCString(ctx, queue_used_cpu_total, bthread_used_cpu_total);

--- a/tests/flow/tests_common.py
+++ b/tests/flow/tests_common.py
@@ -301,7 +301,7 @@ def test_info_modules(env):
     env.assertEqual( 'ai_self_used_cpu_user' in ret, True )
     env.assertEqual( 'ai_children_used_cpu_sys' in ret, True )
     env.assertEqual( 'ai_children_used_cpu_user' in ret, True )
-    env.assertEqual( 'ai_queue_CPU_bthread_#1_used_cpu_total' in ret, True )
+    env.assertEqual( 'ai_queue_CPU_bthread_n1_used_cpu_total' in ret, True )
 
 def test_lua_multi(env):
     con = env.getConnection()


### PR DESCRIPTION
The following PR exposes the main thread CPU info via info modules ( linux systems only ). In that manner we will have:
- `ai_self_used_cpu_sys and ai_self_used_cpu_user`: which is the sum of resources used by all threads in the process
- `ai_children_used_cpu_sys and ai_children_used_cpu_user`: resource usage statistics for all of redis terminated child processes
-  `ai_main_thread_used_cpu_sys and ai_main_thread_used_cpu_user`: resource usage statistics for the main thread which in this case is Redis/RedisAI main thread

Sample output:
```
$ redis-cli info modules
# Modules
module:name=ai,ver=999999,api=1,filters=0,usedby=[],using=[],options=[]

# ai_git
ai_git_sha:ffd7e8e7db02ba97d0472493d4dc626a2703eb09

# ai_load_time_configs
ai_threads_per_queue:1
ai_inter_op_parallelism:0
ai_intra_op_parallelism:0

# ai_cpu
ai_self_used_cpu_sys:9.682204
ai_self_used_cpu_user:150.129278
ai_children_used_cpu_sys:0.000000
ai_children_used_cpu_user:0.000000
ai_main_thread_used_cpu_sys:5.129278
ai_main_thread_used_cpu_user:2.682204
ai_queue_CPU_bthread_#1_used_cpu_total:0.000856

```