### PR TITLE
Script run refactor and llapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ RedisAI currently supports PyTorch (libtorch), Tensorflow (libtensorflow), Tenso
 | 0.4.0   | 1.2.0   | 1.14.0     | None   | 0.5.0         |
 | 0.9.0   | 1.3.1   | 1.14.0     | 2.0.0  | 1.0.0         |
 | 1.0.0   | 1.5.0   | 1.15.0     | 2.0.0  | 1.2.0         |
-| master  | 1.5.0   | 1.15.0     | 2.0.0  | 1.2.0         |
+| master  | 1.7.0   | 1.15.0     | 2.0.0  | 1.2.0         |
 
 Note: Keras and TensorFlow 2.x are supported through graph freezing. See [this script](https://github.com/RedisAI/RedisAI/blob/master/tests/test_data/tf2-minimal.py) to see how to export a frozen graph from Keras and TensorFlow 2.x. Note that a frozen graph will be executed using the TensorFlow 1.15 backend. Should any 2.0 ops be not supported on the 1.15 after freezing, please open an Issue.
 
@@ -152,4 +152,4 @@ Got questions? Feel free to ask at the [RedisAI Forum](https://forum.redislabs.c
 
 Redis Source Available License Agreement - see [LICENSE](LICENSE)
 
-Copyright 2020, [Tensorwerk, Inc](https://tensorwerk.com) & [Redis Labs, Inc](https://redislabs.com)
+Copyright 2020, [Redis Labs, Inc](https://redislabs.com)

--- a/src/DAG/dag.c
+++ b/src/DAG/dag.c
@@ -257,7 +257,7 @@ void RedisAI_DagRunSession_ScriptRun_Step(RedisAI_RunInfo *rinfo, RAI_DagOp *cur
         RAI_ContextUnlock(rinfo);
 
         for (uint i = 0; i < n_inkeys; i++) {
-            RAI_ScriptRunCtxAddInput(currentOp->sctx, inputTensors[i]);
+            RAI_ScriptRunCtxAddInput(currentOp->sctx, inputTensors[i], currentOp->err);
         }
         for (uint i = 0; i < n_outkeys; i++) {
             RAI_ScriptRunCtxAddOutput(currentOp->sctx);
@@ -593,16 +593,16 @@ static void _PersistTensors(RedisModuleCtx *ctx, RedisAI_RunInfo *rinfo) {
                                        "ERR specified persistent key that was not used in DAG");
             rinfo->dagReplyLength++;
             RedisModule_Log(ctx, "warning",
-                            "on DAGRUN's PERSIST pecified persistent key (%s) that "
+                            "on DAGRUN's PERSIST specified persistent key (%s) that "
                             "was not used on DAG. Logging all local context keys",
-                            persist_key_name);
+                            RedisModule_StringPtrLen(persist_key_name, NULL));
             AI_dictIterator *local_iter = AI_dictGetSafeIterator(rinfo->dagTensorsContext);
             AI_dictEntry *local_entry = AI_dictNext(local_iter);
 
             while (local_entry) {
                 RedisModuleString *localcontext_key_name = AI_dictGetKey(local_entry);
                 RedisModule_Log(ctx, "warning", "DAG's local context key (%s)",
-                                localcontext_key_name);
+                                RedisModule_StringPtrLen(localcontext_key_name, NULL));
                 local_entry = AI_dictNext(local_iter);
             }
             AI_dictReleaseIterator(local_iter);

--- a/src/DAG/dag_parser.c
+++ b/src/DAG/dag_parser.c
@@ -136,18 +136,9 @@ int DAG_CommandParser(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, b
     int chainingOpCount = 0;
     bool load_complete = false;
     bool persist_complete = false;
-    int arg_pos = 1;
-
-    // If we're parsing a AI.SCRIPTRUN command, we don't expect there to be a chaining |> operator
-    if (!strcasecmp(RedisModule_StringPtrLen(argv[0], NULL), "AI.SCRIPTRUN")) {
-        arg_pos = 0;
-        chainingOpCount++;
-        rinfo->single_op_dag = 1;
-        rinfo->single_device_dag = 1;
-    }
 
     // The first arg is "AI.DAGRUN", so we go over from the next arg.
-    for (; arg_pos < argc; arg_pos++) {
+    for (int arg_pos = 1; arg_pos < argc; arg_pos++) {
         const char *arg_string = RedisModule_StringPtrLen(argv[arg_pos], NULL);
 
         if (!strcasecmp(arg_string, "LOAD") && !load_complete) {
@@ -232,6 +223,7 @@ int DAG_CommandParser(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, b
                 RedisModuleKey *modelKey;
                 const int status = RAI_GetModelFromKeyspace(ctx, argv[arg_pos + 1], &modelKey, &mto,
                                                             REDISMODULE_READ);
+                RedisModule_OpenKey(ctx, argv[arg_pos + 1], REDISMODULE_READ);
                 if (status == REDISMODULE_ERR) {
                     RAI_FreeRunInfo(rinfo);
                     RedisModule_ReplyWithError(ctx, "ERR Model not found");
@@ -252,6 +244,7 @@ int DAG_CommandParser(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, b
                 RedisModuleKey *scriptKey;
                 const int status = RAI_GetScriptFromKeyspace(ctx, argv[arg_pos + 1], &scriptKey,
                                                              &sto, REDISMODULE_READ);
+                RedisModule_OpenKey(ctx, argv[arg_pos + 1], REDISMODULE_READ);
                 if (status == REDISMODULE_ERR) {
                     RAI_FreeRunInfo(rinfo);
                     return REDISMODULE_ERR;
@@ -300,35 +293,6 @@ int DAG_CommandParser(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, b
                 return REDISMODULE_ERR;
             }
             break;
-        }
-    }
-
-    if (rinfo->single_op_dag && rinfo->dagOps[0]->commandType == REDISAI_DAG_CMD_SCRIPTRUN) {
-        RAI_DagOp *op = rinfo->dagOps[0];
-        RAI_Tensor *t;
-        RedisModuleKey *key;
-        for (size_t i = 0; i < array_len(op->inkeys); i++) {
-            RedisModuleString *inkey = op->inkeys[i];
-            const int status = RAI_GetTensorFromKeyspace(ctx, inkey, &key, &t, REDISMODULE_READ);
-            if (status == REDISMODULE_ERR) {
-                RedisModule_Log(ctx, "warning",
-                                "on DAGRUN's LOAD could not load tensor %s from keyspace",
-                                RedisModule_StringPtrLen(inkey, NULL));
-                return REDISMODULE_ERR;
-            }
-            char buf[16];
-            sprintf(buf, "%04d", 1);
-            RedisModuleString *dictKey = RedisModule_CreateStringFromString(NULL, inkey);
-            RedisModule_StringAppendBuffer(NULL, dictKey, buf, strlen(buf));
-            AI_dictAdd(rinfo->dagTensorsContext, (void *)dictKey,
-                       (void *)RAI_TensorGetShallowCopy(t));
-            AI_dictAdd(rinfo->dagTensorsLoadedContext, (void *)dictKey, (void *)1);
-            RedisModule_Free(dictKey);
-        }
-
-        for (size_t i = 0; i < array_len(op->outkeys); i++) {
-            RedisModuleString *outkey = op->outkeys[i];
-            AI_dictAdd(rinfo->dagTensorsPersistedContext, (void *)outkey, (void *)1);
         }
     }
 

--- a/src/DAG/dag_parser.c
+++ b/src/DAG/dag_parser.c
@@ -223,7 +223,6 @@ int DAG_CommandParser(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, b
                 RedisModuleKey *modelKey;
                 const int status = RAI_GetModelFromKeyspace(ctx, argv[arg_pos + 1], &modelKey, &mto,
                                                             REDISMODULE_READ);
-                RedisModule_OpenKey(ctx, argv[arg_pos + 1], REDISMODULE_READ);
                 if (status == REDISMODULE_ERR) {
                     RAI_FreeRunInfo(rinfo);
                     RedisModule_ReplyWithError(ctx, "ERR Model not found");
@@ -244,7 +243,6 @@ int DAG_CommandParser(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, b
                 RedisModuleKey *scriptKey;
                 const int status = RAI_GetScriptFromKeyspace(ctx, argv[arg_pos + 1], &scriptKey,
                                                              &sto, REDISMODULE_READ);
-                RedisModule_OpenKey(ctx, argv[arg_pos + 1], REDISMODULE_READ);
                 if (status == REDISMODULE_ERR) {
                     RAI_FreeRunInfo(rinfo);
                     return REDISMODULE_ERR;

--- a/src/command_parser.c
+++ b/src/command_parser.c
@@ -263,6 +263,7 @@ static int _ScriptRunCtx_SetParams(RedisModuleCtx *ctx, RedisModuleString **inke
 
     RAI_Tensor *t;
     RedisModuleKey *key;
+    RAI_Error *err;
     size_t ninputs = array_len(inkeys), noutputs = array_len(outkeys);
     for (size_t i = 0; i < ninputs; i++) {
         const int status = RAI_GetTensorFromKeyspace(ctx, inkeys[i], &key, &t, REDISMODULE_READ);
@@ -271,7 +272,7 @@ static int _ScriptRunCtx_SetParams(RedisModuleCtx *ctx, RedisModuleString **inke
                             RedisModule_StringPtrLen(inkeys[i], NULL));
             return REDISMODULE_ERR;
         }
-        RAI_ScriptRunCtxAddInput(sctx, t);
+        RAI_ScriptRunCtxAddInput(sctx, t, err);
     }
     for (size_t i = 0; i < noutputs; i++) {
         RAI_ScriptRunCtxAddOutput(sctx);

--- a/src/model.c
+++ b/src/model.c
@@ -261,6 +261,7 @@ int RAI_GetModelFromKeyspace(RedisModuleCtx *ctx, RedisModuleString *keyName, Re
         return REDISMODULE_ERR;
     }
     *model = RedisModule_ModuleTypeGetValue(*key);
+    RedisModule_CloseKey(*key);
     return REDISMODULE_OK;
 }
 

--- a/src/modelRun_ctx.c
+++ b/src/modelRun_ctx.c
@@ -1,5 +1,6 @@
 
 #include "modelRun_ctx.h"
+#include "util/string_utils.h"
 
 static int _Model_RunCtxAddParam(RAI_ModelCtxParam **paramArr, const char *name,
                                  RAI_Tensor *tensor) {
@@ -96,11 +97,7 @@ int RedisAI_Parse_ModelRun_RedisCommand(RedisModuleCtx *ctx, RedisModuleString *
             is_input = 1;
             outputs_flag_count = 1;
         } else {
-            if (RMAPI_FUNC_SUPPORTED(RedisModule_HoldString)) {
-                RedisModule_HoldString(NULL, argv[argpos]);
-            } else {
-                RedisModule_RetainString(NULL, argv[argpos]);
-            }
+            RAI_HoldString(NULL, argv[argpos]);
             if (is_input == 0) {
                 *inkeys = array_append(*inkeys, argv[argpos]);
                 ninputs++;

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -427,18 +427,15 @@ int RedisAI_ModelGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     }
 
     if (!meta && !blob) {
-        RedisModule_CloseKey(key);
         return RedisModule_ReplyWithError(ctx, "ERR no META or BLOB specified");
     }
 
     RAI_Error err = {0};
-
     char *buffer = NULL;
     size_t len = 0;
 
     if (blob) {
         RAI_ModelSerialize(mto, &buffer, &len, &err);
-
         if (err.code != RAI_OK) {
 #ifdef RAI_PRINT_BACKEND_ERRORS
             printf("ERR: %s\n", err.detail);
@@ -455,12 +452,10 @@ int RedisAI_ModelGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     if (!meta && blob) {
         RAI_ReplyWithChunks(ctx, buffer, len);
         RedisModule_Free(buffer);
-        RedisModule_CloseKey(key);
         return REDISMODULE_OK;
     }
 
     const int outentries = blob ? 16 : 14;
-
     RedisModule_ReplyWithArray(ctx, outentries);
 
     RedisModule_ReplyWithCString(ctx, "backend");
@@ -503,8 +498,6 @@ int RedisAI_ModelGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
         RedisModule_Free(buffer);
     }
 
-    RedisModule_CloseKey(key);
-
     return REDISMODULE_OK;
 }
 
@@ -523,6 +516,7 @@ int RedisAI_ModelDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
         return REDISMODULE_ERR;
     }
 
+    key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
     RedisModule_DeleteKey(key);
     RedisModule_CloseKey(key);
     RedisModule_ReplicateVerbatim(ctx);
@@ -617,13 +611,11 @@ int RedisAI_ScriptGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
     }
 
     if (!meta && !source) {
-        RedisModule_CloseKey(key);
         return RedisModule_ReplyWithError(ctx, "ERR no META or SOURCE specified");
     }
 
     if (!meta && source) {
         RedisModule_ReplyWithCString(ctx, sto->scriptdef);
-        RedisModule_CloseKey(key);
         return REDISMODULE_OK;
     }
 
@@ -638,7 +630,6 @@ int RedisAI_ScriptGet_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
         RedisModule_ReplyWithCString(ctx, "source");
         RedisModule_ReplyWithCString(ctx, sto->scriptdef);
     }
-    RedisModule_CloseKey(key);
     return REDISMODULE_OK;
 }
 
@@ -655,12 +646,11 @@ int RedisAI_ScriptDel_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
     if (status == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
-
+    key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
     RedisModule_DeleteKey(key);
     RedisModule_CloseKey(key);
 
     RedisModule_ReplicateVerbatim(ctx);
-
     return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -969,7 +969,7 @@ static int RedisAI_RegisterApi(RedisModuleCtx *ctx) {
     REGISTER_API(ModelGetShallowCopy, ctx);
     REGISTER_API(ModelRedisType, ctx);
     REGISTER_API(ModelRunAsync, ctx);
-    REGISTER_API(GetAsModelRunCtx, ctx)
+    REGISTER_API(GetAsModelRunCtx, ctx);
 
     REGISTER_API(ScriptCreate, ctx);
     REGISTER_API(ScriptFree, ctx);
@@ -983,6 +983,8 @@ static int RedisAI_RegisterApi(RedisModuleCtx *ctx) {
     REGISTER_API(ScriptRun, ctx);
     REGISTER_API(ScriptGetShallowCopy, ctx);
     REGISTER_API(ScriptRedisType, ctx);
+    REGISTER_API(ScriptRunAsync, ctx);
+    REGISTER_API(GetAsScriptRunCtx, ctx);
 
     return REDISMODULE_OK;
 }

--- a/src/redisai.h
+++ b/src/redisai.h
@@ -121,6 +121,9 @@ void MODULE_API_FUNC(RedisAI_ScriptRunCtxFree)(RAI_ScriptRunCtx *sctx);
 int MODULE_API_FUNC(RedisAI_ScriptRun)(RAI_ScriptRunCtx *sctx, RAI_Error *err);
 RAI_Script *MODULE_API_FUNC(RedisAI_ScriptGetShallowCopy)(RAI_Script *script);
 RedisModuleType *MODULE_API_FUNC(RedisAI_ScriptRedisType)(void);
+int MODULE_API_FUNC(RedisAI_ScriptRunAsync)(RAI_ScriptRunCtx *sctx, RAI_OnFinishCB DAGAsyncFinish,
+                                            void *private_data);
+RAI_ScriptRunCtx *MODULE_API_FUNC(RedisAI_GetAsScriptRunCtx)(RAI_OnFinishCtx *ctx, RAI_Error *err);
 
 int MODULE_API_FUNC(RedisAI_GetLLAPIVersion)();
 
@@ -204,6 +207,8 @@ static int RedisAI_Initialize(RedisModuleCtx *ctx) {
     REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRun);
     REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptGetShallowCopy);
     REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRedisType);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, ScriptRunAsync);
+    REDISAI_MODULE_INIT_FUNCTION(ctx, GetAsScriptRunCtx);
 
     if (RedisAI_GetLLAPIVersion() < REDISAI_LLAPI_VERSION) {
         return REDISMODULE_ERR;

--- a/src/run_info.c
+++ b/src/run_info.c
@@ -329,6 +329,7 @@ int RAI_RunInfoBatchable(struct RAI_DagOp *op1, struct RAI_DagOp *op2) {
 
     return 1;
 }
+
 RAI_ModelRunCtx *RAI_GetAsModelRunCtx(RedisAI_RunInfo *rinfo, RAI_Error *err) {
 
     RAI_DagOp *op = rinfo->dagOps[0];
@@ -341,4 +342,18 @@ RAI_ModelRunCtx *RAI_GetAsModelRunCtx(RedisAI_RunInfo *rinfo, RAI_Error *err) {
     rinfo->dagOps[0]->mctx = NULL;
     RAI_FreeRunInfo(rinfo);
     return mctx;
+}
+
+RAI_ScriptRunCtx *RAI_GetAsScriptRunCtx(RedisAI_RunInfo *rinfo, RAI_Error *err) {
+
+    RAI_DagOp *op = rinfo->dagOps[0];
+    if (!rinfo->single_op_dag || !op->sctx) {
+        RAI_SetError(err, RedisAI_ErrorCode_EFINISHCTX, "Finish ctx is not a script run ctx");
+        return NULL;
+    }
+    RAI_SetError(err, RAI_GetErrorCode(op->err), RAI_GetError(op->err));
+    RAI_ScriptRunCtx *sctx = op->sctx;
+    rinfo->dagOps[0]->sctx = NULL;
+    RAI_FreeRunInfo(rinfo);
+    return sctx;
 }

--- a/src/run_info.c
+++ b/src/run_info.c
@@ -145,9 +145,6 @@ int RAI_ShallowCopyDagRunInfo(RedisAI_RunInfo **result, RedisAI_RunInfo *src) {
 void RAI_FreeDagOp(RAI_DagOp *dagOp) {
     if (dagOp) {
         RAI_FreeError(dagOp->err);
-        if (dagOp->runkey) {
-            RedisModule_FreeString(NULL, dagOp->runkey);
-        }
         if (dagOp->argv) {
             for (size_t i = 0; i < array_len(dagOp->argv); i++) {
                 RedisModule_FreeString(NULL, dagOp->argv[i]);

--- a/src/run_info.c
+++ b/src/run_info.c
@@ -167,7 +167,7 @@ void RAI_FreeDagOp(RAI_DagOp *dagOp) {
             RAI_ModelRunCtxFree(dagOp->mctx);
         }
         if (dagOp->sctx) {
-            RAI_ScriptRunCtxFree(dagOp->sctx, true);
+            RAI_ScriptRunCtxFree(dagOp->sctx);
         }
 
         if (dagOp->inkeys) {

--- a/src/run_info.h
+++ b/src/run_info.h
@@ -188,6 +188,14 @@ int RAI_RunInfoBatchable(struct RAI_DagOp *op1, struct RAI_DagOp *op2);
  */
 RAI_ModelRunCtx *RAI_GetAsModelRunCtx(RedisAI_RunInfo *rinfo, RAI_Error *err);
 
+/**
+ * Retreive the ScriptRunCtx of a DAG runInfo that contains a single op of type
+ * SCRIPTRUN.
+ * @param DAG runInfo.
+ * @return Pointer to the ScriptRunCtx in DAG's single op.
+ */
+RAI_ScriptRunCtx *RAI_GetAsScriptRunCtx(RedisAI_RunInfo *rinfo, RAI_Error *err);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/script.h
+++ b/src/script.h
@@ -66,11 +66,9 @@ RAI_ScriptRunCtx *RAI_ScriptRunCtxCreate(RAI_Script *script, const char *fnname)
  *
  * @param sctx input RAI_ScriptRunCtx to add the input tensor
  * @param inputTensor input tensor structure
- * @param err error data structure to store error message in the case of
- * failures
  * @return returns 1 on success, 0 in case of error.
  */
-int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx *sctx, RAI_Tensor *inputTensor, RAI_Error *err);
+int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx *sctx, RAI_Tensor *inputTensor);
 
 /**
  * For each Allocates a RAI_ScriptCtxParam data structure, and enforces a
@@ -80,12 +78,10 @@ int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx *sctx, RAI_Tensor *inputTensor, RA
  * @param sctx input RAI_ScriptRunCtx to add the input tensor
  * @param inputTensors input tensors array
  * @param len input tensors array len
- * @param err error data structure to store error message in the case of
- * failures
  * @return returns 1 on success, 0 in case of error.
  */
 int RAI_ScriptRunCtxAddInputList(RAI_ScriptRunCtx *sctx, RAI_Tensor **inputTensors, size_t len,
-                                 RAI_Error *err);
+                                 RAI_Error *error);
 
 /**
  * Allocates a RAI_ScriptCtxParam data structure, and sets the tensor reference
@@ -119,9 +115,8 @@ RAI_Tensor *RAI_ScriptRunCtxOutputTensor(RAI_ScriptRunCtx *sctx, size_t index);
  * work
  *
  * @param sctx
- * @param freeTensors free input and output tensors or leave them allocated
  */
-void RAI_ScriptRunCtxFree(RAI_ScriptRunCtx *sctx, int freeTensors);
+void RAI_ScriptRunCtxFree(RAI_ScriptRunCtx *sctx);
 
 /**
  * Given the input script context, run associated script

--- a/src/script.h
+++ b/src/script.h
@@ -14,6 +14,7 @@
 #include "redismodule.h"
 #include "script_struct.h"
 #include "tensor.h"
+#include "run_info.h"
 
 extern RedisModuleType *RedisAI_ScriptType;
 
@@ -68,7 +69,7 @@ RAI_ScriptRunCtx *RAI_ScriptRunCtxCreate(RAI_Script *script, const char *fnname)
  * @param inputTensor input tensor structure
  * @return returns 1 on success, 0 in case of error.
  */
-int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx *sctx, RAI_Tensor *inputTensor);
+int RAI_ScriptRunCtxAddInput(RAI_ScriptRunCtx *sctx, RAI_Tensor *inputTensor, RAI_Error *error);
 
 /**
  * For each Allocates a RAI_ScriptCtxParam data structure, and enforces a
@@ -211,5 +212,17 @@ void RedisAI_ReplyOrSetError(RedisModuleCtx *ctx, RAI_Error *error, RAI_ErrorCod
  * @return redis module type representing a script.
  */
 RedisModuleType *RAI_ScriptRedisType(void);
+
+/**
+ * Insert the ScriptRunCtx to the run queues so it will run asynchronously.
+ *
+ * @param sctx SodelRunCtx to execute
+ * @param ScriptAsyncFinish A callback that will be called when the execution is finished.
+ * @param private_data This is going to be sent to to the ScriptAsyncFinish.
+ * @return REDISMODULE_OK if the sctx was insert to the queues successfully, REDISMODULE_ERR
+ * otherwise.
+ */
+int RAI_ScriptRunAsync(RAI_ScriptRunCtx *sctx, RAI_OnFinishCB ScriptAsyncFinish,
+                       void *private_data);
 
 #endif /* SRC_SCRIPT_H_ */

--- a/tests/flow/tests_llapi.py
+++ b/tests/flow/tests_llapi.py
@@ -2,30 +2,45 @@ import redis
 
 from includes import *
 import os
+from functools import wraps
 
 '''
 python -m RLTest --test tests_llapi.py --module path/to/redisai.so
 '''
 
-goal_dir = os.path.join(os.getcwd(), "../module/LLAPI.so")
-TEST_MODULE_PATH = os.path.abspath(goal_dir)
+
+def ensure_test_module_loaded(f):
+    @wraps(f)
+    def wrapper(env, *args, **kwargs):
+        goal_dir = os.path.join(os.getcwd(), "../module/LLAPI.so")
+        TEST_MODULE_PATH = os.path.abspath(goal_dir)
+        con = env.getConnection()
+        modules = con.execute_command("MODULE", "LIST")
+        if b'RAI_llapi' in [module[1] for module in modules]:
+            return f(env, *args, **kwargs)
+        try:
+            ret = con.execute_command('MODULE', 'LOAD', TEST_MODULE_PATH)
+            env.assertEqual(ret, b'OK')
+            return f(env, *args, **kwargs)
+        except Exception as e:
+            env.assertFalse(True)
+            env.debugPrint(str(e), force=True)
+            return
+    return wrapper
 
 
+@ensure_test_module_loaded
 def test_basic_check(env):
 
     con = env.getConnection()
-    ret = con.execute_command("MODULE", "LOAD", TEST_MODULE_PATH)
-    env.assertEqual(ret, b'OK')
     ret = con.execute_command("RAI_llapi.basic_check")
     env.assertEqual(ret, b'OK')
 
 
+@ensure_test_module_loaded
 def test_model_run_async(env):
 
     con = env.getConnection()
-    ret = con.execute_command("MODULE", "LOAD", TEST_MODULE_PATH)
-    env.assertEqual(ret, b'OK')
-
     test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
     model_filename = os.path.join(test_data_path, 'graph.pb')
 
@@ -38,4 +53,26 @@ def test_model_run_async(env):
     con.execute_command('AI.TENSORSET', 'a{1}', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
     con.execute_command('AI.TENSORSET', 'b{1}', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
     ret = con.execute_command("RAI_llapi.modelRun")
+    env.assertEqual(ret, b'Async run success')
+
+
+@ensure_test_module_loaded
+def test_script_run_async(env):
+
+    con = env.getConnection()
+    test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
+    script_filename = os.path.join(test_data_path, 'script.txt')
+
+    with open(script_filename, 'rb') as f:
+        script = f.read()
+
+    ret = con.execute_command('AI.SCRIPTSET', 'myscript{1}', DEVICE, 'TAG', 'version1', 'SOURCE', script)
+    env.assertEqual(ret, b'OK')
+
+    ret = con.execute_command('AI.TENSORSET', 'a{1}', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
+    env.assertEqual(ret, b'OK')
+    ret = con.execute_command('AI.TENSORSET', 'b{1}', 'FLOAT', 2, 2, 'VALUES', 2, 3, 2, 3)
+    env.assertEqual(ret, b'OK')
+
+    ret = con.execute_command("RAI_llapi.scriptRun")
     env.assertEqual(ret, b'Async run success')


### PR DESCRIPTION
Support async LLAPI (part 2/3): Refactor Script run command (parsing, execution as a single DAG op, persist tensors before reply to client). Support async LLAPI, in a similar way to the new model run async LLAPI.