### PR TITLE
Introduce AI.DAGEXECUTE command, AI.DAGRUN is now deprecated.

### DIFF
--- a/src/execution/DAG/dag.c
+++ b/src/execution/DAG/dag.c
@@ -668,24 +668,23 @@ cleanup:
     return REDISMODULE_OK;
 }
 
-int RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                                    int argc) {
+int RedisAI_DagExecute_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
+                                                        RedisModuleString **argv, int argc) {
     for (size_t argpos = 1; argpos < argc; argpos++) {
-        const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
-        if ((!strcasecmp(arg_string, "LOAD") || !strcasecmp(arg_string, "PERSIST")) &&
-            (argpos + 1 < argc)) {
+        const char *arg_string = RedisModule_StringPtrLen(argv[argpos++], NULL);
+        if (!strcasecmp(arg_string, "LOAD") || !strcasecmp(arg_string, "PERSIST") ||
+            !strcasecmp(arg_string, "KEYS")) {
+            if (argpos >= argc) {
+                return REDISMODULE_ERR;
+            }
             long long n_keys;
-            argpos++;
-            const int retval = RedisModule_StringToLongLong(argv[argpos], &n_keys);
+            const int retval = RedisModule_StringToLongLong(argv[argpos++], &n_keys);
             if (retval != REDISMODULE_OK) {
                 return REDISMODULE_ERR;
             }
-            argpos++;
-            if (n_keys > 0) {
-                size_t last_persist_argpos = n_keys + argpos;
-                for (; argpos < last_persist_argpos && argpos < argc; argpos++) {
-                    RedisModule_KeyAtPos(ctx, argpos);
-                }
+            size_t last_argpos = n_keys + argpos;
+            for (; argpos < last_argpos && argpos < argc; argpos++) {
+                RedisModule_KeyAtPos(ctx, argpos);
             }
         }
     }

--- a/src/execution/DAG/dag.h
+++ b/src/execution/DAG/dag.h
@@ -144,8 +144,8 @@ int RedisAI_DagRun_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
  * @param argc Redis command number of arguments
  * @return
  */
-int RedisAI_DagRun_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                                    int argc);
+int RedisAI_DagExecute_IsKeysPositionRequest_ReportKeys(RedisModuleCtx *ctx,
+                                                        RedisModuleString **argv, int argc);
 
 /**
  * @brief This callback is called at the end of a DAG run and performs unblock client and reply.

--- a/src/execution/DAG/dag_builder.c
+++ b/src/execution/DAG/dag_builder.c
@@ -163,7 +163,7 @@ int RAI_DAGAddOpsFromString(RAI_DAGRunCtx *run_info, const char *dag, RAI_Error 
         }
     }
 
-    if (ParseDAGOps(rinfo, new_ops) != REDISMODULE_OK) {
+    if (ParseDAGExecuteOps(rinfo, new_ops, false) != REDISMODULE_OK) {
         RAI_SetError(err, RAI_GetErrorCode(rinfo->err), RAI_GetError(rinfo->err));
         goto cleanup;
     }

--- a/src/execution/command_parser.c
+++ b/src/execution/command_parser.c
@@ -35,13 +35,6 @@ int RedisAI_ExecuteCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         rinfo->dagOps = array_append(rinfo->dagOps, scriptRunOp);
         status = ParseScriptRunCommand(rinfo, scriptRunOp, argv, argc);
         break;
-    case CMD_SCRIPTEXECUTE:
-        rinfo->single_op_dag = 1;
-        RAI_DagOp *scriptExecOp;
-        RAI_InitDagOp(&scriptExecOp);
-        rinfo->dagOps = array_append(rinfo->dagOps, scriptExecOp);
-        status = ParseScriptExecuteCommand(rinfo, scriptExecOp, argv, argc);
-        break;
     case CMD_DAGRUN:
         status = ParseDAGRunCommand(rinfo, ctx, argv, argc, ro_dag);
         break;
@@ -51,6 +44,16 @@ int RedisAI_ExecuteCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         RAI_InitDagOp(&modelExecuteOp);
         rinfo->dagOps = array_append(rinfo->dagOps, modelExecuteOp);
         status = ParseModelExecuteCommand(rinfo, modelExecuteOp, argv, argc);
+        break;
+    case CMD_SCRIPTEXECUTE:
+        rinfo->single_op_dag = 1;
+        RAI_DagOp *scriptExecOp;
+        RAI_InitDagOp(&scriptExecOp);
+        rinfo->dagOps = array_append(rinfo->dagOps, scriptExecOp);
+        status = ParseScriptExecuteCommand(rinfo, scriptExecOp, argv, argc);
+        break;
+    case CMD_DAGEXECUTE:
+        status = ParseDAGExecuteCommand(rinfo, ctx, argv, argc, ro_dag);
         break;
     default:
         break;

--- a/src/execution/command_parser.h
+++ b/src/execution/command_parser.h
@@ -8,7 +8,8 @@ typedef enum RunCommand {
     CMD_SCRIPTRUN,
     CMD_DAGRUN,
     CMD_MODELEXECUTE,
-    CMD_SCRIPTEXECUTE
+    CMD_SCRIPTEXECUTE,
+    CMD_DAGEXECUTE
 } RunCommand;
 
 /**

--- a/src/execution/parsing/dag_parser.h
+++ b/src/execution/parsing/dag_parser.h
@@ -3,16 +3,17 @@
 #include "execution/run_info.h"
 
 /**
- * @brief  Parse and validate DAGRUN command (Populate the rinfo object):
- * - parse LOAD, PERSIST, and TIMEOUT args. Persist is not allowed if the DAG is READ-ONLY (dag_to
- * is true).
- * - parse and validate every DAGop individually.
+ * @brief  Parse and validate DAGEXECUTE command (Populate the rinfo object):
+ * - parse KEYS, LOAD, PERSIST, and TIMEOUT args. Persist is not allowed if the DAG is READ-ONLY
+ * (dag_to is true).
+ * - parse and validate every DAGop individually. SCRIPTEXECUTE is not allowed if the DAG is
+ * READ-ONLY.
  * - Generate a unique key for every tensor name that appear in the DAG's ops.
  * (thus ensure that the operations will be done by the desired order).
  * @return Returns REDISMODULE_OK if the command is valid, REDISMODULE_ERR otherwise.
  */
-int ParseDAGRunCommand(RedisAI_RunInfo *rinfo, RedisModuleCtx *ctx, RedisModuleString **argv,
-                       int argc, bool dag_ro);
+int ParseDAGExecuteCommand(RedisAI_RunInfo *rinfo, RedisModuleCtx *ctx, RedisModuleString **argv,
+                           int argc, bool dag_ro);
 
 /**
  * @brief Parse the arguments of the given ops in the DAGRUN command and build every op accordingly.
@@ -23,4 +24,7 @@ int ParseDAGRunCommand(RedisAI_RunInfo *rinfo, RedisModuleCtx *ctx, RedisModuleS
  * args.
  * @return Returns REDISMODULE_OK if the command is valid, REDISMODULE_ERR otherwise.
  */
-int ParseDAGOps(RedisAI_RunInfo *rinfo, RAI_DagOp **ops);
+int ParseDAGExecuteOps(RedisAI_RunInfo *rinfo, RAI_DagOp **ops, bool ro);
+
+int DAGInitialParsing(RedisAI_RunInfo *rinfo, RedisModuleCtx *ctx, RedisModuleString **argv,
+                      int argc, bool dag_ro, RAI_DagOp ***dag_ops);

--- a/src/execution/parsing/deprecated.c
+++ b/src/execution/parsing/deprecated.c
@@ -1,14 +1,17 @@
+#include <execution/DAG/dag_execute.h>
 #include "deprecated.h"
 #include "util/string_utils.h"
 #include "rmutil/args.h"
 #include "backends/backends.h"
 #include "redis_ai_objects/stats.h"
+#include "execution/DAG/dag_builder.h"
 #include "execution/utils.h"
 #include "execution/command_parser.h"
 #include "execution/background_workers.h"
 #include "execution/execution_contexts/modelRun_ctx.h"
 #include "execution/execution_contexts/scriptRun_ctx.h"
 #include "execution/parsing/parse_utils.h"
+#include "dag_parser.h"
 
 static int _ModelRunCommand_ParseArgs(RedisModuleCtx *ctx, int argc, RedisModuleString **argv,
                                       RAI_Model **model, RAI_Error *error,
@@ -488,5 +491,118 @@ cleanup:
     if (sctx) {
         RAI_ScriptRunCtxFree(sctx);
     }
+    return res;
+}
+
+int ParseDAGRunOps(RedisAI_RunInfo *rinfo, RAI_DagOp **ops) {
+
+    for (long long i = 0; i < array_len(ops); i++) {
+        RAI_DagOp *currentOp = ops[i];
+        // The first op arg is the command name.
+        const char *arg_string = RedisModule_StringPtrLen(currentOp->argv[0], NULL);
+
+        if (!strcasecmp(arg_string, "AI.TENSORGET")) {
+            currentOp->commandType = REDISAI_DAG_CMD_TENSORGET;
+            currentOp->devicestr = "CPU";
+            RAI_HoldString(currentOp->argv[1]);
+            currentOp->inkeys = array_append(currentOp->inkeys, currentOp->argv[1]);
+            currentOp->fmt = ParseTensorGetArgs(rinfo->err, currentOp->argv, currentOp->argc);
+            if (currentOp->fmt == TENSOR_NONE)
+                goto cleanup;
+            continue;
+        }
+        if (!strcasecmp(arg_string, "AI.TENSORSET")) {
+            currentOp->commandType = REDISAI_DAG_CMD_TENSORSET;
+            currentOp->devicestr = "CPU";
+            RAI_HoldString(currentOp->argv[1]);
+            currentOp->outkeys = array_append(currentOp->outkeys, currentOp->argv[1]);
+            if (RAI_parseTensorSetArgs(currentOp->argv, currentOp->argc, &currentOp->outTensor, 0,
+                                       rinfo->err) == -1)
+                goto cleanup;
+            continue;
+        }
+        if (!strcasecmp(arg_string, "AI.MODELRUN")) {
+            if (ParseModelRunCommand(rinfo, currentOp, currentOp->argv, currentOp->argc) !=
+                REDISMODULE_OK) {
+                goto cleanup;
+            }
+            continue;
+        }
+        if (!strcasecmp(arg_string, "AI.SCRIPTRUN")) {
+            if (ParseScriptRunCommand(rinfo, currentOp, currentOp->argv, currentOp->argc) !=
+                REDISMODULE_OK) {
+                goto cleanup;
+            }
+            continue;
+        }
+        if (!strcasecmp(arg_string, "AI.MODELEXECUTE")) {
+            RAI_SetError(rinfo->err, RAI_EDAGBUILDER,
+                         "AI.MODELEXECUTE"
+                         " cannot be used in deprecated AI.DAGRUN command");
+            goto cleanup;
+        }
+        if (!strcasecmp(arg_string, "AI.SCRIPTEXECUTE")) {
+            RAI_SetError(rinfo->err, RAI_EDAGBUILDER,
+                         "AI.SCRIPTEXECUTE"
+                         " cannot be used in deprecated AI.DAGRUN command");
+            goto cleanup;
+        }
+        // If none of the cases match, we have an invalid op.
+        RAI_SetError(rinfo->err, RAI_EDAGBUILDER, "Unsupported command within DAG");
+        goto cleanup;
+    }
+
+    // After validating all the ops, insert them to the DAG.
+    for (size_t i = 0; i < array_len(ops); i++) {
+        rinfo->dagOps = array_append(rinfo->dagOps, ops[i]);
+    }
+    rinfo->dagOpCount = array_len(rinfo->dagOps);
+    return REDISMODULE_OK;
+
+cleanup:
+    for (size_t i = 0; i < array_len(ops); i++) {
+        RAI_FreeDagOp(ops[i]);
+    }
+    return REDISMODULE_ERR;
+}
+
+int ParseDAGRunCommand(RedisAI_RunInfo *rinfo, RedisModuleCtx *ctx, RedisModuleString **argv,
+                       int argc, bool dag_ro) {
+
+    int res = REDISMODULE_ERR;
+    if (argc < 4) {
+        if (dag_ro) {
+            RAI_SetError(rinfo->err, RAI_EDAGBUILDER,
+                         "ERR wrong number of arguments for 'AI.DAGRUN_RO' command");
+        } else {
+            RAI_SetError(rinfo->err, RAI_EDAGBUILDER,
+                         "ERR wrong number of arguments for 'AI.DAGRUN' command");
+        }
+        return res;
+    }
+
+    // First we parse LOAD, PERSIST and TIMEOUT parts, and we collect the DAG ops' args.
+    array_new_on_stack(RAI_DagOp *, 10, dag_ops);
+    if (DAGInitialParsing(rinfo, ctx, argv, argc, dag_ro, &dag_ops) != REDISMODULE_OK) {
+        return REDISMODULE_ERR;
+    }
+
+    if (ParseDAGRunOps(rinfo, dag_ops) != REDISMODULE_OK) {
+        goto cleanup;
+    }
+    if (MapTensorsKeysToIndices(rinfo, rinfo->tensorsNamesToIndices) != REDISMODULE_OK) {
+        goto cleanup;
+    }
+    if (ValidatePersistKeys(rinfo, rinfo->tensorsNamesToIndices, rinfo->persistTensors) !=
+        REDISMODULE_OK) {
+        goto cleanup;
+    }
+
+    AI_dictRelease(rinfo->tensorsNamesToIndices);
+    rinfo->tensorsNamesToIndices = NULL;
+    res = REDISMODULE_OK;
+
+cleanup:
+    array_free(dag_ops);
     return res;
 }

--- a/src/execution/parsing/deprecated.h
+++ b/src/execution/parsing/deprecated.h
@@ -17,3 +17,26 @@ int ParseScriptRunCommand(RedisAI_RunInfo *rinfo, RAI_DagOp *currentOp, RedisMod
                           int argc);
 
 int ModelSetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+
+/**
+ * @brief Parse the arguments of the given ops in the DAGRUN command and build every op accordingly.
+ * @param rinfo The DAG run info that will be populated with the ops if they are valid.
+ * with its op,
+ * @param ops A local array of ops, where every op has an argv field that points to an
+ * array of RedisModule strings arguments, and an argc field which is the number of
+ * args.
+ * @return Returns REDISMODULE_OK if the command is valid, REDISMODULE_ERR otherwise.
+ */
+int ParseDAGRunOps(RedisAI_RunInfo *rinfo, RAI_DagOp **ops);
+
+/**
+ * @brief  Parse and validate DAGRUN command (Populate the rinfo object):
+ * - parse LOAD, PERSIST, and TIMEOUT args. Persist is not allowed if the DAG is READ-ONLY (dag_to
+ * is true).
+ * - parse and validate every DAGop individually.
+ * - Generate a unique key for every tensor name that appear in the DAG's ops.
+ * (thus ensure that the operations will be done by the desired order).
+ * @return Returns REDISMODULE_OK if the command is valid, REDISMODULE_ERR otherwise.
+ */
+int ParseDAGRunCommand(RedisAI_RunInfo *rinfo, RedisModuleCtx *ctx, RedisModuleString **argv,
+                       int argc, bool dag_ro);

--- a/src/execution/parsing/script_commands_parser.c
+++ b/src/execution/parsing/script_commands_parser.c
@@ -11,7 +11,7 @@ static bool _Script_buildInputsBySchema(RAI_ScriptRunCtx *sctx, RedisModuleStrin
     TorchScriptFunctionArgumentType *signature = RAI_ScriptRunCtxGetSignature(sctx);
     if (!signature) {
         RAI_SetError(error, RAI_ESCRIPTRUN,
-                     "Wrong function name provider to AI.SCRIPTEXECUTE command");
+                     "Wrong function name given to AI.SCRIPTEXECUTE command");
         return false;
     }
     size_t nlists = array_len(sctx->listSizes);
@@ -130,13 +130,11 @@ static int _ScriptExecuteCommand_ParseArgs(RedisModuleCtx *ctx, RedisModuleStrin
     int argpos = 3;
     bool inputsDone = false;
     bool outputsDone = false;
-    bool KeysDone = false;
     // Local input context to verify correctness.
     array_new_on_stack(RedisModuleString *, 10, inputs);
     if (keysRequired) {
         const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
         if (!strcasecmp(arg_string, "KEYS")) {
-            KeysDone = true;
             // Read key number.
             argpos++;
             if (argpos >= argc) {
@@ -179,7 +177,7 @@ static int _ScriptExecuteCommand_ParseArgs(RedisModuleCtx *ctx, RedisModuleStrin
 
     while (argpos < argc) {
         const char *arg_string = RedisModule_StringPtrLen(argv[argpos], NULL);
-        // See that no addtional KEYS scope is provided.
+        // See that no additional KEYS scope is provided.
         if (!strcasecmp(arg_string, "KEYS")) {
             RAI_SetError(error, RAI_ESCRIPTRUN,
                          "ERR Already Encountered KEYS scope in current command");
@@ -301,7 +299,8 @@ static int _ScriptExecuteCommand_ParseArgs(RedisModuleCtx *ctx, RedisModuleStrin
             continue;
         }
 
-        RAI_SetError(error, RAI_ESCRIPTRUN, "ERR Unrecongnized parameter to AI.SCRIPTEXECUTE");
+        RAI_SetError(error, RAI_ESCRIPTRUN, "ERR Unrecognized parameter to AI.SCRIPTEXECUTE");
+        RedisModule_Log(ctx, "error", "Command syntax error. Unexpected argument: %s", arg_string);
         goto cleanup;
     }
     if (argpos != argc) {

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -31,22 +31,21 @@ print("Using a max of {} iterations per test\n".format(MAX_ITERATIONS))
 # change this to make inference tests longer
 MAX_TRANSACTIONS=100
 
-def ensureSlaveSynced(con, env, timeout_ms=5000):
+
+def ensureSlaveSynced(con, env, timeout_ms=0):
     if env.useSlaves:
         # When WAIT returns, all the previous write commands
         # sent in the context of the current connection are
         # guaranteed to be received by the number of replicas returned by WAIT.
         wait_reply = con.execute_command('WAIT', '1', timeout_ms)
-        number_replicas = 0
         try:
             number_replicas = int(wait_reply)
-        # does not contain anything convertible to int
-        except ValueError as verr:
-            pass
-        # Exception occurred while converting to int
         except Exception as ex:
-            pass
-        env.assertTrue(number_replicas >= 1)
+            # Error in converting to int
+            env.debugPring(str(ex), force=True)
+            env.assertFalse(True)
+            return
+        env.assertEquals(number_replicas, 1)
 
 
 # Ensures command is sent and forced disconnect

--- a/tests/flow/tests_deprecated_commands.py
+++ b/tests/flow/tests_deprecated_commands.py
@@ -6,6 +6,7 @@ from includes import *
 python -m RLTest --test tests_deprecated_commands.py --module path/to/redisai.so
 '''
 
+
 def test_modelset_errors(env):
     if not TEST_PT:
         env.debugPrint("skipping {} since TEST_PT=0".format(sys._getframe().f_code.co_name), force=True)
@@ -316,7 +317,6 @@ def test_pytorch_scriptrun_errors(env):
         return
 
     con = env.getConnection()
-
     script = load_file_content('script.txt')
 
     ret = con.execute_command('AI.SCRIPTSET', 'ket{1}', DEVICE, 'TAG', 'asdf', 'SOURCE', script)
@@ -361,6 +361,7 @@ def test_pytorch_scriptrun_errors(env):
 
     check_error(env, con, 'AI.SCRIPTRUN', 'ket{1}', 'bar', 'INPUTS', 'OUTPUTS')
 
+
 def test_pytorch_scriptrun_variadic_errors(env):
     if not TEST_PT:
         env.debugPrint("skipping {} since TEST_PT=0".format(sys._getframe().f_code.co_name), force=True)
@@ -395,3 +396,190 @@ def test_pytorch_scriptrun_variadic_errors(env):
     check_error(env, con, 'AI.SCRIPTRUN', 'ket{$}', 'bar_variadic', 'INPUTS', '$', 'OUTPUTS')
 
     check_error_message(env, con, "Already encountered a variable size list of tensors", 'AI.SCRIPTRUN', 'ket{$}', 'bar_variadic', 'INPUTS', '$', 'a{$}', '$', 'b{$}' 'OUTPUTS')
+
+
+def test_dagrun_common_errors(env):
+    con = env.getConnection()
+
+    model_pb = load_file_content('graph.pb')
+    ret = con.execute_command('AI.MODELSET', 'm{1}', 'TF', DEVICE,
+                              'INPUTS', 'a', 'b', 'OUTPUTS', 'mul', 'BLOB', model_pb)
+    env.assertEqual(ret, b'OK')
+    script = load_file_content('script.txt')
+    ret = con.execute_command('AI.SCRIPTSET', 'script{1}', DEVICE, 'SOURCE', script)
+    env.assertEqual(ret, b'OK')
+
+    # ERR bad syntax
+    check_error_message(env, con, "Invalid DAG command",
+                        "AI.DAGRUN PERSIST 1 a{{1}} BAD_ARG")
+
+    # ERR unsupported command within DAG
+    check_error_message(env, con, "Unsupported command within DAG",
+                        "AI.DAGRUN |> AI.NOCOMMAND a{{1}} FLOAT 1 2 VALUES 5 10")
+
+    # ERR wrong number of arguments for 'AI.DAGRUN' command
+    check_error_message(env, con, "wrong number of arguments for 'AI.DAGRUN' command", "AI.DAGRUN ")
+
+    # ERR DAG with no ops
+    command = "AI.TENSORSET volatile_tensor{1} FLOAT 2 2 VALUES 5 10 5 10"
+    ret = con.execute_command(command)
+    env.assertEqual(ret, b'OK')
+    check_error_message(env, con, "DAG is empty", "AI.DAGRUN LOAD 1 volatile_tensor{1}")
+
+    # ERR non-deprecated commands in (deprecated) AI.DAGRUN
+    check_error_message(env, con, "AI.MODELEXECUTE cannot be used in deprecated AI.DAGRUN command",
+                        "AI.DAGRUN LOAD 1 volatile_tensor{1} "
+                        "|> AI.MODELEXECUTE m{1} INPUTS 2 volatile_tensor{1} volatile_tensor{1} OUTPUTS 1 output_tensor{1}")
+
+    check_error_message(env, con, "AI.SCRIPTEXECUTE cannot be used in deprecated AI.DAGRUN command",
+                        "AI.DAGRUN LOAD 1 volatile_tensor{1} "
+                        "|> AI.SCRIPTEXECUTE script{1} bar INPUTS 2 volatile_tensor{1} volatile_tensor{1} OUTPUTS 1 output_tensor{1}")
+
+    # ERR wrong number of arguments for 'AI.DAGEXECUTE_RO' command
+    check_error_message(env, con, "wrong number of arguments for 'AI.DAGRUN_RO' command", "AI.DAGRUN_RO ")
+
+    # ERR persist in not allowed in AI.DAGEXECUTE_RO
+    check_error_message(env, con, "PERSIST cannot be specified in a read-only DAG",
+                        "AI.DAGRUN_RO PERSIST 1 tensor1{{1}} |> AI.TENSORSET tensor1{{1}} FLOAT 1 2 VALUES 5 10")
+
+
+def test_dagrun_modelexecute_multidevice_resnet_ensemble_alias(env):
+    if (not TEST_TF or not TEST_PT):
+        return
+    con = env.getConnection()
+
+    model_name_0 = 'imagenet_model1:{{1}}'
+    model_name_1 = 'imagenet_model2:{{1}}'
+    script_name_0 = 'imagenet_script1:{{1}}'
+    script_name_1 = 'imagenet_script2:{{1}}'
+    inputvar = 'images'
+    outputvar = 'output'
+    image_key = 'image:{{1}}'
+    temp_key1 = 'temp_key1:{{1}}'
+    temp_key2_0 = 'temp_key2_0'
+    temp_key2_1 = 'temp_key2_1'
+    class_key_0 = 'output0:{{1}}'
+    class_key_1 = 'output1:{{1}}'
+
+    model_pb, script, labels, img = load_resnet_test_data()
+
+    device_0 = 'CPU:1'
+    device_1 = DEVICE
+
+    ret = con.execute_command('AI.MODELSET', model_name_0, 'TF', device_0,
+                              'INPUTS', inputvar,
+                              'OUTPUTS', outputvar,
+                              'BLOB', model_pb)
+    env.assertEqual(ret, b'OK')
+
+    ensureSlaveSynced(con, env)
+
+    ret = con.execute_command('AI.MODELSET', model_name_1, 'TF', device_1,
+                              'INPUTS', inputvar,
+                              'OUTPUTS', outputvar,
+                              'BLOB', model_pb)
+    env.assertEqual(ret, b'OK')
+
+    ensureSlaveSynced(con, env)
+
+    ret = con.execute_command('AI.SCRIPTSET', script_name_0, device_0, 'SOURCE', script)
+    env.assertEqual(ret, b'OK')
+
+    ensureSlaveSynced(con, env)
+
+    ret = con.execute_command('AI.SCRIPTSET', script_name_1, device_1, 'SOURCE', script)
+    env.assertEqual(ret, b'OK')
+
+    ensureSlaveSynced(con, env)
+
+    # Cannot persist class_key_1
+    check_error_message(env, con, "PERSIST key cannot be found in DAG",
+                        'AI.DAGRUN',
+                        'PERSIST', '2', class_key_0, class_key_1, '|>',
+                        'AI.TENSORSET', image_key, 'UINT8', img.shape[1], img.shape[0], 3, 'BLOB', img.tobytes(),
+                        '|>',
+                        'AI.SCRIPTRUN',  script_name_0, 'pre_process_3ch',
+                        'INPUTS', image_key,
+                        'OUTPUTS', temp_key1,
+                        '|>',
+                        'AI.MODELRUN', model_name_0,
+                        'INPUTS', temp_key1,
+                        'OUTPUTS', temp_key2_0,
+                        '|>',
+                        'AI.MODELRUN', model_name_1,
+                        'INPUTS', temp_key1,
+                        'OUTPUTS', temp_key2_1,
+                        '|>',
+                        'AI.SCRIPTRUN', script_name_1, 'ensemble',
+                        'INPUTS', temp_key2_0, temp_key2_1,
+                        'OUTPUTS', temp_key1,
+                        '|>',
+                        'AI.SCRIPTRUN', script_name_0, 'post_process',
+                        'INPUTS', temp_key1,
+                        'OUTPUTS', class_key_0)
+
+
+    try:
+        ret = con.execute_command(
+            'AI.DAGRUN',
+            'PERSIST', '1', class_key_0, '|>',
+            'AI.TENSORSET', image_key, 'UINT8', img.shape[1], img.shape[0], 3, 'BLOB', img.tobytes(),
+            '|>',
+            'AI.SCRIPTRUN',  script_name_0, 'pre_process_3ch',
+            'INPUTS', image_key,
+            'OUTPUTS', temp_key1,
+            '|>',
+            'AI.MODELRUN', model_name_0,
+            'INPUTS', temp_key1,
+            'OUTPUTS', temp_key2_0,
+            '|>',
+            'AI.MODELRUN', model_name_1,
+            'INPUTS', temp_key1,
+            'OUTPUTS', temp_key2_1,
+            '|>',
+            'AI.SCRIPTRUN', script_name_0, 'ensemble',
+            'INPUTS', temp_key2_0,
+            'OUTPUTS', temp_key1,
+            '|>',
+            'AI.SCRIPTRUN', script_name_0, 'post_process',
+            'INPUTS', temp_key1,
+            'OUTPUTS', class_key_0,
+        )
+    except Exception as e:
+        exception = e
+        env.assertEqual(type(exception), redis.exceptions.ResponseError)
+        env.assertTrue(exception.__str__().startswith("expected 2 inputs, but got only 1"))
+
+    ret = con.execute_command(
+        'AI.DAGRUN',
+        'PERSIST', '1', class_key_0,
+        '|>',
+        'AI.TENSORSET', image_key, 'UINT8', img.shape[1], img.shape[0], 3, 'BLOB', img.tobytes(),
+        '|>',
+        'AI.SCRIPTRUN',  script_name_0, 'pre_process_3ch',
+        'INPUTS', image_key,
+        'OUTPUTS', temp_key1,
+        '|>',
+        'AI.MODELRUN', model_name_0,
+        'INPUTS', temp_key1,
+        'OUTPUTS', temp_key2_0,
+        '|>',
+        'AI.MODELRUN', model_name_1,
+        'INPUTS', temp_key1,
+        'OUTPUTS', temp_key2_1,
+        '|>',
+        'AI.SCRIPTRUN', script_name_0, 'ensemble',
+        'INPUTS', temp_key2_0, temp_key2_1,
+        'OUTPUTS', temp_key1,
+        '|>',
+        'AI.SCRIPTRUN', script_name_0, 'post_process',
+        'INPUTS', temp_key1,
+        'OUTPUTS', class_key_0,
+    )
+    env.assertEqual([b'OK', b'OK', b'OK', b'OK', b'OK', b'OK'], ret)
+
+    ensureSlaveSynced(con, env)
+
+    ret = con.execute_command('AI.TENSORGET', class_key_0, 'VALUES' )
+    # tf model has 100 classes [0,999]
+    env.assertEqual(ret[0]>=0 and ret[0]<1001, True)

--- a/tests/flow/tests_withGears.py
+++ b/tests/flow/tests_withGears.py
@@ -245,7 +245,7 @@ async def DAGRun_addOpsFromString(record):
     tensors = redisAI.mgetTensorsFromKeyspace(keys)
     DAGRunner = redisAI.createDAGRunner()
     DAGRunner.Input('tensor_a', tensors[0]).Input('tensor_b', tensors[1])
-    DAGRunner.OpsFromString('|> AI.MODELRUN m{1} INPUTS tensor_a tensor_b OUTPUTS tensor_c |> AI.TENSORGET tensor_c')
+    DAGRunner.OpsFromString('|> AI.MODELEXECUTE m{1} INPUTS 2 tensor_a tensor_b OUTPUTS 1 tensor_c |> AI.TENSORGET tensor_c')
     res = await DAGRunner.Run()
     redisAI.setTensorInKey('test5_res{1}', res[0])
     return "test5_OK"

--- a/tests/module/DAG_utils.c
+++ b/tests/module/DAG_utils.c
@@ -195,15 +195,17 @@ int testBuildDAGFromString(RedisModuleCtx *ctx) {
     t = (RAI_Tensor *)_getFromKeySpace(ctx, "b{1}");
     RedisAI_DAGAddTensorSet(run_info, "input2", t);
 
-    dag_string = "|> AI.MODELRUN m{1} INPUTS input1 input2 OUTPUTS output |> bad_op no_tensor";
+    dag_string =
+        "|> AI.MODELEXECUTE m{1} INPUTS 2 input1 input2 OUTPUTS 1 output |> bad_op no_tensor";
     status = RedisAI_DAGAddOpsFromString(run_info, dag_string, run_ctx.error);
-    if (!_assertError(run_ctx.error, status, "unsupported command within DAG")) {
+    if (!_assertError(run_ctx.error, status, "Unsupported command within DAG")) {
         goto cleanup;
     }
     RedisAI_ClearError(run_ctx.error);
     RedisModule_Assert(RedisAI_DAGNumOps(run_info) == 1);
 
-    dag_string = "|> AI.MODELRUN m{1} INPUTS input1 input2 OUTPUTS output |> AI.TENSORGET output";
+    dag_string =
+        "|> AI.MODELEXECUTE m{1} INPUTS 2 input1 input2 OUTPUTS 1 output |> AI.TENSORGET output";
     if (RedisAI_DAGAddOpsFromString(run_info, dag_string, run_ctx.error) != REDISMODULE_OK) {
         goto cleanup;
     }


### PR DESCRIPTION
Add the new command according to the new design, no actual change in semantics. 
The main difference between AI.DAGRUN and AI.DAGEXECUTE is: 
1. AI.DAGEXECUTE may contain only (non-deprecated) *EXECUTE ops, while AI.DAGRUN mat contain only *RUN (deprecated) ops.
2. AI.DAGEXECUTE has KEYS section (like AI.SCRIPTEXECUTE). **At least one** out of LOAD, PERSIST, KEYS sections must appear in the command. KEYS section shouldn't appear in inner AI.SCRIPTEXCUTE commands of the DAG.
3. AI.DAGEXECUTE_RO cannot contain an inner AI.SCRIPTEXECUTE op, as it may perform write operation from within the script.

TODO: Update documentation.