### PR TITLE
lint on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,8 @@ workflows:
   version: 2
   build_and_package:
     jobs:
-      - lint
+      - lint:
+          <<: *on-any-branch
       - build-debian:
           <<: *on-any-branch
           <<: *after-linter


### PR DESCRIPTION
@rafie - from circle ci support:
```
Hi Dvir,
Thank you for contacting CircleCI Support.
In the build_and_package workflow, there are jobs with filters requiring the lint job. However, no filters are specified for the lint job.
By default, CircleCI will build for all branches, but won't build for any tag.
To have a build triggered when you push a tag you'll need to add the filters to the lint job too.
Let me know if this helps.
Yann - Support Engineer - CircleCI

```