### PR TITLE
Revert TensorGetValueAsDouble/LongLong return value

### DIFF
--- a/src/tensor.c
+++ b/src/tensor.c
@@ -468,12 +468,12 @@ int RAI_TensorGetValueAsDouble(RAI_Tensor *t, long long i, double *val) {
             *val = ((double *)data)[i];
             break;
         default:
-            return REDISMODULE_ERR;
+            return 0;
         }
     } else {
-        return REDISMODULE_ERR;
+        return 0;
     }
-    return REDISMODULE_OK;
+    return 1;
 }
 
 int RAI_TensorGetValueAsLongLong(RAI_Tensor *t, long long i, long long *val) {
@@ -497,7 +497,7 @@ int RAI_TensorGetValueAsLongLong(RAI_Tensor *t, long long i, long long *val) {
             *val = ((int64_t *)data)[i];
             break;
         default:
-            return REDISMODULE_ERR;
+            return 0;
         }
     } else if (dtype.code == kDLUInt) {
         switch (dtype.bits) {
@@ -514,12 +514,12 @@ int RAI_TensorGetValueAsLongLong(RAI_Tensor *t, long long i, long long *val) {
             *val = ((uint64_t *)data)[i];
             break;
         default:
-            return REDISMODULE_ERR;
+            return 0;
         }
     } else {
-        return REDISMODULE_ERR;
+        return 0;
     }
-    return REDISMODULE_OK;
+    return 1;
 }
 
 RAI_Tensor *RAI_TensorGetShallowCopy(RAI_Tensor *t) {
@@ -736,7 +736,7 @@ int RAI_TensorReplyWithValues(RedisModuleCtx *ctx, RAI_Tensor *t) {
         double val;
         for (i = 0; i < len; i++) {
             int ret = RAI_TensorGetValueAsDouble(t, i, &val);
-            if (ret == REDISMODULE_ERR) {
+            if (!ret) {
                 RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
                 return -1;
             }
@@ -746,7 +746,7 @@ int RAI_TensorReplyWithValues(RedisModuleCtx *ctx, RAI_Tensor *t) {
         long long val;
         for (i = 0; i < len; i++) {
             int ret = RAI_TensorGetValueAsLongLong(t, i, &val);
-            if (ret == REDISMODULE_ERR) {
+            if (!ret) {
                 RedisModule_ReplyWithError(ctx, "ERR cannot get values for this datatype");
                 return -1;
             }

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -237,7 +237,7 @@ int RAI_TensorSetValueFromLongLong(RAI_Tensor *t, long long i, long long val);
  * @param t tensor to set the data
  * @param i dl_tensor data pointer position
  * @param val value to set the data from
- * @return 0 on success, or 1 if the setting failed
+ * @return 1 on success, or 0 if the setting failed
  */
 int RAI_TensorSetValueFromDouble(RAI_Tensor *t, long long i, double val);
 
@@ -248,7 +248,7 @@ int RAI_TensorSetValueFromDouble(RAI_Tensor *t, long long i, double val);
  * @param t tensor to get the data
  * @param i dl_tensor data pointer position
  * @param val value to set the data to
- * @return 0 on success, or 1 if getting the data failed
+ * @return 1 on success, or 0 if getting the data failed
  */
 int RAI_TensorGetValueAsDouble(RAI_Tensor *t, long long i, double *val);
 
@@ -259,7 +259,7 @@ int RAI_TensorGetValueAsDouble(RAI_Tensor *t, long long i, double *val);
  * @param t tensor to get the data
  * @param i dl_tensor data pointer position
  * @param val value to set the data to
- * @return 0 on success, or 1 if getting the data failed
+ * @return 1 on success, or 0 if getting the data failed
  */
 int RAI_TensorGetValueAsLongLong(RAI_Tensor *t, long long i, long long *val);
 

--- a/tests/module/DAG_utils.c
+++ b/tests/module/DAG_utils.c
@@ -263,7 +263,7 @@ int testSimpleDAGRun(RedisModuleCtx *ctx) {
     double expceted[4] = {4, 9, 4, 9};
     double val;
     for (long long i = 0; i < 4; i++) {
-        if(RedisAI_TensorGetValueAsDouble(out_tensor, i, &val) != 0) {
+        if(!RedisAI_TensorGetValueAsDouble(out_tensor, i, &val)) {
             goto cleanup;
         }
         if (expceted[i] != val) {
@@ -316,7 +316,7 @@ int testSimpleDAGRun2(RedisModuleCtx *ctx) {
     double expceted[4] = {4, 6, 4, 6};
     double val;
     for (long long i = 0; i < 4; i++) {
-        if(RedisAI_TensorGetValueAsDouble(out_tensor, i, &val) != 0) {
+        if(!RedisAI_TensorGetValueAsDouble(out_tensor, i, &val)) {
             goto cleanup;
         }
         if (expceted[i] != val) {
@@ -427,7 +427,7 @@ int testDAGResnet(RedisModuleCtx *ctx) {
     RedisModule_Assert(_ResultsNumOutputs(results) == 1);
     RAI_Tensor *out_tensor = results.outputs[0];
     long long val;
-    if(RedisAI_TensorGetValueAsLongLong(out_tensor, 0, &val) != 0) goto cleanup;
+    if(!RedisAI_TensorGetValueAsLongLong(out_tensor, 0, &val)) goto cleanup;
     if (0 <= val && val <= 1000) {
         res = LLAPIMODULE_OK;
     }

--- a/tests/module/LLAPI.c
+++ b/tests/module/LLAPI.c
@@ -53,7 +53,7 @@ static void _ScriptFinishFunc(RAI_OnFinishCtx *onFinishCtx, void *private_data) 
 
 	// Verify that we received the expected tensor at the end of the run.
 	for (long long i = 0; i < 4; i++) {
-		if(RedisAI_TensorGetValueAsDouble(tensor, i, &val[i]) != 0) {
+		if(!RedisAI_TensorGetValueAsDouble(tensor, i, &val[i])) {
 			goto finish;
 		}
 		if (expceted[i] != val[i]) {
@@ -86,7 +86,7 @@ static void _ModelFinishFunc(RAI_OnFinishCtx *onFinishCtx, void *private_data) {
 
 	// Verify that we received the expected tensor at the end of the run.
 	for (long long i = 0; i < 4; i++) {
-		if(RedisAI_TensorGetValueAsDouble(tensor, i, &val[i]) != 0) {
+		if(!RedisAI_TensorGetValueAsDouble(tensor, i, &val[i])) {
 			goto finish;
 		}
 		if (expceted[i] != val[i]) {


### PR DESCRIPTION
Revert to avoid breaking api with gears: return 1 if TensorGetValueAsDouble/LongLong succeeded, 0 otherwise.
Add a test with gears that checks the method that flatten tensor to list method (which use these APIs)