### PR TITLE
LLAPI tests - fix deadlock

### DIFF
--- a/opt/clang-check-all.sh
+++ b/opt/clang-check-all.sh
@@ -4,8 +4,14 @@
 set -e
 
 CLANG_FMT_SRCS=$(find ../src/ \( -name '*.c' -o -name '*.cc'-o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))
+CLANG_FMT_TESTS=$(find ../tests/ \( -name '*.c' -o -name '*.cc'-o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))
 
 for filename in $CLANG_FMT_SRCS; do
+    echo "Checking $filename"
+    clang-format -style=file -Werror --dry-run $filename
+done
+
+for filename in $CLANG_FMT_TESTS; do
     echo "Checking $filename"
     clang-format -style=file -Werror --dry-run $filename
 done

--- a/opt/clang-format-all.sh
+++ b/opt/clang-format-all.sh
@@ -4,7 +4,12 @@
 set -e
 
 CLANG_FMT_SRCS=$(find ../src/ \( -name '*.c' -o -name '*.cc'-o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))
+CLANG_FMT_TESTS=$(find ../tests/ \( -name '*.c' -o -name '*.cc'-o -name '*.cpp' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' \))
 
 for filename in $CLANG_FMT_SRCS; do
+    clang-format --verbose -style=file -i $filename
+done
+
+for filename in $CLANG_FMT_TESTS; do
     clang-format --verbose -style=file -i $filename
 done

--- a/tests/flow/pt_api_test.c
+++ b/tests/flow/pt_api_test.c
@@ -4,41 +4,41 @@
 #include "dlpack/dlpack.h"
 
 int main() {
-  printf("Hello from libTorch C library version %s\n", "1.0");
-  torchBasicTest();
+    printf("Hello from libTorch C library version %s\n", "1.0");
+    torchBasicTest();
 
-  void* ctx;
-  char *err = NULL;
+    void *ctx;
+    char *err = NULL;
 
-  const char script[] = "\n\
+    const char script[] = "\n\
     def foo(a):          \n\
         return a * 2     \n\
     ";
 
-  ctx = torchCompileScript(script, kDLCPU, &err);
-  if (err) {
-    printf("ERR: %s\n", err);
-    free(err);
-    err = NULL;
-    return 1;
-  }
-  printf("Compiled: %p\n", ctx);
+    ctx = torchCompileScript(script, kDLCPU, &err);
+    if (err) {
+        printf("ERR: %s\n", err);
+        free(err);
+        err = NULL;
+        return 1;
+    }
+    printf("Compiled: %p\n", ctx);
 
-  DLDataType dtype = (DLDataType){ .code = kDLFloat, .bits = 32, .lanes = 1};
-  int64_t shape[1] = {1};
-  int64_t strides[1] = {1};
-  char data[4] = "0000";
-  DLManagedTensor* input = torchNewTensor(dtype, 1, shape, strides, data);
-  DLManagedTensor* output;
-  torchRunScript(ctx, "foo", 1, &input, 1, &output, &err);
-  if (err) {
-    printf("ERR: %s\n", err);
-    free(err);
-    return 1;
-  }
+    DLDataType dtype = (DLDataType){.code = kDLFloat, .bits = 32, .lanes = 1};
+    int64_t shape[1] = {1};
+    int64_t strides[1] = {1};
+    char data[4] = "0000";
+    DLManagedTensor *input = torchNewTensor(dtype, 1, shape, strides, data);
+    DLManagedTensor *output;
+    torchRunScript(ctx, "foo", 1, &input, 1, &output, &err);
+    if (err) {
+        printf("ERR: %s\n", err);
+        free(err);
+        return 1;
+    }
 
-  torchDeallocContext(ctx);
-  printf("Deallocated\n");
+    torchDeallocContext(ctx);
+    printf("Deallocated\n");
 
-  return 0;
+    return 0;
 }

--- a/tests/flow/tests_llapi.py
+++ b/tests/flow/tests_llapi.py
@@ -101,6 +101,12 @@ def test_dag_build_and_run(env):
     ret = con.execute_command("RAI_llapi.DAGrun")
     env.assertEqual(ret, b'DAG run success')
 
+    # Run the DAG LLAPI test again with multi process test to ensure that there are no dead-locks
+    def run_dag_llapi(con):
+        con.execute_command("RAI_llapi.DAGrun")
+
+    run_test_multiproc(env, 500, run_dag_llapi)
+
 
 @with_test_module
 def test_dagrun_multidevice_resnet(env):

--- a/tests/flow/tf_api_test.c
+++ b/tests/flow/tf_api_test.c
@@ -2,6 +2,6 @@
 #include <tensorflow/c/c_api.h>
 
 int main() {
-  printf("Hello from TensorFlow C library version %s\n", TF_Version());
-  return 0;
+    printf("Hello from TensorFlow C library version %s\n", TF_Version());
+    return 0;
 }

--- a/tests/module/DAG_utils.c
+++ b/tests/module/DAG_utils.c
@@ -23,9 +23,7 @@ static void _FreeRunResults(RAI_RunCtx *run_ctx) {
     pthread_cond_destroy(&run_ctx->cond);
 }
 
-static size_t _ResultsNumOutputs(RAI_RunCtx run_ctx) {
-    return array_len(run_ctx.outputs);
-}
+static size_t _ResultsNumOutputs(RAI_RunCtx run_ctx) { return array_len(run_ctx.outputs); }
 static void *_getFromKeySpace(RedisModuleCtx *ctx, const char *keyNameStr) {
 
     RedisModuleString *keyRedisStr = RedisModule_CreateString(ctx, keyNameStr, strlen(keyNameStr));
@@ -47,7 +45,7 @@ static bool _assertError(RAI_Error *err, int status, const char *error_msg) {
 static void _DAGFinishFuncError(RAI_OnFinishCtx *onFinishCtx, void *private_data) {
     REDISMODULE_NOT_USED(onFinishCtx);
     REDISMODULE_NOT_USED(private_data);
-    //Do nothing, this callback should not be used...
+    // Do nothing, this callback should not be used...
     RedisModule_Assert(false);
 }
 
@@ -70,7 +68,7 @@ static void _DAGFinishFunc(RAI_OnFinishCtx *onFinishCtx, void *private_data) {
     RAI_Tensor *t = (RAI_Tensor *)RedisAI_DAGOutputTensor(onFinishCtx, n_outputs);
     RedisModule_Assert(t == NULL);
 
-    finish:
+finish:
     pthread_mutex_lock(&run_ctx->lock);
     pthread_cond_signal(&run_ctx->cond);
     pthread_mutex_unlock(&run_ctx->lock);
@@ -91,7 +89,7 @@ int testLoadTensor(RedisModuleCtx *ctx) {
     }
     res = LLAPIMODULE_OK;
 
-    cleanup:
+cleanup:
     RedisAI_DAGFree(run_info);
     return res;
 }
@@ -109,7 +107,8 @@ int testModelRunOpError(RedisModuleCtx *ctx) {
 
     // This model expect for 2 inputs not 1.
     int status = RedisAI_DAGAddRunOp(run_info, op, err);
-    if (!_assertError(err, status, "Number of keys given as INPUTS does not match model definition")) {
+    if (!_assertError(err, status,
+                      "Number of keys given as INPUTS does not match model definition")) {
         goto cleanup;
     }
     RedisAI_ClearError(err);
@@ -117,12 +116,13 @@ int testModelRunOpError(RedisModuleCtx *ctx) {
     status = RedisAI_DAGAddRunOp(run_info, op, err);
 
     // We still get an error since the model expects for an output as well.
-    if (!_assertError(err, status, "Number of keys given as OUTPUTS does not match model definition")) {
+    if (!_assertError(err, status,
+                      "Number of keys given as OUTPUTS does not match model definition")) {
         goto cleanup;
     }
     res = LLAPIMODULE_OK;
 
-    cleanup:
+cleanup:
     RedisAI_FreeError(err);
     RedisAI_DAGRunOpFree(op);
     RedisAI_DAGFree(run_info);
@@ -132,7 +132,7 @@ int testModelRunOpError(RedisModuleCtx *ctx) {
 int testEmptyDAGError(RedisModuleCtx *ctx) {
 
     RAI_DAGRunCtx *run_info = RedisAI_DAGRunCtxCreate();
-    RAI_Error* err;
+    RAI_Error *err;
     RedisAI_InitError(&err);
     int res = LLAPIMODULE_ERR;
 
@@ -140,12 +140,12 @@ int testEmptyDAGError(RedisModuleCtx *ctx) {
     RedisAI_DAGLoadTensor(run_info, "input", t);
 
     int status = RedisAI_DAGRun(run_info, _DAGFinishFuncError, NULL, err);
-    if(!_assertError(err, status, "ERR DAG is empty")) {
+    if (!_assertError(err, status, "ERR DAG is empty")) {
         goto cleanup;
     }
     res = LLAPIMODULE_OK;
 
-    cleanup:
+cleanup:
     RedisAI_FreeError(err);
     RedisAI_DAGFree(run_info);
     return res;
@@ -154,7 +154,7 @@ int testEmptyDAGError(RedisModuleCtx *ctx) {
 int testKeysMismatchError(RedisModuleCtx *ctx) {
 
     RAI_DAGRunCtx *run_info = RedisAI_DAGRunCtxCreate();
-    RAI_Error* err;
+    RAI_Error *err;
     RedisAI_InitError(&err);
     int res = LLAPIMODULE_ERR;
 
@@ -163,12 +163,12 @@ int testKeysMismatchError(RedisModuleCtx *ctx) {
 
     RedisAI_DAGAddTensorGet(run_info, "non existing tensor");
     int status = RedisAI_DAGRun(run_info, _DAGFinishFuncError, NULL, err);
-    if(!_assertError(err, status, "ERR INPUT key cannot be found in DAG")) {
+    if (!_assertError(err, status, "ERR INPUT key cannot be found in DAG")) {
         goto cleanup;
     }
     res = LLAPIMODULE_OK;
 
-    cleanup:
+cleanup:
     RedisAI_FreeError(err);
     RedisAI_DAGFree(run_info);
     return res;
@@ -223,7 +223,7 @@ int testBuildDAGFromString(RedisModuleCtx *ctx) {
     RedisModule_Assert(_ResultsNumOutputs(run_ctx) == 2);
     res = LLAPIMODULE_OK;
 
-    cleanup:
+cleanup:
     _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;
@@ -267,7 +267,7 @@ int testSimpleDAGRun(RedisModuleCtx *ctx) {
     double expceted[4] = {4, 9, 4, 9};
     double val;
     for (long long i = 0; i < 4; i++) {
-        if(!RedisAI_TensorGetValueAsDouble(out_tensor, i, &val)) {
+        if (!RedisAI_TensorGetValueAsDouble(out_tensor, i, &val)) {
             goto cleanup;
         }
         if (expceted[i] != val) {
@@ -276,7 +276,7 @@ int testSimpleDAGRun(RedisModuleCtx *ctx) {
     }
     res = LLAPIMODULE_OK;
 
-    cleanup:
+cleanup:
     _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;
@@ -289,13 +289,13 @@ int testSimpleDAGRun2(RedisModuleCtx *ctx) {
     _InitRunResults(&run_ctx);
     int res = LLAPIMODULE_ERR;
 
-    RAI_Tensor *tensor = (RAI_Tensor*)_getFromKeySpace(ctx, "a{1}");
+    RAI_Tensor *tensor = (RAI_Tensor *)_getFromKeySpace(ctx, "a{1}");
     RedisAI_DAGAddTensorSet(run_info, "input1", tensor);
-    tensor = (RAI_Tensor*)_getFromKeySpace(ctx, "b{1}");
+    tensor = (RAI_Tensor *)_getFromKeySpace(ctx, "b{1}");
     RedisAI_DAGAddTensorSet(run_info, "input2", tensor);
 
     // The script myscript{1} should exist in key space.
-    RAI_Script *script = (RAI_Script*)_getFromKeySpace(ctx, "myscript{1}");
+    RAI_Script *script = (RAI_Script *)_getFromKeySpace(ctx, "myscript{1}");
     RAI_DAGRunOp *op = RedisAI_DAGCreateScriptRunOp(script, "bar");
     RedisAI_DAGRunOpAddInput(op, "input1");
     RedisAI_DAGRunOpAddInput(op, "input2");
@@ -320,7 +320,7 @@ int testSimpleDAGRun2(RedisModuleCtx *ctx) {
     double expceted[4] = {4, 6, 4, 6};
     double val;
     for (long long i = 0; i < 4; i++) {
-        if(!RedisAI_TensorGetValueAsDouble(out_tensor, i, &val)) {
+        if (!RedisAI_TensorGetValueAsDouble(out_tensor, i, &val)) {
             goto cleanup;
         }
         if (expceted[i] != val) {
@@ -329,7 +329,7 @@ int testSimpleDAGRun2(RedisModuleCtx *ctx) {
     }
     res = LLAPIMODULE_OK;
 
-    cleanup:
+cleanup:
     _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;
@@ -342,11 +342,11 @@ int testSimpleDAGRun2Error(RedisModuleCtx *ctx) {
     _InitRunResults(&run_ctx);
     int res = LLAPIMODULE_ERR;
 
-    RAI_Tensor *tensor = (RAI_Tensor*) _getFromKeySpace(ctx, "a{1}");
+    RAI_Tensor *tensor = (RAI_Tensor *)_getFromKeySpace(ctx, "a{1}");
     RedisAI_DAGAddTensorSet(run_info, "input1", tensor);
 
     // The script myscript{1} should exist in key space.
-    RAI_Script *script = (RAI_Script*)_getFromKeySpace(ctx, "myscript{1}");
+    RAI_Script *script = (RAI_Script *)_getFromKeySpace(ctx, "myscript{1}");
     RAI_DAGRunOp *op = RedisAI_DAGCreateScriptRunOp(script, "no_function");
     RedisAI_DAGRunOpAddInput(op, "input1");
     RedisAI_DAGRunOpAddOutput(op, "output");
@@ -371,7 +371,7 @@ int testSimpleDAGRun2Error(RedisModuleCtx *ctx) {
     }
     res = LLAPIMODULE_OK;
 
-    cleanup:
+cleanup:
     _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;
@@ -387,23 +387,25 @@ int testDAGResnet(RedisModuleCtx *ctx) {
     RAI_Tensor *t = (RAI_Tensor *)_getFromKeySpace(ctx, "image:{{1}}");
     RedisAI_DAGLoadTensor(run_info, "image:{{1}}", t);
 
-    RAI_Script *script = (RAI_Script *)_getFromKeySpace(ctx,  "imagenet_script1:{{1}}");
+    RAI_Script *script = (RAI_Script *)_getFromKeySpace(ctx, "imagenet_script1:{{1}}");
     RAI_DAGRunOp *script_op = RedisAI_DAGCreateScriptRunOp(script, "pre_process_3ch");
     RedisAI_DAGRunOpAddInput(script_op, "image:{{1}}");
     RedisAI_DAGRunOpAddOutput(script_op, "tmp_key:{{1}}");
     RedisAI_DAGAddRunOp(run_info, script_op, run_ctx.error);
 
-    RAI_Model *model = (RAI_Model *)_getFromKeySpace(ctx,  "imagenet_model1:{{1}}");
+    RAI_Model *model = (RAI_Model *)_getFromKeySpace(ctx, "imagenet_model1:{{1}}");
     RAI_DAGRunOp *model_op = RedisAI_DAGCreateModelRunOp(model);
     RedisAI_DAGRunOpAddInput(model_op, "tmp_key:{{1}}");
     RedisAI_DAGRunOpAddOutput(model_op, "tmp_key2_0");
-    if (RedisAI_DAGAddRunOp(run_info, model_op, run_ctx.error) != REDISMODULE_OK) goto cleanup;
+    if (RedisAI_DAGAddRunOp(run_info, model_op, run_ctx.error) != REDISMODULE_OK)
+        goto cleanup;
 
-    model = (RAI_Model *)_getFromKeySpace(ctx,  "imagenet_model2:{{1}}");
+    model = (RAI_Model *)_getFromKeySpace(ctx, "imagenet_model2:{{1}}");
     model_op = RedisAI_DAGCreateModelRunOp(model);
     RedisAI_DAGRunOpAddInput(model_op, "tmp_key:{{1}}");
     RedisAI_DAGRunOpAddOutput(model_op, "tmp_key2_1");
-    if (RedisAI_DAGAddRunOp(run_info, model_op, run_ctx.error) != REDISMODULE_OK) goto cleanup;
+    if (RedisAI_DAGAddRunOp(run_info, model_op, run_ctx.error) != REDISMODULE_OK)
+        goto cleanup;
 
     script_op = RedisAI_DAGCreateScriptRunOp(script, "ensemble");
     RedisAI_DAGRunOpAddInput(script_op, "tmp_key2_0");
@@ -431,12 +433,13 @@ int testDAGResnet(RedisModuleCtx *ctx) {
     RedisModule_Assert(_ResultsNumOutputs(run_ctx) == 1);
     RAI_Tensor *out_tensor = run_ctx.outputs[0];
     long long val;
-    if(!RedisAI_TensorGetValueAsLongLong(out_tensor, 0, &val)) goto cleanup;
+    if (!RedisAI_TensorGetValueAsLongLong(out_tensor, 0, &val))
+        goto cleanup;
     if (0 <= val && val <= 1000) {
         res = LLAPIMODULE_OK;
     }
 
-    cleanup:
+cleanup:
     _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;

--- a/tests/module/DAG_utils.c
+++ b/tests/module/DAG_utils.c
@@ -6,24 +6,25 @@
 #include <stdlib.h>
 #include "util/arr.h"
 
-pthread_mutex_t global_lock = PTHREAD_MUTEX_INITIALIZER;
-pthread_cond_t global_cond = PTHREAD_COND_INITIALIZER;
-
-static void _InitRunResults(RAI_RunResults *results) {
-    RedisAI_InitError(&results->error);
-    results->outputs = array_new(RAI_Tensor *, 1);
+static void _InitRunResults(RAI_RunCtx *run_ctx) {
+    RedisAI_InitError(&run_ctx->error);
+    run_ctx->outputs = array_new(RAI_Tensor *, 1);
+    pthread_mutex_init(&run_ctx->lock, NULL);
+    pthread_cond_init(&run_ctx->cond, NULL);
 }
 
-static void _FreeRunResults(RAI_RunResults *results) {
-    RedisAI_FreeError(results->error);
-    for (size_t i = 0; i < array_len(results->outputs); i++) {
-        RedisAI_TensorFree(results->outputs[i]);
+static void _FreeRunResults(RAI_RunCtx *run_ctx) {
+    RedisAI_FreeError(run_ctx->error);
+    for (size_t i = 0; i < array_len(run_ctx->outputs); i++) {
+        RedisAI_TensorFree(run_ctx->outputs[i]);
     }
-    array_free(results->outputs);
+    array_free(run_ctx->outputs);
+    pthread_mutex_destroy(&run_ctx->lock);
+    pthread_cond_destroy(&run_ctx->cond);
 }
 
-static size_t _ResultsNumOutputs(RAI_RunResults results) {
-    return array_len(results.outputs);
+static size_t _ResultsNumOutputs(RAI_RunCtx run_ctx) {
+    return array_len(run_ctx.outputs);
 }
 static void *_getFromKeySpace(RedisModuleCtx *ctx, const char *keyNameStr) {
 
@@ -52,24 +53,27 @@ static void _DAGFinishFuncError(RAI_OnFinishCtx *onFinishCtx, void *private_data
 
 static void _DAGFinishFunc(RAI_OnFinishCtx *onFinishCtx, void *private_data) {
 
-    RAI_RunResults *results = (RAI_RunResults *)private_data;
+    RAI_RunCtx *run_ctx = (RAI_RunCtx *)private_data;
     if (RedisAI_DAGRunError(onFinishCtx)) {
         const RAI_Error *error = RedisAI_DAGGetError(onFinishCtx);
-        RedisAI_CloneError(results->error, error);
-        pthread_cond_signal(&global_cond);
-        return;
+        RedisAI_CloneError(run_ctx->error, error);
+        goto finish;
     }
     size_t n_outputs = RedisAI_DAGNumOutputs(onFinishCtx);
     for (size_t i = 0; i < n_outputs; i++) {
         RAI_Tensor *t = (RAI_Tensor *)RedisAI_DAGOutputTensor(onFinishCtx, i);
         RedisModule_Assert(t != NULL);
-        results->outputs = array_append(results->outputs, RedisAI_TensorGetShallowCopy(t));
+        run_ctx->outputs = array_append(run_ctx->outputs, RedisAI_TensorGetShallowCopy(t));
     }
 
     // Verify that we return NULL as output for an index out of range.
     RAI_Tensor *t = (RAI_Tensor *)RedisAI_DAGOutputTensor(onFinishCtx, n_outputs);
     RedisModule_Assert(t == NULL);
-    pthread_cond_signal(&global_cond);
+
+    finish:
+    pthread_mutex_lock(&run_ctx->lock);
+    pthread_cond_signal(&run_ctx->cond);
+    pthread_mutex_unlock(&run_ctx->lock);
 }
 
 int testLoadTensor(RedisModuleCtx *ctx) {
@@ -173,54 +177,54 @@ int testKeysMismatchError(RedisModuleCtx *ctx) {
 int testBuildDAGFromString(RedisModuleCtx *ctx) {
 
     RAI_DAGRunCtx *run_info = RedisAI_DAGRunCtxCreate();
-    RAI_RunResults results;
-    _InitRunResults(&results);
+    RAI_RunCtx run_ctx;
+    _InitRunResults(&run_ctx);
     int res = LLAPIMODULE_ERR;
 
     RAI_Tensor *t = (RAI_Tensor *)_getFromKeySpace(ctx, "a{1}");
     RedisAI_DAGLoadTensor(run_info, "input1", t);
 
     const char *dag_string = "bad string";
-    int status = RedisAI_DAGAddOpsFromString(run_info, dag_string, results.error);
-    if (!_assertError(results.error, status, "DAG op should start with: '|>' ")) {
+    int status = RedisAI_DAGAddOpsFromString(run_info, dag_string, run_ctx.error);
+    if (!_assertError(run_ctx.error, status, "DAG op should start with: '|>' ")) {
         goto cleanup;
     }
-    RedisAI_ClearError(results.error);
+    RedisAI_ClearError(run_ctx.error);
 
     t = (RAI_Tensor *)_getFromKeySpace(ctx, "b{1}");
     RedisAI_DAGAddTensorSet(run_info, "input2", t);
 
     dag_string = "|> AI.MODELRUN m{1} INPUTS input1 input2 OUTPUTS output |> bad_op no_tensor";
-    status = RedisAI_DAGAddOpsFromString(run_info, dag_string, results.error);
-    if (!_assertError(results.error, status, "unsupported command within DAG")) {
+    status = RedisAI_DAGAddOpsFromString(run_info, dag_string, run_ctx.error);
+    if (!_assertError(run_ctx.error, status, "unsupported command within DAG")) {
         goto cleanup;
     }
-    RedisAI_ClearError(results.error);
+    RedisAI_ClearError(run_ctx.error);
     RedisModule_Assert(RedisAI_DAGNumOps(run_info) == 1);
 
     dag_string = "|> AI.MODELRUN m{1} INPUTS input1 input2 OUTPUTS output |> AI.TENSORGET output";
-    if (RedisAI_DAGAddOpsFromString(run_info, dag_string, results.error) != REDISMODULE_OK) {
+    if (RedisAI_DAGAddOpsFromString(run_info, dag_string, run_ctx.error) != REDISMODULE_OK) {
         goto cleanup;
     }
     RedisModule_Assert(RedisAI_DAGNumOps(run_info) == 3);
     RedisAI_DAGAddTensorGet(run_info, "input1");
     RedisModule_Assert(RedisAI_DAGNumOps(run_info) == 4);
 
-    pthread_mutex_lock(&global_lock);
-    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &results, results.error) != REDISMODULE_OK) {
-        pthread_mutex_unlock(&global_lock);
+    pthread_mutex_lock(&run_ctx.lock);
+    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &run_ctx, run_ctx.error) != REDISMODULE_OK) {
+        pthread_mutex_unlock(&run_ctx.lock);
         goto cleanup;
     }
     // Wait until the onFinish callback returns.
-    pthread_cond_wait(&global_cond, &global_lock);
-    pthread_mutex_unlock(&global_lock);
+    pthread_cond_wait(&run_ctx.cond, &run_ctx.lock);
+    pthread_mutex_unlock(&run_ctx.lock);
 
     // Verify that we received the expected tensor at the end of the run.
-    RedisModule_Assert(_ResultsNumOutputs(results) == 2);
+    RedisModule_Assert(_ResultsNumOutputs(run_ctx) == 2);
     res = LLAPIMODULE_OK;
 
     cleanup:
-    _FreeRunResults(&results);
+    _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;
 }
@@ -228,8 +232,8 @@ int testBuildDAGFromString(RedisModuleCtx *ctx) {
 int testSimpleDAGRun(RedisModuleCtx *ctx) {
 
     RAI_DAGRunCtx *run_info = RedisAI_DAGRunCtxCreate();
-    RAI_RunResults results;
-    _InitRunResults(&results);
+    RAI_RunCtx run_ctx;
+    _InitRunResults(&run_ctx);
     int res = LLAPIMODULE_ERR;
 
     RAI_Tensor *t = (RAI_Tensor *)_getFromKeySpace(ctx, "a{1}");
@@ -243,23 +247,23 @@ int testSimpleDAGRun(RedisModuleCtx *ctx) {
     RedisAI_DAGRunOpAddInput(op, "input1");
     RedisAI_DAGRunOpAddInput(op, "input2");
     RedisAI_DAGRunOpAddOutput(op, "output");
-    if (RedisAI_DAGAddRunOp(run_info, op, results.error) != REDISMODULE_OK) {
+    if (RedisAI_DAGAddRunOp(run_info, op, run_ctx.error) != REDISMODULE_OK) {
         goto cleanup;
     }
 
     RedisAI_DAGAddTensorGet(run_info, "output");
-    pthread_mutex_lock(&global_lock);
-    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &results, results.error) != REDISMODULE_OK) {
-        pthread_mutex_unlock(&global_lock);
+    pthread_mutex_lock(&run_ctx.lock);
+    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &run_ctx, run_ctx.error) != REDISMODULE_OK) {
+        pthread_mutex_unlock(&run_ctx.lock);
         goto cleanup;
     }
     // Wait until the onFinish callback returns.
-    pthread_cond_wait(&global_cond, &global_lock);
-    pthread_mutex_unlock(&global_lock);
+    pthread_cond_wait(&run_ctx.cond, &run_ctx.lock);
+    pthread_mutex_unlock(&run_ctx.lock);
 
     // Verify that we received the expected tensor at the end of the run.
-    RedisModule_Assert(_ResultsNumOutputs(results) == 1);
-    RAI_Tensor *out_tensor = results.outputs[0];
+    RedisModule_Assert(_ResultsNumOutputs(run_ctx) == 1);
+    RAI_Tensor *out_tensor = run_ctx.outputs[0];
     double expceted[4] = {4, 9, 4, 9};
     double val;
     for (long long i = 0; i < 4; i++) {
@@ -273,7 +277,7 @@ int testSimpleDAGRun(RedisModuleCtx *ctx) {
     res = LLAPIMODULE_OK;
 
     cleanup:
-    _FreeRunResults(&results);
+    _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;
 }
@@ -281,8 +285,8 @@ int testSimpleDAGRun(RedisModuleCtx *ctx) {
 int testSimpleDAGRun2(RedisModuleCtx *ctx) {
 
     RAI_DAGRunCtx *run_info = RedisAI_DAGRunCtxCreate();
-    RAI_RunResults results;
-    _InitRunResults(&results);
+    RAI_RunCtx run_ctx;
+    _InitRunResults(&run_ctx);
     int res = LLAPIMODULE_ERR;
 
     RAI_Tensor *tensor = (RAI_Tensor*)_getFromKeySpace(ctx, "a{1}");
@@ -296,23 +300,23 @@ int testSimpleDAGRun2(RedisModuleCtx *ctx) {
     RedisAI_DAGRunOpAddInput(op, "input1");
     RedisAI_DAGRunOpAddInput(op, "input2");
     RedisAI_DAGRunOpAddOutput(op, "output");
-    if (RedisAI_DAGAddRunOp(run_info, op, results.error) != REDISMODULE_OK) {
+    if (RedisAI_DAGAddRunOp(run_info, op, run_ctx.error) != REDISMODULE_OK) {
         goto cleanup;
     }
 
     RedisAI_DAGAddTensorGet(run_info, "output");
-    pthread_mutex_lock(&global_lock);
-    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &results, results.error) != REDISMODULE_OK) {
-        pthread_mutex_unlock(&global_lock);
+    pthread_mutex_lock(&run_ctx.lock);
+    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &run_ctx, run_ctx.error) != REDISMODULE_OK) {
+        pthread_mutex_unlock(&run_ctx.lock);
         goto cleanup;
     }
     // Wait until the onFinish callback returns.
-    pthread_cond_wait(&global_cond, &global_lock);
-    pthread_mutex_unlock(&global_lock);
+    pthread_cond_wait(&run_ctx.cond, &run_ctx.lock);
+    pthread_mutex_unlock(&run_ctx.lock);
 
     // Verify that we received the expected tensor at the end of the run.
-    RedisModule_Assert(_ResultsNumOutputs(results) == 1);
-    RAI_Tensor *out_tensor = results.outputs[0];
+    RedisModule_Assert(_ResultsNumOutputs(run_ctx) == 1);
+    RAI_Tensor *out_tensor = run_ctx.outputs[0];
     double expceted[4] = {4, 6, 4, 6};
     double val;
     for (long long i = 0; i < 4; i++) {
@@ -326,7 +330,7 @@ int testSimpleDAGRun2(RedisModuleCtx *ctx) {
     res = LLAPIMODULE_OK;
 
     cleanup:
-    _FreeRunResults(&results);
+    _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;
 }
@@ -334,8 +338,8 @@ int testSimpleDAGRun2(RedisModuleCtx *ctx) {
 int testSimpleDAGRun2Error(RedisModuleCtx *ctx) {
 
     RAI_DAGRunCtx *run_info = RedisAI_DAGRunCtxCreate();
-    RAI_RunResults results;
-    _InitRunResults(&results);
+    RAI_RunCtx run_ctx;
+    _InitRunResults(&run_ctx);
     int res = LLAPIMODULE_ERR;
 
     RAI_Tensor *tensor = (RAI_Tensor*) _getFromKeySpace(ctx, "a{1}");
@@ -346,36 +350,36 @@ int testSimpleDAGRun2Error(RedisModuleCtx *ctx) {
     RAI_DAGRunOp *op = RedisAI_DAGCreateScriptRunOp(script, "no_function");
     RedisAI_DAGRunOpAddInput(op, "input1");
     RedisAI_DAGRunOpAddOutput(op, "output");
-    if (RedisAI_DAGAddRunOp(run_info, op, results.error) != REDISMODULE_OK) {
+    if (RedisAI_DAGAddRunOp(run_info, op, run_ctx.error) != REDISMODULE_OK) {
         goto cleanup;
     }
 
     RedisAI_DAGAddTensorGet(run_info, "output");
-    pthread_mutex_lock(&global_lock);
-    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &results, results.error) != REDISMODULE_OK) {
-        pthread_mutex_unlock(&global_lock);
+    pthread_mutex_lock(&run_ctx.lock);
+    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &run_ctx, run_ctx.error) != REDISMODULE_OK) {
+        pthread_mutex_unlock(&run_ctx.lock);
         goto cleanup;
     }
     // Wait until the onFinish callback returns.
-    pthread_cond_wait(&global_cond, &global_lock);
-    pthread_mutex_unlock(&global_lock);
+    pthread_cond_wait(&run_ctx.cond, &run_ctx.lock);
+    pthread_mutex_unlock(&run_ctx.lock);
 
     // Verify that we received an error in SCRIPTRUN op.
-    RedisModule_Assert(_ResultsNumOutputs(results) == 0);
-    if (RedisAI_GetErrorCode(results.error) != RedisAI_ErrorCode_ESCRIPTRUN) {
+    RedisModule_Assert(_ResultsNumOutputs(run_ctx) == 0);
+    if (RedisAI_GetErrorCode(run_ctx.error) != RedisAI_ErrorCode_ESCRIPTRUN) {
         goto cleanup;
     }
     res = LLAPIMODULE_OK;
 
     cleanup:
-    _FreeRunResults(&results);
+    _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;
 }
 
 int testDAGResnet(RedisModuleCtx *ctx) {
-    RAI_RunResults results;
-    _InitRunResults(&results);
+    RAI_RunCtx run_ctx;
+    _InitRunResults(&run_ctx);
     int res = LLAPIMODULE_ERR;
 
     // Build the DAG with LOAD->SCRIPTRUN->MODELRUN->MODELRUN-SCRIPTRUN->SCRIPTRUN->TENSORGET
@@ -387,45 +391,45 @@ int testDAGResnet(RedisModuleCtx *ctx) {
     RAI_DAGRunOp *script_op = RedisAI_DAGCreateScriptRunOp(script, "pre_process_3ch");
     RedisAI_DAGRunOpAddInput(script_op, "image:{{1}}");
     RedisAI_DAGRunOpAddOutput(script_op, "tmp_key:{{1}}");
-    RedisAI_DAGAddRunOp(run_info, script_op, results.error);
+    RedisAI_DAGAddRunOp(run_info, script_op, run_ctx.error);
 
     RAI_Model *model = (RAI_Model *)_getFromKeySpace(ctx,  "imagenet_model1:{{1}}");
     RAI_DAGRunOp *model_op = RedisAI_DAGCreateModelRunOp(model);
     RedisAI_DAGRunOpAddInput(model_op, "tmp_key:{{1}}");
     RedisAI_DAGRunOpAddOutput(model_op, "tmp_key2_0");
-    if (RedisAI_DAGAddRunOp(run_info, model_op, results.error) != REDISMODULE_OK) goto cleanup;
+    if (RedisAI_DAGAddRunOp(run_info, model_op, run_ctx.error) != REDISMODULE_OK) goto cleanup;
 
     model = (RAI_Model *)_getFromKeySpace(ctx,  "imagenet_model2:{{1}}");
     model_op = RedisAI_DAGCreateModelRunOp(model);
     RedisAI_DAGRunOpAddInput(model_op, "tmp_key:{{1}}");
     RedisAI_DAGRunOpAddOutput(model_op, "tmp_key2_1");
-    if (RedisAI_DAGAddRunOp(run_info, model_op, results.error) != REDISMODULE_OK) goto cleanup;
+    if (RedisAI_DAGAddRunOp(run_info, model_op, run_ctx.error) != REDISMODULE_OK) goto cleanup;
 
     script_op = RedisAI_DAGCreateScriptRunOp(script, "ensemble");
     RedisAI_DAGRunOpAddInput(script_op, "tmp_key2_0");
     RedisAI_DAGRunOpAddInput(script_op, "tmp_key2_1");
     RedisAI_DAGRunOpAddOutput(script_op, "tmp_key_1:{{1}}");
-    RedisAI_DAGAddRunOp(run_info, script_op, results.error);
+    RedisAI_DAGAddRunOp(run_info, script_op, run_ctx.error);
 
     script_op = RedisAI_DAGCreateScriptRunOp(script, "post_process");
     RedisAI_DAGRunOpAddInput(script_op, "tmp_key_1:{{1}}");
     RedisAI_DAGRunOpAddOutput(script_op, "output:{{1}}");
-    RedisAI_DAGAddRunOp(run_info, script_op, results.error);
+    RedisAI_DAGAddRunOp(run_info, script_op, run_ctx.error);
 
     RedisAI_DAGAddTensorGet(run_info, "output:{{1}}");
 
-    pthread_mutex_lock(&global_lock);
-    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &results, results.error) != REDISMODULE_OK) {
-        pthread_mutex_unlock(&global_lock);
+    pthread_mutex_lock(&run_ctx.lock);
+    if (RedisAI_DAGRun(run_info, _DAGFinishFunc, &run_ctx, run_ctx.error) != REDISMODULE_OK) {
+        pthread_mutex_unlock(&run_ctx.lock);
         goto cleanup;
     }
     // Wait until the onFinish callback returns.
-    pthread_cond_wait(&global_cond, &global_lock);
-    pthread_mutex_unlock(&global_lock);
+    pthread_cond_wait(&run_ctx.cond, &run_ctx.lock);
+    pthread_mutex_unlock(&run_ctx.lock);
 
     // Verify that we received the expected output.
-    RedisModule_Assert(_ResultsNumOutputs(results) == 1);
-    RAI_Tensor *out_tensor = results.outputs[0];
+    RedisModule_Assert(_ResultsNumOutputs(run_ctx) == 1);
+    RAI_Tensor *out_tensor = run_ctx.outputs[0];
     long long val;
     if(!RedisAI_TensorGetValueAsLongLong(out_tensor, 0, &val)) goto cleanup;
     if (0 <= val && val <= 1000) {
@@ -433,7 +437,7 @@ int testDAGResnet(RedisModuleCtx *ctx) {
     }
 
     cleanup:
-    _FreeRunResults(&results);
+    _FreeRunResults(&run_ctx);
     RedisAI_DAGFree(run_info);
     return res;
 }

--- a/tests/module/DAG_utils.h
+++ b/tests/module/DAG_utils.h
@@ -3,7 +3,7 @@
 #include <pthread.h>
 #include <stdbool.h>
 
-#define LLAPIMODULE_OK 0
+#define LLAPIMODULE_OK  0
 #define LLAPIMODULE_ERR 1
 
 typedef struct RAI_RunCtx {

--- a/tests/module/DAG_utils.h
+++ b/tests/module/DAG_utils.h
@@ -6,10 +6,12 @@
 #define LLAPIMODULE_OK 0
 #define LLAPIMODULE_ERR 1
 
-typedef struct RAI_RunResults {
+typedef struct RAI_RunCtx {
     RAI_Tensor **outputs;
     RAI_Error *error;
-} RAI_RunResults;
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+} RAI_RunCtx;
 
 int testLoadTensor(RedisModuleCtx *ctx);
 

--- a/tests/module/LLAPI.c
+++ b/tests/module/LLAPI.c
@@ -5,278 +5,276 @@
 #include <errno.h>
 #include <string.h>
 
-
-typedef enum LLAPI_status {LLAPI_RUN_NONE = 0,
-						   LLAPI_RUN_SUCCESS,
-						   LLAPI_RUN_ERROR,
-						   LLAPI_NUM_OUTPUTS_ERROR
+typedef enum LLAPI_status {
+    LLAPI_RUN_NONE = 0,
+    LLAPI_RUN_SUCCESS,
+    LLAPI_RUN_ERROR,
+    LLAPI_NUM_OUTPUTS_ERROR
 } LLAPI_status;
 
 pthread_mutex_t global_lock = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t global_cond = PTHREAD_COND_INITIALIZER;
 
-
 int RAI_llapi_basic_check(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argv);
 
-	if (argc>1) {
-		RedisModule_WrongArity(ctx);
-		return REDISMODULE_OK;
-	}
+    if (argc > 1) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_OK;
+    }
 
-	RAI_Error *err;
-	RedisAI_InitError(&err);
-	if(RedisAI_GetErrorCode(err) == RedisAI_ErrorCode_OK) {
+    RAI_Error *err;
+    RedisAI_InitError(&err);
+    if (RedisAI_GetErrorCode(err) == RedisAI_ErrorCode_OK) {
         RedisModule_ReplyWithSimpleString(ctx, "OK");
     }
-	RedisModule_ReplyWithError(ctx, "ERROR");
-	RedisAI_FreeError(err);
-	return REDISMODULE_OK;
+    RedisModule_ReplyWithError(ctx, "ERROR");
+    RedisAI_FreeError(err);
+    return REDISMODULE_OK;
 }
 
 static void _ScriptFinishFunc(RAI_OnFinishCtx *onFinishCtx, void *private_data) {
 
-	RAI_Error *err;
-	if (RedisAI_InitError(&err) != REDISMODULE_OK) goto finish;
-	RAI_ScriptRunCtx* sctx = RedisAI_GetAsScriptRunCtx(onFinishCtx, err);
-	if(RedisAI_GetErrorCode(err) != RedisAI_ErrorCode_OK) {
-		*(int *) private_data = LLAPI_RUN_ERROR;
-		goto finish;
-	}
-	if(RedisAI_ScriptRunCtxNumOutputs(sctx) != 1) {
-		*(int *) private_data = LLAPI_NUM_OUTPUTS_ERROR;
-		goto finish;
-	}
-	RAI_Tensor *tensor = RedisAI_ScriptRunCtxOutputTensor(sctx, 0);
-	double expceted[4] = {4, 6, 4, 6};
-	double val[4];
+    RAI_Error *err;
+    if (RedisAI_InitError(&err) != REDISMODULE_OK)
+        goto finish;
+    RAI_ScriptRunCtx *sctx = RedisAI_GetAsScriptRunCtx(onFinishCtx, err);
+    if (RedisAI_GetErrorCode(err) != RedisAI_ErrorCode_OK) {
+        *(int *)private_data = LLAPI_RUN_ERROR;
+        goto finish;
+    }
+    if (RedisAI_ScriptRunCtxNumOutputs(sctx) != 1) {
+        *(int *)private_data = LLAPI_NUM_OUTPUTS_ERROR;
+        goto finish;
+    }
+    RAI_Tensor *tensor = RedisAI_ScriptRunCtxOutputTensor(sctx, 0);
+    double expceted[4] = {4, 6, 4, 6};
+    double val[4];
 
-	// Verify that we received the expected tensor at the end of the run.
-	for (long long i = 0; i < 4; i++) {
-		if(!RedisAI_TensorGetValueAsDouble(tensor, i, &val[i])) {
-			goto finish;
-		}
-		if (expceted[i] != val[i]) {
-			goto finish;
-		}
-	}
-	*(int *)private_data = LLAPI_RUN_SUCCESS;
+    // Verify that we received the expected tensor at the end of the run.
+    for (long long i = 0; i < 4; i++) {
+        if (!RedisAI_TensorGetValueAsDouble(tensor, i, &val[i])) {
+            goto finish;
+        }
+        if (expceted[i] != val[i]) {
+            goto finish;
+        }
+    }
+    *(int *)private_data = LLAPI_RUN_SUCCESS;
 
-	finish:
-	RedisAI_FreeError(err);
+finish:
+    RedisAI_FreeError(err);
     pthread_mutex_lock(&global_lock);
-	pthread_cond_signal(&global_cond);
+    pthread_cond_signal(&global_cond);
     pthread_mutex_unlock(&global_lock);
 }
 
 static void _ModelFinishFunc(RAI_OnFinishCtx *onFinishCtx, void *private_data) {
 
-	RAI_Error *err;
-	if (RedisAI_InitError(&err) != REDISMODULE_OK) goto finish;
-	RAI_ModelRunCtx* mctx = RedisAI_GetAsModelRunCtx(onFinishCtx, err);
-	if(RedisAI_GetErrorCode(err) != RedisAI_ErrorCode_OK) {
-		*(int *) private_data = LLAPI_RUN_ERROR;
-		goto finish;
-	}
-	if(RedisAI_ModelRunCtxNumOutputs(mctx) != 1) {
-		*(int *) private_data = LLAPI_NUM_OUTPUTS_ERROR;
-		goto finish;
-	}
-	RAI_Tensor *tensor = RedisAI_ModelRunCtxOutputTensor(mctx, 0);
-	double expceted[4] = {4, 9, 4, 9};
-	double val[4];
+    RAI_Error *err;
+    if (RedisAI_InitError(&err) != REDISMODULE_OK)
+        goto finish;
+    RAI_ModelRunCtx *mctx = RedisAI_GetAsModelRunCtx(onFinishCtx, err);
+    if (RedisAI_GetErrorCode(err) != RedisAI_ErrorCode_OK) {
+        *(int *)private_data = LLAPI_RUN_ERROR;
+        goto finish;
+    }
+    if (RedisAI_ModelRunCtxNumOutputs(mctx) != 1) {
+        *(int *)private_data = LLAPI_NUM_OUTPUTS_ERROR;
+        goto finish;
+    }
+    RAI_Tensor *tensor = RedisAI_ModelRunCtxOutputTensor(mctx, 0);
+    double expceted[4] = {4, 9, 4, 9};
+    double val[4];
 
-	// Verify that we received the expected tensor at the end of the run.
-	for (long long i = 0; i < 4; i++) {
-		if(!RedisAI_TensorGetValueAsDouble(tensor, i, &val[i])) {
-			goto finish;
-		}
-		if (expceted[i] != val[i]) {
-			goto finish;
-		}
-	}
-	*(int *)private_data = LLAPI_RUN_SUCCESS;
+    // Verify that we received the expected tensor at the end of the run.
+    for (long long i = 0; i < 4; i++) {
+        if (!RedisAI_TensorGetValueAsDouble(tensor, i, &val[i])) {
+            goto finish;
+        }
+        if (expceted[i] != val[i]) {
+            goto finish;
+        }
+    }
+    *(int *)private_data = LLAPI_RUN_SUCCESS;
 
-	finish:
-	RedisAI_FreeError(err);
-	pthread_mutex_lock(&global_lock);
-	pthread_cond_signal(&global_cond);
+finish:
+    RedisAI_FreeError(err);
+    pthread_mutex_lock(&global_lock);
+    pthread_cond_signal(&global_cond);
     pthread_mutex_unlock(&global_lock);
 }
 
-static int _ExecuteModelRunAsync(RedisModuleCtx *ctx, RAI_ModelRunCtx* mctx) {
-	LLAPI_status status = LLAPI_RUN_NONE;
-	pthread_mutex_lock(&global_lock);
-	if (RedisAI_ModelRunAsync(mctx, _ModelFinishFunc, &status) != REDISMODULE_OK) {
-		pthread_mutex_unlock(&global_lock);
-		RedisAI_ModelRunCtxFree(mctx);
-		RedisModule_ReplyWithError(ctx, "Async run could not start");
-		return LLAPI_RUN_NONE;
-	}
+static int _ExecuteModelRunAsync(RedisModuleCtx *ctx, RAI_ModelRunCtx *mctx) {
+    LLAPI_status status = LLAPI_RUN_NONE;
+    pthread_mutex_lock(&global_lock);
+    if (RedisAI_ModelRunAsync(mctx, _ModelFinishFunc, &status) != REDISMODULE_OK) {
+        pthread_mutex_unlock(&global_lock);
+        RedisAI_ModelRunCtxFree(mctx);
+        RedisModule_ReplyWithError(ctx, "Async run could not start");
+        return LLAPI_RUN_NONE;
+    }
 
-	// Wait until the onFinish callback returns.
-	pthread_cond_wait(&global_cond, &global_lock);
-	pthread_mutex_unlock(&global_lock);
-	RedisAI_ModelRunCtxFree(mctx);
-	return status;
+    // Wait until the onFinish callback returns.
+    pthread_cond_wait(&global_cond, &global_lock);
+    pthread_mutex_unlock(&global_lock);
+    RedisAI_ModelRunCtxFree(mctx);
+    return status;
 }
 
-static int _ExecuteScriptRunAsync(RedisModuleCtx *ctx, RAI_ScriptRunCtx* sctx) {
-	LLAPI_status status = LLAPI_RUN_NONE;
-	pthread_mutex_lock(&global_lock);
-	if (RedisAI_ScriptRunAsync(sctx, _ScriptFinishFunc, &status) != REDISMODULE_OK) {
-		pthread_mutex_unlock(&global_lock);
-		RedisAI_ScriptRunCtxFree(sctx);
-		RedisModule_ReplyWithError(ctx, "Async run could not start");
-		return LLAPI_RUN_NONE;
-	}
+static int _ExecuteScriptRunAsync(RedisModuleCtx *ctx, RAI_ScriptRunCtx *sctx) {
+    LLAPI_status status = LLAPI_RUN_NONE;
+    pthread_mutex_lock(&global_lock);
+    if (RedisAI_ScriptRunAsync(sctx, _ScriptFinishFunc, &status) != REDISMODULE_OK) {
+        pthread_mutex_unlock(&global_lock);
+        RedisAI_ScriptRunCtxFree(sctx);
+        RedisModule_ReplyWithError(ctx, "Async run could not start");
+        return LLAPI_RUN_NONE;
+    }
 
-	// Wait until the onFinish callback returns.
-	pthread_cond_wait(&global_cond, &global_lock);
-	pthread_mutex_unlock(&global_lock);
-	RedisAI_ScriptRunCtxFree(sctx);
-	return status;
+    // Wait until the onFinish callback returns.
+    pthread_cond_wait(&global_cond, &global_lock);
+    pthread_mutex_unlock(&global_lock);
+    RedisAI_ScriptRunCtxFree(sctx);
+    return status;
 }
 
 int RAI_llapi_modelRun(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argv);
 
-	if (argc>1) {
-		RedisModule_WrongArity(ctx);
-		return REDISMODULE_OK;
-	}
-	// The model m{1} should exist in key space.
-	const char *keyNameStr = "m{1}";
-	RedisModuleString *keyRedisStr = RedisModule_CreateString(ctx, keyNameStr, strlen(keyNameStr));
-	RedisModuleKey *key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
-	RAI_Model *model = RedisModule_ModuleTypeGetValue(key);
-	RAI_ModelRunCtx* mctx = RedisAI_ModelRunCtxCreate(model);
-	RedisModule_FreeString(ctx, keyRedisStr);
-	RedisModule_CloseKey(key);
+    if (argc > 1) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_OK;
+    }
+    // The model m{1} should exist in key space.
+    const char *keyNameStr = "m{1}";
+    RedisModuleString *keyRedisStr = RedisModule_CreateString(ctx, keyNameStr, strlen(keyNameStr));
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
+    RAI_Model *model = RedisModule_ModuleTypeGetValue(key);
+    RAI_ModelRunCtx *mctx = RedisAI_ModelRunCtxCreate(model);
+    RedisModule_FreeString(ctx, keyRedisStr);
+    RedisModule_CloseKey(key);
 
-	// Test the case of a failure in the model run execution (no inputs specified).
-	if(_ExecuteModelRunAsync(ctx, mctx) != LLAPI_RUN_ERROR) {
-		return RedisModule_ReplyWithSimpleString(ctx, "Async run should end with an error");
-	}
+    // Test the case of a failure in the model run execution (no inputs specified).
+    if (_ExecuteModelRunAsync(ctx, mctx) != LLAPI_RUN_ERROR) {
+        return RedisModule_ReplyWithSimpleString(ctx, "Async run should end with an error");
+    }
 
-	mctx = RedisAI_ModelRunCtxCreate(model);
-	// The tensors a{1} and b{1} should exist in key space.
-	// Load the tensors a{1} and b{1} and add them as inputs for m{1}.
-	keyNameStr = "a{1}";
-	keyRedisStr = RedisModule_CreateString(ctx, keyNameStr,
-	  strlen(keyNameStr));
-	key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
-	RAI_Tensor *input1 = RedisModule_ModuleTypeGetValue(key);
-	RedisAI_ModelRunCtxAddInput(mctx, "a", input1);
-	RedisModule_FreeString(ctx, keyRedisStr);
-	RedisModule_CloseKey(key);
+    mctx = RedisAI_ModelRunCtxCreate(model);
+    // The tensors a{1} and b{1} should exist in key space.
+    // Load the tensors a{1} and b{1} and add them as inputs for m{1}.
+    keyNameStr = "a{1}";
+    keyRedisStr = RedisModule_CreateString(ctx, keyNameStr, strlen(keyNameStr));
+    key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
+    RAI_Tensor *input1 = RedisModule_ModuleTypeGetValue(key);
+    RedisAI_ModelRunCtxAddInput(mctx, "a", input1);
+    RedisModule_FreeString(ctx, keyRedisStr);
+    RedisModule_CloseKey(key);
 
-	keyNameStr = "b{1}";
-	keyRedisStr = RedisModule_CreateString(ctx, keyNameStr,
-	  strlen(keyNameStr));
-	key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
-	RAI_Tensor *input2 = RedisModule_ModuleTypeGetValue(key);
-	RedisAI_ModelRunCtxAddInput(mctx, "b", input2);
-	RedisModule_FreeString(ctx, keyRedisStr);
-	RedisModule_CloseKey(key);
+    keyNameStr = "b{1}";
+    keyRedisStr = RedisModule_CreateString(ctx, keyNameStr, strlen(keyNameStr));
+    key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
+    RAI_Tensor *input2 = RedisModule_ModuleTypeGetValue(key);
+    RedisAI_ModelRunCtxAddInput(mctx, "b", input2);
+    RedisModule_FreeString(ctx, keyRedisStr);
+    RedisModule_CloseKey(key);
 
-	// Add the expected output tensor.
-	RedisAI_ModelRunCtxAddOutput(mctx, "mul");
+    // Add the expected output tensor.
+    RedisAI_ModelRunCtxAddOutput(mctx, "mul");
 
-	if (_ExecuteModelRunAsync(ctx, mctx) != LLAPI_RUN_SUCCESS)
-		return RedisModule_ReplyWithSimpleString(ctx, "Async run failed");
-	return RedisModule_ReplyWithSimpleString(ctx, "Async run success");
+    if (_ExecuteModelRunAsync(ctx, mctx) != LLAPI_RUN_SUCCESS)
+        return RedisModule_ReplyWithSimpleString(ctx, "Async run failed");
+    return RedisModule_ReplyWithSimpleString(ctx, "Async run success");
 }
 
 int RAI_llapi_scriptRun(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argv);
 
-	if (argc>1) {
-		RedisModule_WrongArity(ctx);
-		return REDISMODULE_OK;
-	}
-	// The script 'myscript{1}' should exist in key space.
-	const char *keyNameStr = "myscript{1}";
-	RedisModuleString *keyRedisStr = RedisModule_CreateString(ctx, keyNameStr, strlen(keyNameStr));
-	RedisModuleKey *key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
-	RAI_Script *script = RedisModule_ModuleTypeGetValue(key);
-	RAI_ScriptRunCtx* sctx = RedisAI_ScriptRunCtxCreate(script, "bad_func");
-	RedisModule_FreeString(ctx, keyRedisStr);
-	RedisModule_CloseKey(key);
+    if (argc > 1) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_OK;
+    }
+    // The script 'myscript{1}' should exist in key space.
+    const char *keyNameStr = "myscript{1}";
+    RedisModuleString *keyRedisStr = RedisModule_CreateString(ctx, keyNameStr, strlen(keyNameStr));
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
+    RAI_Script *script = RedisModule_ModuleTypeGetValue(key);
+    RAI_ScriptRunCtx *sctx = RedisAI_ScriptRunCtxCreate(script, "bad_func");
+    RedisModule_FreeString(ctx, keyRedisStr);
+    RedisModule_CloseKey(key);
 
-	// Test the case of a failure in the script run execution (func name does not exist in script).
-	if(_ExecuteScriptRunAsync(ctx, sctx) != LLAPI_RUN_ERROR) {
-		return RedisModule_ReplyWithSimpleString(ctx, "Async run should end with an error");
-	}
+    // Test the case of a failure in the script run execution (func name does not exist in script).
+    if (_ExecuteScriptRunAsync(ctx, sctx) != LLAPI_RUN_ERROR) {
+        return RedisModule_ReplyWithSimpleString(ctx, "Async run should end with an error");
+    }
 
-	sctx = RedisAI_ScriptRunCtxCreate(script, "bar");
-	RAI_Error *err;
-	// The tensors a{1} and b{1} should exist in key space.
-	// Load the tensors a{1} and b{1} and add them as inputs for the script.
-	keyNameStr = "a{1}";
-	keyRedisStr = RedisModule_CreateString(ctx, keyNameStr,
-	  strlen(keyNameStr));
-	key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
-	RAI_Tensor *input1 = RedisModule_ModuleTypeGetValue(key);
-	RedisAI_ScriptRunCtxAddInput(sctx, input1, err);
-	RedisModule_FreeString(ctx, keyRedisStr);
-	RedisModule_CloseKey(key);
+    sctx = RedisAI_ScriptRunCtxCreate(script, "bar");
+    RAI_Error *err;
+    // The tensors a{1} and b{1} should exist in key space.
+    // Load the tensors a{1} and b{1} and add them as inputs for the script.
+    keyNameStr = "a{1}";
+    keyRedisStr = RedisModule_CreateString(ctx, keyNameStr, strlen(keyNameStr));
+    key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
+    RAI_Tensor *input1 = RedisModule_ModuleTypeGetValue(key);
+    RedisAI_ScriptRunCtxAddInput(sctx, input1, err);
+    RedisModule_FreeString(ctx, keyRedisStr);
+    RedisModule_CloseKey(key);
 
-	keyNameStr = "b{1}";
-	keyRedisStr = RedisModule_CreateString(ctx, keyNameStr,
-	  strlen(keyNameStr));
-	key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
-	RAI_Tensor *input2 = RedisModule_ModuleTypeGetValue(key);
-	RedisAI_ScriptRunCtxAddInput(sctx, input2, err);
-	RedisModule_FreeString(ctx, keyRedisStr);
-	RedisModule_CloseKey(key);
+    keyNameStr = "b{1}";
+    keyRedisStr = RedisModule_CreateString(ctx, keyNameStr, strlen(keyNameStr));
+    key = RedisModule_OpenKey(ctx, keyRedisStr, REDISMODULE_READ);
+    RAI_Tensor *input2 = RedisModule_ModuleTypeGetValue(key);
+    RedisAI_ScriptRunCtxAddInput(sctx, input2, err);
+    RedisModule_FreeString(ctx, keyRedisStr);
+    RedisModule_CloseKey(key);
 
-	// Add the expected output tensor.
-	RedisAI_ScriptRunCtxAddOutput(sctx);
+    // Add the expected output tensor.
+    RedisAI_ScriptRunCtxAddOutput(sctx);
 
-	if (_ExecuteScriptRunAsync(ctx, sctx) != LLAPI_RUN_SUCCESS)
-		return RedisModule_ReplyWithSimpleString(ctx, "Async run failed");
-	return RedisModule_ReplyWithSimpleString(ctx, "Async run success");
+    if (_ExecuteScriptRunAsync(ctx, sctx) != LLAPI_RUN_SUCCESS)
+        return RedisModule_ReplyWithSimpleString(ctx, "Async run failed");
+    return RedisModule_ReplyWithSimpleString(ctx, "Async run success");
 }
 
 int RAI_llapi_DAGRun(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
 
-    if(argc > 1) {
+    if (argc > 1) {
         RedisModule_WrongArity(ctx);
         return REDISMODULE_OK;
     }
 
     // Test the case a successful and failure tensor load input to DAG.
-    if(testLoadTensor(ctx) != LLAPIMODULE_OK) {
+    if (testLoadTensor(ctx) != LLAPIMODULE_OK) {
         return RedisModule_ReplyWithSimpleString(ctx, "LOAD tensor test failed");
     }
     // Test the case of a failure due to addition of a non compatible MODELRUN op.
-    if(testModelRunOpError(ctx) != LLAPIMODULE_OK) {
+    if (testModelRunOpError(ctx) != LLAPIMODULE_OK) {
         return RedisModule_ReplyWithSimpleString(ctx, "MODELRUN op error test failed");
     }
     // Test the case of a failure due an empty DAG.
-    if(testEmptyDAGError(ctx) != LLAPIMODULE_OK) {
+    if (testEmptyDAGError(ctx) != LLAPIMODULE_OK) {
         return RedisModule_ReplyWithSimpleString(ctx, "DAG keys mismatch error test failed");
     }
     // Test the case of a failure due to an op within a DAG whose inkey does not exist in the DAG.
-    if(testKeysMismatchError(ctx) != LLAPIMODULE_OK) {
+    if (testKeysMismatchError(ctx) != LLAPIMODULE_OK) {
         return RedisModule_ReplyWithSimpleString(ctx, "DAG keys mismatch error test failed");
     }
     // Test the case of building and running a DAG with LOAD, TENSORGET and MODELRUN ops.
-    if(testSimpleDAGRun(ctx) != LLAPIMODULE_OK) {
+    if (testSimpleDAGRun(ctx) != LLAPIMODULE_OK) {
         return RedisModule_ReplyWithSimpleString(ctx, "Simple DAG run test failed");
     }
     // Test the case of building and running a DAG with TENSORSET, SCRIPTRUN and TENSORGET ops.
-    if(testSimpleDAGRun2(ctx) != LLAPIMODULE_OK) {
+    if (testSimpleDAGRun2(ctx) != LLAPIMODULE_OK) {
         return RedisModule_ReplyWithSimpleString(ctx, "Simple DAG run2 test failed");
     }
-    // Test the case of building the same DAG as in previous test, but when this time it should return with an error.
-    if(testSimpleDAGRun2Error(ctx) != LLAPIMODULE_OK) {
+    // Test the case of building the same DAG as in previous test, but when this time it should
+    // return with an error.
+    if (testSimpleDAGRun2Error(ctx) != LLAPIMODULE_OK) {
         return RedisModule_ReplyWithSimpleString(ctx, "Simple DAG run2 error test failed");
     }
     // Test the case of building DAG ops from string.
-    if(testBuildDAGFromString(ctx) != LLAPIMODULE_OK) {
+    if (testBuildDAGFromString(ctx) != LLAPIMODULE_OK) {
         return RedisModule_ReplyWithSimpleString(ctx, "Build DAG from string test failed");
     }
     return RedisModule_ReplyWithSimpleString(ctx, "DAG run success");
@@ -285,7 +283,7 @@ int RAI_llapi_DAGRun(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 int RAI_llapi_DAG_resnet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
 
-    if(argc > 1) {
+    if (argc > 1) {
         RedisModule_WrongArity(ctx);
         return REDISMODULE_OK;
     }
@@ -296,41 +294,38 @@ int RAI_llapi_DAG_resnet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     return RedisModule_ReplyWithSimpleString(ctx, "DAG resnet success");
 }
 
-
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	REDISMODULE_NOT_USED(argv);
-	REDISMODULE_NOT_USED(argc);
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
 
-	if(RedisModule_Init(ctx, "RAI_llapi", 1, REDISMODULE_APIVER_1) ==
-	   REDISMODULE_ERR)
-		return REDISMODULE_ERR;
+    if (RedisModule_Init(ctx, "RAI_llapi", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-	if(RedisAI_Initialize(ctx) != REDISMODULE_OK)
-		RedisModule_Log(ctx, "warning",
-		  "could not initialize RedisAI api, running without AI support.");
+    if (RedisAI_Initialize(ctx) != REDISMODULE_OK)
+        RedisModule_Log(ctx, "warning",
+                        "could not initialize RedisAI api, running without AI support.");
 
-	if(RedisModule_CreateCommand(ctx, "RAI_llapi.basic_check", RAI_llapi_basic_check, "",
-	  0, 0, 0) == REDISMODULE_ERR)
-		return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "RAI_llapi.basic_check", RAI_llapi_basic_check, "", 0, 0,
+                                  0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-	if(RedisModule_CreateCommand(ctx, "RAI_llapi.modelRun", RAI_llapi_modelRun, "",
-	  0, 0, 0) == REDISMODULE_ERR)
-		return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "RAI_llapi.modelRun", RAI_llapi_modelRun, "", 0, 0, 0) ==
+        REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-	if(RedisModule_CreateCommand(ctx, "RAI_llapi.scriptRun", RAI_llapi_scriptRun, "",
-	  0, 0, 0) == REDISMODULE_ERR)
-		return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "RAI_llapi.scriptRun", RAI_llapi_scriptRun, "", 0, 0, 0) ==
+        REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
-
-    if(RedisModule_CreateCommand(ctx, "RAI_llapi.DAGRun", RAI_llapi_DAGRun, "",
-      0, 0, 0) == REDISMODULE_ERR) {
+    if (RedisModule_CreateCommand(ctx, "RAI_llapi.DAGRun", RAI_llapi_DAGRun, "", 0, 0, 0) ==
+        REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 
-    if(RedisModule_CreateCommand(ctx, "RAI_llapi.DAG_resnet", RAI_llapi_DAG_resnet, "",
-      0, 0, 0) == REDISMODULE_ERR) {
+    if (RedisModule_CreateCommand(ctx, "RAI_llapi.DAG_resnet", RAI_llapi_DAG_resnet, "", 0, 0, 0) ==
+        REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 
-	return REDISMODULE_OK;
+    return REDISMODULE_OK;
 }


### PR DESCRIPTION
- Fix dead-lock in llapi tests: need to acquire and release the lock in the "on-finish" callback to ensure that "on-finish" isn't done before the main-thread has begun waiting.

- Refactor the RunResult_ctx in dag_utils to include the mutex and condition variable instead of having them global.

- Add c-lang formatting to tests files