### PR TITLE
Enable async modelset + refactor of model creation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ ADD_LIBRARY(redisai_obj OBJECT
         execution/command_parser.c
         execution/run_info.c
         execution/background_workers.c
+        execution/background_modelset.c
         config/config.c
         execution/DAG/dag.c
         execution/DAG/dag_parser.c

--- a/src/backends/backends.c
+++ b/src/backends/backends.c
@@ -88,9 +88,7 @@ int RAI_LoadBackend_TensorFlow(RedisModuleCtx *ctx, const char *path) {
     init_backend(RedisModule_GetApi);
 
     backend.model_create_with_nodes =
-        (RAI_Model * (*)(RAI_Backend, const char *, RAI_ModelOpts, size_t, const char **, size_t,
-                         const char **, const char *, size_t,
-                         RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTF");
+        (int (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTF");
     if (backend.model_create_with_nodes == NULL) {
         dlclose(handle);
         RedisModule_Log(ctx, "warning",
@@ -180,8 +178,7 @@ int RAI_LoadBackend_TFLite(RedisModuleCtx *ctx, const char *path) {
     init_backend(RedisModule_GetApi);
 
     backend.model_create =
-        (RAI_Model * (*)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
-                         RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTFLite");
+        (int (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTFLite");
     if (backend.model_create == NULL) {
         dlclose(handle);
         RedisModule_Log(ctx, "warning",
@@ -272,8 +269,7 @@ int RAI_LoadBackend_Torch(RedisModuleCtx *ctx, const char *path) {
     init_backend(RedisModule_GetApi);
 
     backend.model_create =
-        (RAI_Model * (*)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
-                         RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTorch");
+        (int (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateTorch");
     if (backend.model_create == NULL) {
         dlclose(handle);
         RedisModule_Log(ctx, "warning",
@@ -396,8 +392,7 @@ int RAI_LoadBackend_ONNXRuntime(RedisModuleCtx *ctx, const char *path) {
     init_backend(RedisModule_GetApi);
 
     backend.model_create =
-        (RAI_Model * (*)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
-                         RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateORT");
+        (int (*)(RAI_Model *, RAI_Error *))(unsigned long)dlsym(handle, "RAI_ModelCreateORT");
     if (backend.model_create == NULL) {
         dlclose(handle);
         RedisModule_Log(ctx, "warning",

--- a/src/backends/backends.h
+++ b/src/backends/backends.h
@@ -40,15 +40,12 @@
  */
 typedef struct RAI_LoadedBackend {
     // ** model_create_with_nodes **:  A callback function pointer that creates a
-    // model given the RAI_ModelOpts and input and output nodes
-    RAI_Model *(*model_create_with_nodes)(RAI_Backend, const char *, RAI_ModelOpts, size_t,
-                                          const char **, size_t, const char **, const char *,
-                                          size_t, RAI_Error *);
+    // model given the RAI_ModelOpts and input and output nodes (which are stored in the model).
+    int (*model_create_with_nodes)(RAI_Model *, RAI_Error *);
 
     // ** model_create **:  A callback function pointer that creates a model given
-    // the RAI_ModelOpts
-    RAI_Model *(*model_create)(RAI_Backend, const char *, RAI_ModelOpts, const char *, size_t,
-                               RAI_Error *);
+    // the RAI_ModelOpts (which are stored in the model).
+    int (*model_create)(RAI_Model *, RAI_Error *);
 
     // ** model_free **:  A callback function pointer that frees a model given the
     // RAI_Model pointer

--- a/src/backends/onnxruntime.h
+++ b/src/backends/onnxruntime.h
@@ -11,8 +11,7 @@ unsigned long long RAI_GetMemoryAccessORT(void);
 
 int RAI_InitBackendORT(int (*get_api_fn)(const char *, void *));
 
-RAI_Model *RAI_ModelCreateORT(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
-                              const char *modeldef, size_t modellen, RAI_Error *err);
+int RAI_ModelCreateORT(RAI_Model *model, RAI_Error *err);
 
 void RAI_ModelFreeORT(RAI_Model *model, RAI_Error *error);
 

--- a/src/backends/tensorflow.h
+++ b/src/backends/tensorflow.h
@@ -7,10 +7,7 @@
 
 int RAI_InitBackendTF(int (*get_api_fn)(const char *, void *));
 
-RAI_Model *RAI_ModelCreateTF(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
-                             size_t ninputs, const char **inputs, size_t noutputs,
-                             const char **outputs, const char *modeldef, size_t modellen,
-                             RAI_Error *error);
+int RAI_ModelCreateTF(RAI_Model *model, RAI_Error *error);
 
 void RAI_ModelFreeTF(RAI_Model *model, RAI_Error *error);
 

--- a/src/backends/tflite.h
+++ b/src/backends/tflite.h
@@ -7,8 +7,7 @@
 
 int RAI_InitBackendTFLite(int (*get_api_fn)(const char *, void *));
 
-RAI_Model *RAI_ModelCreateTFLite(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
-                                 const char *modeldef, size_t modellen, RAI_Error *err);
+int RAI_ModelCreateTFLite(RAI_Model *model, RAI_Error *err);
 
 void RAI_ModelFreeTFLite(RAI_Model *model, RAI_Error *error);
 

--- a/src/backends/torch.h
+++ b/src/backends/torch.h
@@ -8,8 +8,7 @@
 
 int RAI_InitBackendTorch(int (*get_api_fn)(const char *, void *));
 
-RAI_Model *RAI_ModelCreateTorch(RAI_Backend backend, const char *devicestr, RAI_ModelOpts opts,
-                                const char *modeldef, size_t modellen, RAI_Error *err);
+int RAI_ModelCreateTorch(RAI_Model *model, RAI_Error *err);
 
 void RAI_ModelFreeTorch(RAI_Model *model, RAI_Error *error);
 

--- a/src/backends/util.c
+++ b/src/backends/util.c
@@ -1,7 +1,8 @@
 #include "backends/util.h"
+#include "string.h"
 
 int parseDeviceStr(const char *devicestr, RAI_Device *device, int64_t *deviceid) {
-    // if (strcasecmp(devicestr, "CPU") == 0) {
+
     if (strncasecmp(devicestr, "CPU", 3) == 0) {
         *device = RAI_DEVICE_CPU;
         *deviceid = -1;

--- a/src/execution/background_modelset.c
+++ b/src/execution/background_modelset.c
@@ -1,0 +1,154 @@
+#include "background_modelset.h"
+#include "command_parser.h"
+#include "backends/backends.h"
+#include <sys/time.h>
+#include "backends/util.h"
+
+#define BG_MODELSET_THREADS_NUM 1
+
+int Init_BG_ModelSet() {
+
+    modelSet_QueueInfo = RedisModule_Alloc(sizeof(RunQueueInfo));
+    modelSet_QueueInfo->run_queue = queueCreate();
+    modelSet_QueueInfo->devicestr = "";
+    pthread_cond_init(&(modelSet_QueueInfo)->queue_condition_var, NULL);
+    pthread_mutex_init(&(modelSet_QueueInfo)->run_queue_mutex, NULL);
+    modelSet_QueueInfo->threads =
+        (pthread_t *)RedisModule_Alloc(sizeof(pthread_t) * BG_MODELSET_THREADS_NUM);
+
+    /* create thread(s) */
+    for (int i = 0; i < BG_MODELSET_THREADS_NUM; i++) {
+        if (pthread_create(&((modelSet_QueueInfo)->threads[i]), NULL, RedisAI_ModelSet_ThreadMain,
+                           modelSet_QueueInfo) != 0) {
+            freeRunQueueInfo(modelSet_QueueInfo);
+            return REDISMODULE_ERR;
+        }
+    }
+    return REDISMODULE_OK;
+}
+
+void ModelSet_Execute(void *args) {
+    ModelSetCtx *model_ctx = (ModelSetCtx *)args;
+
+    RedisModuleString **argv = model_ctx->args;
+    model_ctx->model = RedisModule_Calloc(1, sizeof(*(model_ctx->model)));
+    RAI_InitError(&model_ctx->err);
+    RAI_Error *err = model_ctx->err;
+    RAI_Model *model = model_ctx->model;
+    model->refCount = 1;
+
+    // If we fail, we unblock and the model_ctx internals will be freed.
+    int status = ParseModelSetCommand(argv, array_len(argv), model, err);
+    if (status != REDISMODULE_OK) {
+        RedisModule_UnblockClient(model_ctx->client, model_ctx);
+        return;
+    }
+
+    const char *backend_str = RAI_BackendName(model->backend);
+
+    if (ModelCreateBE(model, err) != REDISMODULE_OK) {
+        // If we got an error *not* because of lazy loading, we fail and unblock.
+        if (RAI_GetErrorCode(err) != RAI_EBACKENDNOTLOADED) {
+            RedisModule_UnblockClient(model_ctx->client, model_ctx);
+            return;
+        }
+        RedisModule_Log(NULL, "warning", "backend %s not loaded, will try loading default backend",
+                        backend_str);
+        int ret = RAI_LoadDefaultBackend(NULL, model->backend);
+        if (ret != REDISMODULE_OK) {
+            RedisModule_Log(NULL, "error", "could not load %s default backend", backend_str);
+            RedisModule_UnblockClient(model_ctx->client, model_ctx);
+            return;
+        }
+        // Try creating model for backend again.
+        RAI_ClearError(err);
+        ModelCreateBE(model, err);
+    }
+    RedisModule_UnblockClient(model_ctx->client, model_ctx);
+}
+
+int RedisAI_ModelSet_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    ModelSetCtx *model_ctx = RedisModule_GetBlockedClientPrivateData(ctx);
+
+    // If at some point we got an error, we return it (model_ctx is freed).
+    if (RAI_GetErrorCode(model_ctx->err) != RAI_OK) {
+        return RedisModule_ReplyWithError(ctx, RAI_GetErrorOneLine(model_ctx->err));
+    }
+
+    // Save model in keyspace.
+    RAI_Model *model = model_ctx->model;
+    RedisModuleString *key_str = model->infokey;
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, key_str, REDISMODULE_READ | REDISMODULE_WRITE);
+    int type = RedisModule_KeyType(key);
+
+    // Two valid scenarios: 1. We create a new key, 2. The key is already holding
+    // a RedisAI model type (in this case we update the key's value).
+    if (type != REDISMODULE_KEYTYPE_EMPTY &&
+        !(type == REDISMODULE_KEYTYPE_MODULE &&
+          RedisModule_ModuleTypeGetType(key) == RedisAI_ModelType)) {
+        RedisModule_CloseKey(key);
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+    }
+    RedisModule_ModuleTypeSetValue(key, RedisAI_ModelType, model);
+    RedisModule_CloseKey(key);
+
+    // Save this model in stats global dict.
+    RAI_AddStatsEntry(NULL, key_str, RAI_MODEL, model->backend, model->devicestr, model->tag);
+
+    // Get shallow copy so the free callback won't delete the model.
+    RAI_ModelGetShallowCopy(model_ctx->model);
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    RedisModule_ReplicateVerbatim(ctx);
+    return REDISMODULE_OK;
+}
+
+void ModelSet_FreeData(RedisModuleCtx *ctx, void *private_data) {
+    ModelSetCtx *model_ctx = (ModelSetCtx *)private_data;
+
+    RAI_FreeError(model_ctx->err);
+
+    // This is a "dummy" error, we do not need it here since we only decrease
+    // the model's ref_count in case of success, and otherwise a different error has returned.
+    RAI_Error err = {0};
+    if (model_ctx->model) {
+        RAI_ModelFree(model_ctx->model, &err);
+    }
+
+    for (size_t i = 0; i < array_len(model_ctx->args); i++) {
+        RedisModule_FreeString(NULL, model_ctx->args[i]);
+    }
+    array_free(model_ctx->args);
+
+    RedisModule_Free(model_ctx);
+}
+
+void *RedisAI_ModelSet_ThreadMain(void *arg) {
+    RunQueueInfo *run_queue_info = (RunQueueInfo *)arg;
+    RAI_PTHREAD_SETNAME("redisai_modelset_bthread");
+    pthread_mutex_lock(&run_queue_info->run_queue_mutex);
+
+    while (true) {
+        pthread_cond_wait(&run_queue_info->queue_condition_var, &run_queue_info->run_queue_mutex);
+        queueItem *item = queuePop(run_queue_info->run_queue);
+        pthread_mutex_unlock(&run_queue_info->run_queue_mutex);
+
+        // Currently the job's callback is always MODELSET.
+        Job *job = queueItemGetValue(item);
+        RedisModule_Free(item);
+        job->Execute(job->args);
+        JobFree(job);
+        pthread_mutex_lock(&run_queue_info->run_queue_mutex);
+    }
+}
+
+Job *JobCreate(void *args, void (*CallBack)(void *)) {
+    Job *job = RedisModule_Alloc(sizeof(*job));
+    job->args = args;
+    job->Execute = CallBack;
+}
+
+void JobFree(Job *job) { RedisModule_Free(job); }

--- a/src/execution/background_modelset.h
+++ b/src/execution/background_modelset.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "background_workers.h"
+
+RunQueueInfo *modelSet_QueueInfo;
+
+// We use this generic struct to enable future extension - This BG workers may
+// have more purposes (monitoring, statistics etc...)
+typedef struct Job {
+    void (*Execute)(void *);
+    void *args;
+} Job;
+
+typedef struct ModelSetCtx {
+    RedisModuleString **args;
+    RedisModuleBlockedClient *client;
+    RAI_Model *model;
+    RAI_Error *err;
+} ModelSetCtx;
+
+Job *JobCreate(void *args, void (*CallBack)(void *));
+
+void JobFree(Job *job);
+
+int Init_BG_ModelSet();
+
+void ModelSet_FreeData(RedisModuleCtx *ctx, void *err);
+
+int RedisAI_ModelSet_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+
+void *RedisAI_ModelSet_ThreadMain(void *arg);
+
+void ModelSet_Execute(void *args);

--- a/src/execution/background_workers.c
+++ b/src/execution/background_workers.c
@@ -20,24 +20,6 @@
 #include "run_info.h"
 #include "background_workers.h"
 
-/* Define for RedisAI thread name setter */
-#ifdef __linux__
-#define RAI_PTHREAD_SETNAME(name) pthread_setname_np(pthread_self(), name)
-#else
-#if (defined __NetBSD__ || defined __FreeBSD__ || defined __OpenBSD__)
-#include <pthread_np.h>
-#define RAI_PTHREAD_SETNAME(name) pthread_set_name_np(pthread_self(), name)
-#else
-#if (defined __APPLE__ && defined(MAC_OS_X_VERSION_10_7))
-int pthread_setname_np(const char *name);
-#include <pthread.h>
-#define RAI_PTHREAD_SETNAME(name) pthread_setname_np(name)
-#else
-#define RAI_PTHREAD_SETNAME(name)
-#endif
-#endif
-#endif
-
 int freeRunQueueInfo(RunQueueInfo *info) {
     int result = REDISMODULE_OK;
     if (info->run_queue) {

--- a/src/execution/background_workers.h
+++ b/src/execution/background_workers.h
@@ -15,8 +15,6 @@
 #define _GNU_SOURCE
 #endif
 
-#include <pthread.h>
-
 #include "config/config.h"
 #include "DAG/dag.h"
 #include "redis_ai_objects/model.h"
@@ -29,6 +27,24 @@
 #include "util/arr.h"
 #include "util/dict.h"
 #include "util/queue.h"
+
+/* Define for RedisAI thread name setter */
+#ifdef __linux__
+#define RAI_PTHREAD_SETNAME(name) pthread_setname_np(pthread_self(), name)
+#else
+#if (defined __NetBSD__ || defined __FreeBSD__ || defined __OpenBSD__)
+#include <pthread_np.h>
+#define RAI_PTHREAD_SETNAME(name) pthread_set_name_np(pthread_self(), name)
+#else
+#if (defined __APPLE__ && defined(MAC_OS_X_VERSION_10_7))
+int pthread_setname_np(const char *name);
+#include <pthread.h>
+#define RAI_PTHREAD_SETNAME(name) pthread_setname_np(name)
+#else
+#define RAI_PTHREAD_SETNAME(name)
+#endif
+#endif
+#endif
 
 AI_dict *run_queues;
 long long perqueueThreadPoolSize;

--- a/src/execution/command_parser.c
+++ b/src/execution/command_parser.c
@@ -1,4 +1,3 @@
-
 #include "redismodule.h"
 #include "run_info.h"
 #include "command_parser.h"
@@ -6,6 +5,8 @@
 #include "DAG/dag_parser.h"
 #include "util/string_utils.h"
 #include "execution/modelRun_ctx.h"
+#include "rmutil/args.h"
+#include "redis_ai_objects/stats.h"
 
 static int _parseTimeout(RedisModuleString *timeout_arg, RAI_Error *error, long long *timeout) {
 
@@ -339,6 +340,227 @@ cleanup:
     //}
     RedisModule_FreeThreadSafeContext(ctx);
     return res;
+}
+
+int _ModelSetCommand_ParseBatchingArgs(ArgsCursor *ac, RAI_ModelOpts *opts, int backend,
+                                       RAI_Error *err) {
+    unsigned long long batchsize = 0;
+    if (AC_AdvanceIfMatch(ac, "BATCHSIZE")) {
+        if (backend == RAI_BACKEND_TFLITE) {
+            RAI_SetError(err, RAI_EMODELCREATE,
+                         "ERR Auto-batching not supported by the TFLITE backend");
+            return REDISMODULE_ERR;
+        }
+        if (AC_GetUnsignedLongLong(ac, &batchsize, 0) != AC_OK) {
+            RAI_SetError(err, RAI_EMODELCREATE, "ERR Invalid argument for BATCHSIZE");
+            return REDISMODULE_ERR;
+        }
+    }
+
+    unsigned long long minbatchsize = 0;
+    if (AC_AdvanceIfMatch(ac, "MINBATCHSIZE")) {
+        if (batchsize == 0) {
+            RAI_SetError(err, RAI_EMODELCREATE, "ERR MINBATCHSIZE specified without BATCHSIZE");
+            return REDISMODULE_ERR;
+        }
+        if (AC_GetUnsignedLongLong(ac, &minbatchsize, 0) != AC_OK) {
+            RAI_SetError(err, RAI_EMODELCREATE, "ERR Invalid argument for MINBATCHSIZE");
+            return REDISMODULE_ERR;
+        }
+    }
+
+    unsigned long long minbatchtimeout = 0;
+    if (AC_AdvanceIfMatch(ac, "MINBATCHTIMEOUT")) {
+        if (batchsize == 0) {
+            RAI_SetError(err, RAI_EMODELCREATE, "ERR MINBATCHTIMEOUT specified without BATCHSIZE");
+            return REDISMODULE_ERR;
+        }
+        if (minbatchsize == 0) {
+            RAI_SetError(err, RAI_EMODELCREATE,
+                         "ERR MINBATCHTIMEOUT specified without MINBATCHSIZE");
+            return REDISMODULE_ERR;
+        }
+        if (AC_GetUnsignedLongLong(ac, &minbatchtimeout, 0) != AC_OK) {
+            RAI_SetError(err, RAI_EMODELCREATE, "ERR Invalid argument for MINBATCHTIMEOUT");
+            return REDISMODULE_ERR;
+        }
+    }
+
+    opts->batchsize = batchsize;
+    opts->minbatchsize = minbatchsize;
+    opts->minbatchtimeout = minbatchtimeout;
+
+    return REDISMODULE_OK;
+}
+
+int _ModelSetCommand_ParseIOArgs(RAI_Model *model, ArgsCursor *ac, int backend, RAI_Error *err) {
+
+    ArgsCursor optionsac;
+    const char *blob_matches[1] = {"BLOB"};
+    AC_GetSliceUntilMatches(ac, &optionsac, 1, blob_matches);
+
+    if (optionsac.argc == 0) {
+        RAI_SetError(err, RAI_EMODELCREATE,
+                     "ERR Insufficient arguments, INPUTS and OUTPUTS not specified for TF model");
+        return REDISMODULE_ERR;
+    }
+    ArgsCursor inac = {0};
+    ArgsCursor outac = {0};
+    if (optionsac.argc > 0 && backend == RAI_BACKEND_TENSORFLOW) {
+        if (!AC_AdvanceIfMatch(&optionsac, "INPUTS")) {
+            RAI_SetError(err, RAI_EMODELCREATE, "ERR INPUTS not specified for TF model");
+            return REDISMODULE_ERR;
+        }
+
+        const char *matches[1] = {"OUTPUTS"};
+        AC_GetSliceUntilMatches(&optionsac, &inac, 1, matches);
+        if (!AC_IsAtEnd(&optionsac)) {
+            if (!AC_AdvanceIfMatch(&optionsac, "OUTPUTS")) {
+                RAI_SetError(err, RAI_EMODELCREATE, "ERR OUTPUTS not specified for TF model");
+                return REDISMODULE_ERR;
+            }
+            AC_GetSliceToEnd(&optionsac, &outac);
+        }
+    }
+
+    model->ninputs = inac.argc;
+    model->inputs = array_new(char *, model->ninputs);
+    for (size_t i = 0; i < model->ninputs; i++) {
+        const char *input_str;
+        AC_GetString(&inac, &input_str, NULL, 0);
+        model->inputs = array_append(model->inputs, RedisModule_Strdup(input_str));
+    }
+    model->noutputs = outac.argc;
+    model->outputs = array_new(char *, model->noutputs);
+    for (size_t i = 0; i < model->noutputs; i++) {
+        const char *output_str;
+        AC_GetString(&outac, &output_str, NULL, 0);
+        model->outputs = array_append(model->outputs, RedisModule_Strdup(output_str));
+    }
+    return REDISMODULE_OK;
+}
+
+void _ModelSetCommand_ParseBlob(RAI_Model *model, ArgsCursor *ac) {
+    ArgsCursor blobsac;
+    AC_GetSliceToEnd(ac, &blobsac);
+    size_t model_len;
+    char *model_def;
+    char *model_data;
+
+    if (blobsac.argc == 1) {
+        AC_GetString(&blobsac, (const char **)&model_def, &model_len, 0);
+        model_data = RedisModule_Alloc(model_len);
+        memcpy(model_data, model_def, model_len);
+    } else {
+        // Blobs of large models are chunked, in this case we go over and copy the chunks.
+        const char *chunks[blobsac.argc];
+        size_t chunk_lens[blobsac.argc];
+        model_len = 0;
+        while (!AC_IsAtEnd(&blobsac)) {
+            AC_GetString(&blobsac, &chunks[blobsac.offset], &chunk_lens[blobsac.offset], 0);
+            model_len += chunk_lens[blobsac.offset - 1];
+        }
+        model_data = RedisModule_Alloc(model_len);
+        size_t offset = 0;
+        for (size_t i = 0; i < blobsac.argc; i++) {
+            memcpy(model_data + offset, chunks[i], chunk_lens[i]);
+            offset += chunk_lens[i];
+        }
+    }
+    model->data = model_data;
+    model->datalen = model_len;
+}
+
+int ParseModelSetCommand(RedisModuleString **argv, int argc, RAI_Model *model, RAI_Error *err) {
+
+    // Use an args cursor object to go over and parse the command args.
+    ArgsCursor ac;
+    ArgsCursor_InitRString(&ac, argv, argc);
+
+    // Parse model key.
+    RedisModuleString *key_str;
+    AC_GetRString(&ac, &key_str, 0);
+    model->infokey = RAI_HoldString(NULL, key_str);
+
+    // Parse <backend> argument.
+    const char *backend_str;
+    int backend;
+    AC_GetString(&ac, &backend_str, NULL, 0);
+    if (strcasecmp(backend_str, "TF") == 0) {
+        backend = RAI_BACKEND_TENSORFLOW;
+    } else if (strcasecmp(backend_str, "TFLITE") == 0) {
+        backend = RAI_BACKEND_TFLITE;
+    } else if (strcasecmp(backend_str, "TORCH") == 0) {
+        backend = RAI_BACKEND_TORCH;
+    } else if (strcasecmp(backend_str, "ONNX") == 0) {
+        backend = RAI_BACKEND_ONNXRUNTIME;
+    } else {
+        RAI_SetError(err, RAI_EMODELCREATE, "ERR unsupported backend");
+        return REDISMODULE_ERR;
+    }
+    model->backend = backend;
+
+    // Parse <backend> argument: check that the device string is "CPU", "GPU" or
+    // "GPU:<n>" where <n> is a number (contains digits only).
+    const char *device_str;
+    AC_GetString(&ac, &device_str, NULL, 0);
+    bool valid_device = false;
+    if (strcasecmp(device_str, "CPU") == 0 || strcasecmp(device_str, "GPU") == 0) {
+        valid_device = true;
+    } else if (strncasecmp(device_str, "GPU:", 4) == 0 && strlen(device_str) <= 10) {
+        bool digits_only = true;
+        for (size_t i = 5; i < strlen(device_str); i++) {
+            if (device_str[i] < '0' || device_str[i] > '9') {
+                digits_only = false;
+                break;
+            }
+        }
+        valid_device = digits_only;
+    }
+    if (!valid_device) {
+        RAI_SetError(err, RAI_EMODELCREATE, "ERR Invalid DEVICE");
+        return REDISMODULE_ERR;
+    }
+    model->devicestr = RedisModule_Strdup(device_str);
+
+    // Parse <tag> argument, and add model key to the stats dict.
+    RedisModuleString *tag = NULL;
+    if (AC_AdvanceIfMatch(&ac, "TAG")) {
+        AC_GetRString(&ac, &tag, 0);
+    }
+    if (tag) {
+        model->tag = RAI_HoldString(NULL, tag);
+    } else {
+        model->tag = RedisModule_CreateString(NULL, "", 0);
+    }
+
+    // Parse the optional args of BATCHSIZE, MINBATCHSIZE and MINBATCHTIMEOUT, and set model opts.
+    RAI_ModelOpts opts;
+    if (_ModelSetCommand_ParseBatchingArgs(&ac, &opts, backend, err) != REDISMODULE_OK) {
+        return REDISMODULE_ERR;
+    }
+    opts.backends_intra_op_parallelism = getBackendsIntraOpParallelism();
+    opts.backends_inter_op_parallelism = getBackendsInterOpParallelism();
+    model->opts = opts;
+
+    // Parse inputs and output names (this arguments are mandatory only for TF models)
+    // and store them in model objects.
+    if (backend == RAI_BACKEND_TENSORFLOW) {
+        if (_ModelSetCommand_ParseIOArgs(model, &ac, backend, err) != REDISMODULE_OK) {
+            return REDISMODULE_ERR;
+        }
+    }
+
+    // Parse model blob (final argument), and store it in the model.
+    const char *blob_matches[1] = {"BLOB"};
+    AC_AdvanceUntilMatches(&ac, 1, blob_matches);
+    if (AC_IsAtEnd(&ac)) {
+        RAI_SetError(err, RAI_EMODELCREATE, "ERR Insufficient arguments, missing model BLOB");
+        return REDISMODULE_ERR;
+    }
+    AC_Advance(&ac);
+    _ModelSetCommand_ParseBlob(model, &ac);
+    return REDISMODULE_OK;
 }
 
 int RedisAI_ExecuteCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,

--- a/src/execution/command_parser.h
+++ b/src/execution/command_parser.h
@@ -25,6 +25,8 @@ int ParseModelRunCommand(RedisAI_RunInfo *rinfo, RAI_DagOp *currentOp, RedisModu
 int ParseScriptRunCommand(RedisAI_RunInfo *rinfo, RAI_DagOp *currentOp, RedisModuleString **argv,
                           int argc);
 
+int ParseModelSetCommand(RedisModuleString **argv, int argc, RAI_Model *model, RAI_Error *err);
+
 /**
  * @brief  Parse and execute RedisAI run command. After parsing and validation, the resulted
  * runInfo (DAG) is queued and the client is blocked until the execution is complete (async

--- a/src/redis_ai_objects/model.h
+++ b/src/redis_ai_objects/model.h
@@ -150,6 +150,8 @@ size_t ModelGetNumInputs(RAI_Model *model);
  * @brief  Returns the number of outputs in the model definition.
  */
 size_t ModelGetNumOutputs(RAI_Model *model);
+
+int ModelCreateBE(RAI_Model *model, RAI_Error *err);
 /**
  * Insert the ModelRunCtx to the run queues so it will run asynchronously.
  *

--- a/src/redis_ai_objects/stats.c
+++ b/src/redis_ai_objects/stats.c
@@ -25,8 +25,8 @@ mstime_t mstime(void) { return ustime() / 1000; }
 
 void *RAI_AddStatsEntry(RedisModuleCtx *ctx, RedisModuleString *key, RAI_RunType runtype,
                         RAI_Backend backend, const char *devicestr, RedisModuleString *tag) {
-    struct RedisAI_RunStats *rstats = NULL;
-    rstats = RedisModule_Calloc(1, sizeof(struct RedisAI_RunStats));
+
+    RedisAI_RunStats *rstats = RedisModule_Calloc(1, sizeof(*rstats));
     rstats->key = RAI_HoldString(NULL, key);
     rstats->type = runtype;
     rstats->backend = backend;

--- a/src/redis_ai_objects/stats.h
+++ b/src/redis_ai_objects/stats.h
@@ -13,7 +13,7 @@
 #include "redismodule.h"
 #include "util/dict.h"
 
-struct RedisAI_RunStats {
+typedef struct RedisAI_RunStats {
     RedisModuleString *key;
     RAI_RunType type;
     RAI_Backend backend;
@@ -23,7 +23,7 @@ struct RedisAI_RunStats {
     long long samples;
     long long calls;
     long long nerrors;
-};
+} RedisAI_RunStats;
 
 AI_dict *run_stats;
 

--- a/src/serialization/RDB/decoder/current/v1/decode_v1.c
+++ b/src/serialization/RDB/decoder/current/v1/decode_v1.c
@@ -74,36 +74,40 @@ void *RAI_RDBLoadModel_v1(RedisModuleIO *io) {
     char *devicestr = NULL;
     RedisModuleString *tag = NULL;
     size_t ninputs = 0;
-    const char **inputs = NULL;
+    char **inputs = NULL;
     size_t noutputs = 0;
-    const char **outputs = NULL;
+    char **outputs = NULL;
     char *buffer = NULL;
+    RAI_Error err = {0};
+    char *error_str = "Experienced a short read while reading a model from RDB";
 
+    RedisModuleCtx *ctx = RedisModule_GetContextFromIO(io);
+    RedisModuleString *key_str =
+        RedisModule_CreateStringFromString(NULL, RedisModule_GetKeyNameFromIO(io));
+    if (!key_str) {
+        RedisModule_LogIOError(io, "error", "Couldn't get model key name from RDB");
+        return NULL;
+    }
     RAI_Backend backend = RedisModule_LoadUnsigned(io);
     devicestr = RedisModule_LoadStringBuffer(io, NULL);
     tag = RedisModule_LoadString(io);
-
     const size_t batchsize = RedisModule_LoadUnsigned(io);
     const size_t minbatchsize = RedisModule_LoadUnsigned(io);
 
     ninputs = RedisModule_LoadUnsigned(io);
     if (RedisModule_IsIOError(io))
         goto cleanup;
-
-    inputs = RedisModule_Alloc(ninputs * sizeof(char *));
-
+    inputs = array_new(char *, ninputs);
     for (size_t i = 0; i < ninputs; i++) {
-        inputs[i] = RedisModule_LoadStringBuffer(io, NULL);
+        inputs = array_append(inputs, RedisModule_LoadStringBuffer(io, NULL));
     }
 
     noutputs = RedisModule_LoadUnsigned(io);
     if (RedisModule_IsIOError(io))
         goto cleanup;
-
-    outputs = RedisModule_Alloc(noutputs * sizeof(char *));
-
+    outputs = array_new(char *, noutputs);
     for (size_t i = 0; i < noutputs; i++) {
-        outputs[i] = RedisModule_LoadStringBuffer(io, NULL);
+        outputs = array_append(outputs, RedisModule_LoadStringBuffer(io, NULL));
     }
 
     RAI_ModelOpts opts = {
@@ -130,48 +134,41 @@ void *RAI_RDBLoadModel_v1(RedisModuleIO *io) {
         RedisModule_Free(chunk_buffer);
     }
 
-    RAI_Error err = {0};
-    RAI_Model *model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs,
-                                       outputs, buffer, len, &err);
+    RAI_Model *model = RedisModule_Calloc(1, sizeof(*model));
+    model->infokey = RAI_HoldString(NULL, key_str);
+    model->backend = backend;
+    model->devicestr = devicestr;
+    model->tag = tag;
+    model->inputs = inputs;
+    model->ninputs = ninputs;
+    model->outputs = outputs;
+    model->noutputs = noutputs;
+    model->opts = opts;
+    model->data = buffer;
+    model->datalen = len;
 
-    if (err.code == RAI_EBACKENDNOTLOADED) {
-        RedisModuleCtx *ctx = RedisModule_GetContextFromIO(io);
-        int ret = RAI_LoadDefaultBackend(ctx, backend);
-        if (ret == REDISMODULE_ERR) {
-            RedisModule_Log(ctx, "error", "Could not load default backend");
-            RAI_ClearError(&err);
+    const char *backend_str = RAI_BackendName(backend);
+    if (ModelCreateBE(model, &err) != REDISMODULE_OK) {
+        // If we got an error *not* because of lazy loading, we fail and unblock.
+        if (RAI_GetErrorCode(&err) != RAI_EBACKENDNOTLOADED) {
+            error_str = (char *)RAI_GetError(&err);
             goto cleanup;
         }
+        RedisModule_Log(ctx, "warning", "backend %s not loaded, will try loading default backend",
+                        backend_str);
+        int ret = RAI_LoadDefaultBackend(NULL, model->backend);
+        if (ret != REDISMODULE_OK) {
+            sprintf(error_str, "could not load %s default backend", backend_str);
+            goto cleanup;
+        }
+        // Try creating model for backend again.
         RAI_ClearError(&err);
-        model = RAI_ModelCreate(backend, devicestr, tag, opts, ninputs, inputs, noutputs, outputs,
-                                buffer, len, &err);
+        if (ModelCreateBE(model, &err) != REDISMODULE_OK) {
+            error_str = (char *)RAI_GetError(&err);
+            goto cleanup;
+        }
     }
-
-    if (err.code != RAI_OK) {
-        RedisModuleCtx *ctx = RedisModule_GetContextFromIO(io);
-        RedisModule_Log(ctx, "error", "%s", err.detail);
-        RAI_ClearError(&err);
-        goto cleanup;
-    }
-
-    RedisModuleCtx *stats_ctx = RedisModule_GetContextFromIO(io);
-    RedisModuleString *stats_keystr =
-        RedisModule_CreateStringFromString(stats_ctx, RedisModule_GetKeyNameFromIO(io));
-
-    model->infokey = RAI_AddStatsEntry(stats_ctx, stats_keystr, RAI_MODEL, backend, devicestr, tag);
-
-    for (size_t i = 0; i < ninputs; i++) {
-        RedisModule_Free((void *)inputs[i]);
-    }
-    RedisModule_Free(inputs);
-    for (size_t i = 0; i < noutputs; i++) {
-        RedisModule_Free((void *)outputs[i]);
-    }
-    RedisModule_Free(outputs);
-    RedisModule_Free(buffer);
-    RedisModule_Free(devicestr);
-    RedisModule_FreeString(NULL, stats_keystr);
-    RedisModule_FreeString(NULL, tag);
+    RAI_AddStatsEntry(ctx, key_str, RAI_MODEL, backend, devicestr, tag);
 
     return model;
 
@@ -182,22 +179,25 @@ cleanup:
         RedisModule_FreeString(NULL, tag);
     if (inputs) {
         for (size_t i = 0; i < ninputs; i++) {
-            RedisModule_Free((void *)inputs[i]);
+            RedisModule_Free(inputs[i]);
         }
-        RedisModule_Free(inputs);
+        array_free(inputs);
     }
 
     if (outputs) {
         for (size_t i = 0; i < noutputs; i++) {
-            RedisModule_Free((void *)outputs[i]);
+            RedisModule_Free(outputs[i]);
         }
-        RedisModule_Free(outputs);
+        array_free(outputs);
     }
 
     if (buffer)
         RedisModule_Free(buffer);
 
-    RedisModule_LogIOError(io, "error", "Experienced a short read while reading a model from RDB");
+    RedisModule_LogIOError(io, "error", "%s", error_str);
+    if (RAI_GetErrorCode(&err) != RAI_OK) {
+        RAI_ClearError(&err);
+    }
     return NULL;
 }
 

--- a/src/util/queue.c
+++ b/src/util/queue.c
@@ -92,6 +92,8 @@ queueItem *queueEvict(queue *queue, queueItem *item) {
 
 long long queueLength(queue *queue) { return queue->len; }
 
+void *queueItemGetValue(queueItem *item) { return item->value; }
+
 void queueRelease(queue *queue) {
     unsigned long len;
     queueItem *current;

--- a/src/util/queue.h
+++ b/src/util/queue.h
@@ -27,6 +27,7 @@ void queuePushFront(queue *queue, void *value);
 queueItem *queuePop(queue *queue);
 queueItem *queueFront(queue *queue);
 queueItem *queueNext(queueItem *item);
+void *queueItemGetValue(queueItem *item);
 queueItem *queueEvict(queue *queue, queueItem *item);
 long long queueLength(queue *queue);
 void queueRelease(queue *queue);

--- a/tests/flow/tests_pytorch.py
+++ b/tests/flow/tests_pytorch.py
@@ -924,8 +924,9 @@ def test_pytorch_model_rdb_save_load(env):
     env.start()
     con = env.getConnection()
     model_serialized_after_rdbload = con.execute_command('AI.MODELGET', 'm{1}', 'BLOB')
-    con.execute_command('AI.MODELRUN', 'm{1}', 'INPUTS', 'a{1}', 'b{1}', 'OUTPUTS', 'c{1}')
-    _, dtype_after_rdbload, _, shape_after_rdbload, _, data_after_rdbload = con.execute_command('AI.TENSORGET', 'c{1}', 'META', 'VALUES')
+
+    con.execute_command('AI.MODELRUN', 'm{1}', 'INPUTS', 'a{1}', 'b{1}', 'OUTPUTS', 'd{1}')
+    _, dtype_after_rdbload, _, shape_after_rdbload, _, data_after_rdbload = con.execute_command('AI.TENSORGET', 'd{1}', 'META', 'VALUES')
 
     # Assert in memory model metadata is equal to loaded model metadata
     env.assertTrue(model_serialized_memory[1:6] == model_serialized_after_rdbload[1:6])
@@ -966,6 +967,7 @@ def test_parallelism():
                         for k in con.execute_command("INFO MODULES").decode().split("#")[3].split()[1:]}
     env.assertEqual(load_time_config["ai_inter_op_parallelism"], "2")
     env.assertEqual(load_time_config["ai_intra_op_parallelism"], "2")
+
 
 def test_modelget_for_tuple_output(env):
     if not TEST_PT:

--- a/tests/flow/tests_tensorflow.py
+++ b/tests/flow/tests_tensorflow.py
@@ -426,7 +426,7 @@ def test_run_tf_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Insufficient arguments, INPUTS and OUTPUTS not specified", exception.__str__())
+        env.assertEqual("Insufficient arguments, INPUTS and OUTPUTS not specified for TF model", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_8{1}', 'TF', DEVICE,

--- a/tests/flow/tests_tflite.py
+++ b/tests/flow/tests_tflite.py
@@ -106,7 +106,7 @@ def test_run_tflite_model_errors(env):
     except Exception as e:
         exception = e
         env.assertEqual(type(exception), redis.exceptions.ResponseError)
-        env.assertEqual("Insufficient arguments, missing model BLOB", exception.__str__())
+        env.assertEqual("Invalid DEVICE", exception.__str__())
 
     try:
         con.execute_command('AI.MODELSET', 'm_2{1}', 'BLOB', model_pb)


### PR DESCRIPTION
- This PR touches many source files. It is not final yet (looks like there are some problems with RDB loading + valgrind check is required) 
- There are 2 main changed (both concern model set):
1. MODELSET command is processed in a background thread. The design is generic, so that this background thread will be able to get more types of "Jobs" in the future.
2. Refactor in creation of RAI_Model - instead of creating it for every backend separably, it is now created beforehand with all the common fields that are agnostic to the BE, and then every backend enriches the object fields (model/session) as needed.      