### PR TITLE
Backend version

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -660,14 +660,14 @@ Because `AI.DAGRUN` provides the `PERSIST` option it is flagged as a 'write' com
     Refer to the Redis [`READONLY` command](https://redis.io/commands/readonly) for further information about read-only cluster replicas.
 
 ## AI.INFO
-The **`AI.INFO`** command returns information about the execution a model or a script.
+The **`AI.INFO`** command returns general module information or information about the execution a model or a script.
 
 Runtime information is collected each time that [`AI.MODELRUN`](#aimodelrun) or [`AI.SCRIPTRUN`](#aiscriptrun) is called. The information is stored locally by the executing RedisAI engine, so when deployed in a cluster each shard stores its own runtime information.
 
 **Redis API**
 
 ```
-AI.INFO <key> [RESETSTAT]
+AI.INFO [<key>] [RESETSTAT]
 ```
 
 _Arguments_
@@ -677,7 +677,15 @@ _Arguments_
 
 _Return_
 
-An array with alternating entries that represent the following key-value pairs:
+For a module genernal information: An array with alternating entries that represent the following key-value pairs:
+
+* **Version**: a string showing the current module version.
+* **Low level API Version**:  a string showing the current module's low level api version.
+* **RDB Encoding version**: a string showing the current module's RDB encoding version.
+* **TensorFlow version**: a string showing the current loaded TesnorFlow backend version.
+* **ONNX version**: a string showing the current loaded ONNX Runtime backend version.
+
+For model or script runtime information: An array with alternating entries that represent the following key-value pairs:
 
 * **KEY**: a String of the name of the key storing the model or script value
 * **TYPE**: a String of the type of value (i.e. 'MODEL' or 'SCRIPT')

--- a/src/backends.c
+++ b/src/backends.c
@@ -417,6 +417,16 @@ int RAI_LoadBackend_ONNXRuntime(RedisModuleCtx *ctx, const char *path) {
         return REDISMODULE_ERR;
     }
 
+    backend.get_version = (const char*(*)(void))(unsigned long)dlsym(handle, "RAI_GetBackendVersionORT");
+    if (backend.get_version == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_GetBackendVersionORT. ONNX backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
+
     RAI_backends.onnx = backend;
 
     RedisModule_Log(ctx, "notice", "ONNX backend loaded from %s", path);

--- a/src/backends.c
+++ b/src/backends.c
@@ -224,6 +224,17 @@ int RAI_LoadBackend_TFLite(RedisModuleCtx *ctx, const char *path) {
         return REDISMODULE_ERR;
     }
 
+    backend.get_version =
+        (const char *(*)(void))(unsigned long)dlsym(handle, "RAI_GetBackendVersionTFLite");
+    if (backend.get_version == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_GetBackendVersionTFLite. TFLite backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
+
     RAI_backends.tflite = backend;
 
     RedisModule_Log(ctx, "notice", "TFLITE backend loaded from %s", path);
@@ -333,6 +344,17 @@ int RAI_LoadBackend_Torch(RedisModuleCtx *ctx, const char *path) {
         dlclose(handle);
         RedisModule_Log(ctx, "warning",
                         "Backend does not export RAI_ScriptRunTorch. TORCH backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
+
+    backend.get_version =
+        (const char *(*)(void))(unsigned long)dlsym(handle, "RAI_GetBackendVersionTorch");
+    if (backend.get_version == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_GetBackendVersionTorch. TORCH backend "
                         "not loaded from %s",
                         path);
         return REDISMODULE_ERR;

--- a/src/backends.c
+++ b/src/backends.c
@@ -132,6 +132,16 @@ int RAI_LoadBackend_TensorFlow(RedisModuleCtx *ctx, const char *path) {
         return REDISMODULE_ERR;
     }
 
+    backend.get_version = (const char*(*)(void))(unsigned long)dlsym(handle, "RAI_GetBackendVersionTF");
+    if (backend.get_version == NULL) {
+        dlclose(handle);
+        RedisModule_Log(ctx, "warning",
+                        "Backend does not export RAI_GetBackendVersionTF. TF backend "
+                        "not loaded from %s",
+                        path);
+        return REDISMODULE_ERR;
+    }
+
     RAI_backends.tf = backend;
 
     RedisModule_Log(ctx, "notice", "TF backend loaded from %s", path);

--- a/src/backends.c
+++ b/src/backends.c
@@ -132,7 +132,8 @@ int RAI_LoadBackend_TensorFlow(RedisModuleCtx *ctx, const char *path) {
         return REDISMODULE_ERR;
     }
 
-    backend.get_version = (const char*(*)(void))(unsigned long)dlsym(handle, "RAI_GetBackendVersionTF");
+    backend.get_version =
+        (const char *(*)(void))(unsigned long)dlsym(handle, "RAI_GetBackendVersionTF");
     if (backend.get_version == NULL) {
         dlclose(handle);
         RedisModule_Log(ctx, "warning",
@@ -417,7 +418,8 @@ int RAI_LoadBackend_ONNXRuntime(RedisModuleCtx *ctx, const char *path) {
         return REDISMODULE_ERR;
     }
 
-    backend.get_version = (const char*(*)(void))(unsigned long)dlsym(handle, "RAI_GetBackendVersionORT");
+    backend.get_version =
+        (const char *(*)(void))(unsigned long)dlsym(handle, "RAI_GetBackendVersionORT");
     if (backend.get_version == NULL) {
         dlclose(handle);
         RedisModule_Log(ctx, "warning",

--- a/src/backends.h
+++ b/src/backends.h
@@ -75,7 +75,7 @@ typedef struct RAI_LoadedBackend {
     int (*script_run)(RAI_ScriptRunCtx *, RAI_Error *);
 
     // Returns the backend version.
-    const char* (*get_version)(void);
+    const char *(*get_version)(void);
 
 } RAI_LoadedBackend;
 

--- a/src/backends.h
+++ b/src/backends.h
@@ -74,6 +74,9 @@ typedef struct RAI_LoadedBackend {
     // RAI_ScriptRunCtx pointer
     int (*script_run)(RAI_ScriptRunCtx *, RAI_Error *);
 
+    // Returns the backend version.
+    const char* (*get_version)(void);
+
 } RAI_LoadedBackend;
 
 typedef struct RAI_LoadedBackends {

--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -671,7 +671,4 @@ int RAI_ModelSerializeORT(RAI_Model *model, char **buffer, size_t *len, RAI_Erro
     return 0;
 }
 
-const char* RAI_GetBackendVersionORT(void) {
-    return OrtGetApiBase()->GetVersionString();
-}
-
+const char *RAI_GetBackendVersionORT(void) { return OrtGetApiBase()->GetVersionString(); }

--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -670,3 +670,8 @@ int RAI_ModelSerializeORT(RAI_Model *model, char **buffer, size_t *len, RAI_Erro
 
     return 0;
 }
+
+const char* RAI_GetBackendVersionORT(void) {
+    return OrtGetApiBase()->GetVersionString();
+}
+

--- a/src/backends/onnxruntime.h
+++ b/src/backends/onnxruntime.h
@@ -17,4 +17,6 @@ int RAI_ModelRunORT(RAI_ModelRunCtx **mctxs, RAI_Error *error);
 
 int RAI_ModelSerializeORT(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error);
 
+const char* RAI_GetBackendVersionORT(void);
+
 #endif /* SRC_BACKENDS_ONNXRUNTIME_H_ */

--- a/src/backends/onnxruntime.h
+++ b/src/backends/onnxruntime.h
@@ -17,6 +17,6 @@ int RAI_ModelRunORT(RAI_ModelRunCtx **mctxs, RAI_Error *error);
 
 int RAI_ModelSerializeORT(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error);
 
-const char* RAI_GetBackendVersionORT(void);
+const char *RAI_GetBackendVersionORT(void);
 
 #endif /* SRC_BACKENDS_ONNXRUNTIME_H_ */

--- a/src/backends/tensorflow.c
+++ b/src/backends/tensorflow.c
@@ -591,3 +591,7 @@ int RAI_ModelSerializeTF(RAI_Model *model, char **buffer, size_t *len, RAI_Error
 
     return 0;
 }
+
+const char* RAI_GetBackendVersionTF(void) {
+    return TF_Version();
+}

--- a/src/backends/tensorflow.c
+++ b/src/backends/tensorflow.c
@@ -592,6 +592,4 @@ int RAI_ModelSerializeTF(RAI_Model *model, char **buffer, size_t *len, RAI_Error
     return 0;
 }
 
-const char* RAI_GetBackendVersionTF(void) {
-    return TF_Version();
-}
+const char *RAI_GetBackendVersionTF(void) { return TF_Version(); }

--- a/src/backends/tensorflow.h
+++ b/src/backends/tensorflow.h
@@ -19,4 +19,6 @@ int RAI_ModelRunTF(RAI_ModelRunCtx **mctxs, RAI_Error *error);
 
 int RAI_ModelSerializeTF(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error);
 
+const char* RAI_GetBackendVersionTF(void);
+
 #endif /* SRC_BACKENDS_TENSORFLOW_H_ */

--- a/src/backends/tensorflow.h
+++ b/src/backends/tensorflow.h
@@ -19,6 +19,6 @@ int RAI_ModelRunTF(RAI_ModelRunCtx **mctxs, RAI_Error *error);
 
 int RAI_ModelSerializeTF(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error);
 
-const char* RAI_GetBackendVersionTF(void);
+const char *RAI_GetBackendVersionTF(void);
 
 #endif /* SRC_BACKENDS_TENSORFLOW_H_ */

--- a/src/backends/tflite.c
+++ b/src/backends/tflite.c
@@ -237,3 +237,5 @@ int RAI_ModelSerializeTFLite(RAI_Model *model, char **buffer, size_t *len, RAI_E
 
     return 0;
 }
+
+const char *RAI_GetBackendVersionTFLite(void) { return "NA"; }

--- a/src/backends/tflite.h
+++ b/src/backends/tflite.h
@@ -1,5 +1,4 @@
-#ifndef SRC_BACKENDS_TFLITE_H_
-#define SRC_BACKENDS_TFLITE_H_
+#pragma once
 
 #include "config.h"
 #include "tensor_struct.h"
@@ -17,4 +16,4 @@ int RAI_ModelRunTFLite(RAI_ModelRunCtx **mctxs, RAI_Error *error);
 
 int RAI_ModelSerializeTFLite(RAI_Model *model, char **buffer, size_t *len, RAI_Error *error);
 
-#endif /* SRC_BACKENDS_TFLITE_H_ */
+const char *RAI_GetBackendVersionTFLite(void);

--- a/src/backends/torch.c
+++ b/src/backends/torch.c
@@ -367,3 +367,5 @@ int RAI_ScriptRunTorch(RAI_ScriptRunCtx *sctx, RAI_Error *error) {
 
     return 0;
 }
+
+const char *RAI_GetBackendVersionTorch(void) { return "NA"; }

--- a/src/backends/torch.h
+++ b/src/backends/torch.h
@@ -1,5 +1,4 @@
-#ifndef SRC_BACKENDS_TORCH_H_
-#define SRC_BACKENDS_TORCH_H_
+#pragma once
 
 #include "config.h"
 #include "tensor_struct.h"
@@ -24,4 +23,4 @@ void RAI_ScriptFreeTorch(RAI_Script *script, RAI_Error *error);
 
 int RAI_ScriptRunTorch(RAI_ScriptRunCtx *sctx, RAI_Error *error);
 
-#endif /* SRC_BACKENDS_TORCH_H_ */
+const char *RAI_GetBackendVersionTorch(void);

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -805,27 +805,29 @@ int RedisAI_ScriptScan_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **arg
     return REDISMODULE_OK;
 }
 
-void _RedisAI_Info(RedisModuleCtx* ctx) {
-    RedisModuleString* rai_version = RedisModule_CreateStringPrintf(ctx, "%d.%d.%d", REDISAI_VERSION_MAJOR, REDISAI_VERSION_MINOR, REDISAI_VERSION_PATCH);
-    RedisModuleString* llapi_version = RedisModule_CreateStringPrintf(ctx, "%d", REDISAI_LLAPI_VERSION);
-    RedisModuleString* rdb_version = RedisModule_CreateStringPrintf(ctx, "%llu", REDISAI_ENC_VER);
+void _RedisAI_Info(RedisModuleCtx *ctx) {
+    RedisModuleString *rai_version = RedisModule_CreateStringPrintf(
+        ctx, "%d.%d.%d", REDISAI_VERSION_MAJOR, REDISAI_VERSION_MINOR, REDISAI_VERSION_PATCH);
+    RedisModuleString *llapi_version =
+        RedisModule_CreateStringPrintf(ctx, "%d", REDISAI_LLAPI_VERSION);
+    RedisModuleString *rdb_version = RedisModule_CreateStringPrintf(ctx, "%llu", REDISAI_ENC_VER);
 
     int reponse_len = 6;
 
-    if(RAI_backends.tf.get_version){
-        reponse_len+=2;   
+    if (RAI_backends.tf.get_version) {
+        reponse_len += 2;
     }
 
-    if(RAI_backends.torch.get_version){
-        reponse_len+=2;   
+    if (RAI_backends.torch.get_version) {
+        reponse_len += 2;
     }
 
-    if(RAI_backends.tflite.get_version){
-        reponse_len+=2;   
+    if (RAI_backends.tflite.get_version) {
+        reponse_len += 2;
     }
 
-    if(RAI_backends.onnx.get_version){
-        reponse_len+=2;   
+    if (RAI_backends.onnx.get_version) {
+        reponse_len += 2;
     }
 
     RedisModule_ReplyWithArray(ctx, reponse_len);
@@ -838,20 +840,18 @@ void _RedisAI_Info(RedisModuleCtx* ctx) {
     RedisModule_ReplyWithSimpleString(ctx, "Low Level API Version");
     RedisModule_ReplyWithString(ctx, llapi_version);
 
-
     RedisModule_ReplyWithSimpleString(ctx, "RDB Encoding version");
     RedisModule_ReplyWithString(ctx, llapi_version);
 
-    if(RAI_backends.tf.get_version){
-        RedisModule_ReplyWithSimpleString(ctx, "TensorFlow version"); 
-        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.tf.get_version()); 
+    if (RAI_backends.tf.get_version) {
+        RedisModule_ReplyWithSimpleString(ctx, "TensorFlow version");
+        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.tf.get_version());
     }
 
-    if(RAI_backends.onnx.get_version){
-        RedisModule_ReplyWithSimpleString(ctx, "ONNX version"); 
-        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.onnx.get_version()); 
+    if (RAI_backends.onnx.get_version) {
+        RedisModule_ReplyWithSimpleString(ctx, "ONNX version");
+        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.onnx.get_version());
     }
-
 
     RedisModule_FreeString(ctx, rai_version);
     RedisModule_FreeString(ctx, llapi_version);
@@ -865,12 +865,10 @@ int RedisAI_Info_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
     if (argc > 3)
         return RedisModule_WrongArity(ctx);
 
-
-    if(argc == 1) {
+    if (argc == 1) {
         _RedisAI_Info(ctx);
         return REDISMODULE_OK;
     }
-
 
     RedisModuleString *runkey = argv[1];
     struct RedisAI_RunStats *rstats = NULL;

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -847,9 +847,9 @@ void _RedisAI_Info(RedisModuleCtx* ctx) {
         RedisModule_ReplyWithSimpleString(ctx, RAI_backends.tf.get_version()); 
     }
 
-    if(RAI_backends.torch.get_version){
-        RedisModule_ReplyWithSimpleString(ctx, "Torch version"); 
-        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.torch.get_version()); 
+    if(RAI_backends.onnx.get_version){
+        RedisModule_ReplyWithSimpleString(ctx, "ONNX version"); 
+        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.onnx.get_version()); 
     }
 
 

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -844,6 +844,16 @@ void _RedisAI_Info(RedisModuleCtx *ctx) {
         RedisModule_ReplyWithSimpleString(ctx, RAI_backends.tf.get_version());
     }
 
+    if (RAI_backends.torch.get_version) {
+        RedisModule_ReplyWithSimpleString(ctx, "Torch version");
+        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.torch.get_version());
+    }
+
+    if (RAI_backends.tflite.get_version) {
+        RedisModule_ReplyWithSimpleString(ctx, "TFLite version");
+        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.tflite.get_version());
+    }
+
     if (RAI_backends.onnx.get_version) {
         RedisModule_ReplyWithSimpleString(ctx, "ONNX version");
         RedisModule_ReplyWithSimpleString(ctx, RAI_backends.onnx.get_version());

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -805,12 +805,73 @@ int RedisAI_ScriptScan_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **arg
     return REDISMODULE_OK;
 }
 
+void _RedisAI_Info(RedisModuleCtx* ctx) {
+    RedisModuleString* rai_version = RedisModule_CreateStringPrintf(ctx, "%d.%d.%d", REDISAI_VERSION_MAJOR, REDISAI_VERSION_MINOR, REDISAI_VERSION_PATCH);
+    RedisModuleString* llapi_version = RedisModule_CreateStringPrintf(ctx, "%d", REDISAI_LLAPI_VERSION);
+    RedisModuleString* rdb_version = RedisModule_CreateStringPrintf(ctx, "%llu", REDISAI_ENC_VER);
+
+    int reponse_len = 6;
+
+    if(RAI_backends.tf.get_version){
+        reponse_len+=2;   
+    }
+
+    if(RAI_backends.torch.get_version){
+        reponse_len+=2;   
+    }
+
+    if(RAI_backends.tflite.get_version){
+        reponse_len+=2;   
+    }
+
+    if(RAI_backends.onnx.get_version){
+        reponse_len+=2;   
+    }
+
+    RedisModule_ReplyWithArray(ctx, reponse_len);
+
+    RedisModule_ReplyWithSimpleString(ctx, "Version");
+    RedisModule_ReplyWithString(ctx, rai_version);
+
+    // TODO: Add Git SHA
+
+    RedisModule_ReplyWithSimpleString(ctx, "Low Level API Version");
+    RedisModule_ReplyWithString(ctx, llapi_version);
+
+
+    RedisModule_ReplyWithSimpleString(ctx, "RDB Encoding version");
+    RedisModule_ReplyWithString(ctx, llapi_version);
+
+    if(RAI_backends.tf.get_version){
+        RedisModule_ReplyWithSimpleString(ctx, "TensorFlow version"); 
+        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.tf.get_version()); 
+    }
+
+    if(RAI_backends.torch.get_version){
+        RedisModule_ReplyWithSimpleString(ctx, "Torch version"); 
+        RedisModule_ReplyWithSimpleString(ctx, RAI_backends.torch.get_version()); 
+    }
+
+
+    RedisModule_FreeString(ctx, rai_version);
+    RedisModule_FreeString(ctx, llapi_version);
+    RedisModule_FreeString(ctx, rdb_version);
+}
+
 /**
  * AI.INFO <model_or_script_key> [RESETSTAT]
  */
 int RedisAI_Info_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    if (argc != 2 && argc != 3)
+    if (argc > 3)
         return RedisModule_WrongArity(ctx);
+
+
+    if(argc == 1) {
+        _RedisAI_Info(ctx);
+        return REDISMODULE_OK;
+    }
+
+
     RedisModuleString *runkey = argv[1];
     struct RedisAI_RunStats *rstats = NULL;
     if (RAI_GetRunStats(runkey, &rstats) == REDISMODULE_ERR) {

--- a/src/version.h
+++ b/src/version.h
@@ -1,5 +1,4 @@
-#ifndef SRC_VERSION_H_
-#define SRC_VERSION_H_
+#pragma once
 
 #define REDISAI_VERSION_MAJOR 99
 #define REDISAI_VERSION_MINOR 99
@@ -13,4 +12,3 @@
 
 static const long long REDISAI_ENC_VER = 1;
 
-#endif /* SRC_VERSION_H_ */

--- a/src/version.h
+++ b/src/version.h
@@ -11,4 +11,3 @@
 #define REDISAI_LLAPI_VERSION 1
 
 static const long long REDISAI_ENC_VER = 1;
-

--- a/tests/flow/tests_common.py
+++ b/tests/flow/tests_common.py
@@ -332,3 +332,8 @@ def test_lua_multi(env):
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
         env.assertEqual("Cannot run RedisAI command within a transaction or a LUA script", exception.__str__())
+
+def test_info(env):
+    con = env.getConnection()
+    ret = con.execute_command('AI.INFO')
+    env.assertEqual(6, len(ret))

--- a/tests/flow/tests_onnx.py
+++ b/tests/flow/tests_onnx.py
@@ -393,3 +393,23 @@ def test_onnx_model_rdb_save_load(env):
     # Assert input model binary is equal to loaded model binary
     env.assertTrue(model_pb == model_serialized_after_rdbload)
 
+def tests_onnx_info(env):
+    if not TEST_ONNX:
+        env.debugPrint("skipping {} since TEST_ONNX=0".format(sys._getframe().f_code.co_name), force=True)
+        return
+    con = env.getConnection()
+
+    ret = con.execute_command('AI.INFO')
+    env.assertEqual(6, len(ret))
+
+    test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
+    linear_model_filename = os.path.join(test_data_path, 'linear_iris.onnx')
+
+    with open(linear_model_filename, 'rb') as f:
+        model_pb = f.read()
+
+    con.execute_command('AI.MODELSET', 'linear{1}', 'ONNX', DEVICE, 'BLOB', model_pb)
+    
+    ret = con.execute_command('AI.INFO')
+    env.assertEqual(8, len(ret))
+    env.assertEqual(b'ONNX version', ret[6])

--- a/tests/flow/tests_pytorch.py
+++ b/tests/flow/tests_pytorch.py
@@ -984,3 +984,22 @@ def test_modelget_for_tuple_output(env):
     env.assertEqual(ret[9], 0)
     env.assertEqual(len(ret[11]), 2)
     env.assertEqual(len(ret[13]), 2)
+
+def test_torch_info(env):
+    if not TEST_PT:
+        env.debugPrint("skipping {}".format(sys._getframe().f_code.co_name), force=True)
+        return
+    con = env.getConnection()
+
+    ret = con.execute_command('AI.INFO')
+    env.assertEqual(6, len(ret))
+
+    test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
+    model_filename = os.path.join(test_data_path, 'pt-minimal-bb.pt')
+    with open(model_filename, 'rb') as f:
+        model_pb = f.read()
+    ret = con.execute_command('AI.MODELSET', 'm{1}', 'TORCH', DEVICE, 'BLOB', model_pb)
+
+    ret = con.execute_command('AI.INFO')
+    env.assertEqual(8, len(ret))
+    env.assertEqual(b'Torch version', ret[6])

--- a/tests/flow/tests_tensorflow.py
+++ b/tests/flow/tests_tensorflow.py
@@ -860,3 +860,23 @@ def test_tensorflow_modelrun_scriptrun_resnet(env):
     ret = con.execute_command('AI.TENSORGET', output_key, 'VALUES' )
     # tf model has 100 classes [0,999]
     env.assertEqual(ret[0]>=0 and ret[0]<1001, True)
+
+@skip_if_no_TF
+def test_tf_info(env):
+    con = env.getConnection()
+
+    ret = con.execute_command('AI.INFO')
+    env.assertEqual(6, len(ret))
+
+    test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
+    model_filename = os.path.join(test_data_path, 'graph.pb')
+
+    with open(model_filename, 'rb') as f:
+        model_pb = f.read()
+
+    con.execute_command('AI.MODELSET', 'm{1}', 'TF', DEVICE,
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
+    
+    ret = con.execute_command('AI.INFO')
+    env.assertEqual(8, len(ret))
+    env.assertEqual(b'TensorFlow version', ret[6])

--- a/tests/flow/tests_tflite.py
+++ b/tests/flow/tests_tflite.py
@@ -354,3 +354,24 @@ def test_tflite_model_rdb_save_load(env):
     env.assertTrue(model_serialized_memory == model_serialized_after_rdbload)
     # Assert input model binary is equal to loaded model binary
     env.assertTrue(model_pb == model_serialized_after_rdbload)
+
+def test_tflite_info(env):
+    if not TEST_TFLITE:
+        env.debugPrint("skipping {}".format(sys._getframe().f_code.co_name), force=True)
+        return
+    con = env.getConnection()
+
+    ret = con.execute_command('AI.INFO')
+    env.assertEqual(6, len(ret))
+
+    test_data_path = os.path.join(os.path.dirname(__file__), 'test_data')
+    model_filename = os.path.join(test_data_path, 'mnist_model_quant.tflite')
+
+    with open(model_filename, 'rb') as f:
+        model_pb = f.read()
+
+    ret = con.execute_command('AI.MODELSET', 'mnist{1}', 'TFLITE', 'CPU', 'BLOB', model_pb)
+
+    ret = con.execute_command('AI.INFO')
+    env.assertEqual(8, len(ret))
+    env.assertEqual(b'TFLite version', ret[6])


### PR DESCRIPTION
this PR modifies `AI.INFO` arguments to optional. a call to `AI.INFO` without arguments will yields:
1. module version
2.  LLAPI version
3. RDB encoder version.
4. optional: TF version (if loaded)
5. optional onnx version (if loaded)

missing:
TFLIte version - not exported in current depdendecy structure
TORCH version - waiting for https://github.com/pytorch/pytorch/issues/44365

closes #477 