### PR TITLE
tensor len member

### DIFF
--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -174,7 +174,7 @@ RAI_Tensor *RAI_TensorCreateFromOrtValue(OrtValue *v, size_t batch_offset, long 
         return NULL;
     }
 
-    ret = RedisModule_Calloc(1, sizeof(*ret));
+    ret = RAI_TensorNew();
 
     DLContext ctx = (DLContext){.device_type = kDLCPU, .device_id = 0};
 
@@ -261,7 +261,6 @@ RAI_Tensor *RAI_TensorCreateFromOrtValue(OrtValue *v, size_t batch_offset, long 
                                         .manager_ctx = NULL,
                                         .deleter = NULL};
 
-        ret->refCount = 1;
         return ret;
     }
 

--- a/src/backends/tensorflow.c
+++ b/src/backends/tensorflow.c
@@ -88,7 +88,7 @@ DLDataType RAI_GetDLDataTypeFromTF(TF_DataType dtype) {
 
 RAI_Tensor *RAI_TensorCreateFromTFTensor(TF_Tensor *tensor, size_t batch_offset,
                                          long long batch_size) {
-    RAI_Tensor *ret = RedisModule_Calloc(1, sizeof(*ret));
+    RAI_Tensor *ret = RAI_TensorNew();
 
     DLContext ctx = (DLContext){.device_type = kDLCPU, .device_id = 0};
 
@@ -143,7 +143,6 @@ RAI_Tensor *RAI_TensorCreateFromTFTensor(TF_Tensor *tensor, size_t batch_offset,
         .manager_ctx = NULL,
         .deleter = NULL};
 
-    ret->refCount = 1;
     return ret;
 }
 

--- a/src/serialization/RDB/decoder/current/v1/decode_v1.c
+++ b/src/serialization/RDB/decoder/current/v1/decode_v1.c
@@ -48,7 +48,7 @@ void *RAI_RDBLoadTensor_v1(RedisModuleIO *io) {
     if (RedisModule_IsIOError(io))
         goto cleanup;
 
-    RAI_Tensor *ret = RedisModule_Calloc(1, sizeof(*ret));
+    RAI_Tensor *ret = RAI_TensorNew();
     ret->tensor = (DLManagedTensor){.dl_tensor = (DLTensor){.ctx = ctx,
                                                             .data = data,
                                                             .ndim = ndims,
@@ -58,7 +58,6 @@ void *RAI_RDBLoadTensor_v1(RedisModuleIO *io) {
                                                             .byte_offset = byte_offset},
                                     .manager_ctx = NULL,
                                     .deleter = NULL};
-    ret->refCount = 1;
     return ret;
 
 cleanup:

--- a/src/serialization/RDB/decoder/previous/v0/decode_v0.c
+++ b/src/serialization/RDB/decoder/previous/v0/decode_v0.c
@@ -41,7 +41,7 @@ void *RAI_RDBLoadTensor_v0(RedisModuleIO *io) {
     if (RedisModule_IsIOError(io))
         goto cleanup;
 
-    RAI_Tensor *ret = RedisModule_Calloc(1, sizeof(*ret));
+    RAI_Tensor *ret = RAI_TensorNew();
     ret->tensor = (DLManagedTensor){.dl_tensor = (DLTensor){.ctx = ctx,
                                                             .data = data,
                                                             .ndim = ndims,
@@ -51,7 +51,6 @@ void *RAI_RDBLoadTensor_v0(RedisModuleIO *io) {
                                                             .byte_offset = byte_offset},
                                     .manager_ctx = NULL,
                                     .deleter = NULL};
-    ret->refCount = 1;
     return ret;
 
 cleanup:

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -50,6 +50,14 @@ extern RedisModuleType *RedisAI_TensorType;
 int RAI_TensorInit(RedisModuleCtx *ctx);
 
 /**
+ * @brief Allocate an empty tensor with no data.
+ * @note The new tensor ref coutn is 1.
+ *
+ * @return RAI_Tensor* - a pointer to the new tensor.
+ */
+RAI_Tensor *RAI_TensorNew(void);
+
+/**
  * Allocate the memory and initialise the RAI_Tensor. Creates a tensor based on
  * the passed 'dataType` string and with the specified number of dimensions
  * `ndims`, and n-dimension array `dims`.

--- a/src/tensor_struct.h
+++ b/src/tensor_struct.h
@@ -1,12 +1,12 @@
-#ifndef SRC_TENSOR_STRUCT_H_
-#define SRC_TENSOR_STRUCT_H_
+#pragma once
 
 #include "config.h"
 #include "dlpack/dlpack.h"
+#include "limits.h"
 
+#define LEN_UNKOWN ULONG_MAX
 typedef struct RAI_Tensor {
     DLManagedTensor tensor;
+    size_t len;
     long long refCount;
 } RAI_Tensor;
-
-#endif /* SRC_TENSOR_STRUCT_H_ */


### PR DESCRIPTION
this PR adds a new `len` member to `RAI_Tensor` which is lazy evaluated on `RAI_TensorLength` 
This should reduce the amount of calls to `RAI_TensorLength`

closes #495 