### PR TITLE
Fix leak in running onnx with batching

### DIFF
--- a/src/backends/onnxruntime.c
+++ b/src/backends/onnxruntime.c
@@ -571,6 +571,7 @@ int RAI_ModelRunORT(RAI_ModelRunCtx **mctxs, RAI_Error *error) {
                 ONNX_VALIDATE_STATUS(ort->GetDimensionsCount(info, &ndims))
                 int64_t dims[ndims];
                 ONNX_VALIDATE_STATUS(ort->GetDimensions(info, dims, ndims))
+                ort->ReleaseTensorTypeAndShapeInfo(info);
                 if (dims[0] != total_batch_size) {
                     RAI_SetError(error, RAI_EMODELRUN,
                                  "ERR Model did not generate the expected batch size");


### PR DESCRIPTION
Call ReleaseTensorTypeAndShape after running onnx model with batching.
**Waiting for the fix in minbatchsize logic before merge (currently batching is not always testes)**