### PR TITLE
docker prune between

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ commands:
 
   platforms-build-steps:
     steps:
+      - early_return_for_forked_pull_requests
       - abort_for_docs
       - checkout-all
       - relocate-docker-storage
@@ -136,9 +137,11 @@ commands:
           name: Build for platform
           command: |
             pushd opt/build/docker
+            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
             for osnick in bionic xenial; do
-                make CPU=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build
-                make GPU=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build
+                make CPU=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
+                make GPU=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
+                docker image prune -f
             done
             popd > /dev/null
             logstar=bin/artifacts/tests-logs-cpu.tgz
@@ -147,16 +150,6 @@ commands:
             if [[ -e $logstar ]]; then tar -C $logsdir -xzf $logstar; fi
             (cd bin/artifacts; tar -cf snapshots.tar snapshots/)
           no_output_timeout: 40m
-      - early_return_for_forked_pull_requests
-      - run:
-          name: Build for platform (publish)
-          command: |
-            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            cd opt/build/docker
-            for osnick in bionic xenial; do
-                make CPU=1 OSNICK=$osnick VERBOSE=1 publish
-                make GPU=1 OSNICK=$osnick VERBOSE=1 publish
-            done
       - persist_to_workspace:
           root: bin/
           paths:

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -18,7 +18,6 @@ ARG TEST=0
 
 #----------------------------------------------------------------------------------------------
 FROM redisfab/redis:${REDIS_VER}-${ARCH}-${OSNICK} AS redis
-FROM nvidia/cuda:10.2-cudnn8-devel-${OS} AS cuda_10.2
 FROM nvidia/cuda:${CUDA_VER}-devel-${OS} AS builder
 
 ARG OSNICK
@@ -35,10 +34,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 WORKDIR /build
 COPY --from=redis /usr/local/ /usr/local/
 
-COPY --from=cuda_10.2 /usr/local/cuda-10.2 /usr/local/cuda-10.2
-COPY --from=cuda_10.2 /usr/lib/x86_64-linux-gnu/libcu* /usr/lib/x86_64-linux-gnu/
-
-RUN echo export LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda-11.0/lib64:/usr/local/cuda-10.2/lib64:$LD_LIBRARY_PATH > /etc/profile.d/cuda.sh
+RUN echo export LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda-11.0/lib64:$LD_LIBRARY_PATH > /etc/profile.d/cuda.sh
 
 COPY ./opt/ opt/
 COPY ./tests/flow/test_requirements.txt tests/flow/
@@ -75,13 +71,12 @@ FROM nvidia/cuda:${CUDA_VER}-runtime-${OS}
 ARG OS
 
 RUN if [ ! -z $(command -v apt-get) ]; then apt-get -qq update; apt-get -q install -y libgomp1; fi
-RUN if [ ! -z $(command -v yum) ]; then yum install -y libgomp; fi 
+RUN if [ ! -z $(command -v yum) ]; then yum install -y libgomp; fi
 
 ENV REDIS_MODULES /usr/lib/redis/modules
 RUN mkdir -p $REDIS_MODULES/
 
 COPY --from=redis /usr/local/ /usr/local/
-COPY --from=builder /usr/local/cuda-10.2 /usr/local/cuda-10.2
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcu* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /build/install-gpu/ $REDIS_MODULES/
 

--- a/Dockerfile.gpu-test
+++ b/Dockerfile.gpu-test
@@ -17,7 +17,6 @@ ARG PACK=1
 
 #----------------------------------------------------------------------------------------------
 FROM redisfab/redis:${REDIS_VER}-${ARCH}-${OSNICK} AS redis
-FROM nvidia/cuda:10.2-cudnn8-devel-${OS} AS cuda_10.2
 FROM nvidia/cuda:${CUDA_VER}-devel-${OS} AS builder
 
 SHELL ["/bin/bash", "-c"]
@@ -28,10 +27,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 WORKDIR /build
 COPY --from=redis /usr/local/ /usr/local/
 
-COPY --from=cuda_10.2 /usr/local/cuda-10.2 /usr/local/cuda-10.2
-COPY --from=cuda_10.2 /usr/lib/x86_64-linux-gnu/libcu* /usr/lib/x86_64-linux-gnu/
-
-RUN echo export LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda-11.0/lib64:/usr/local/cuda-10.2/lib64:$LD_LIBRARY_PATH > /etc/profile.d/cuda.sh
+RUN echo export LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda-11.0/lib64:$LD_LIBRARY_PATH > /etc/profile.d/cuda.sh
 
 COPY ./opt/ opt/
 COPY ./tests/flow/test_requirements.txt tests/flow/

--- a/opt/pack.sh
+++ b/opt/pack.sh
@@ -51,7 +51,13 @@ BINDIR=$(realpath $BINDIR)
 INSTALL_DIR=$(realpath $INSTALL_DIR)
 
 $READIES/enable-utf8
-source /etc/profile.d/utf8.sh
+if [ -f /etc/profile.d/utf8.sh ]; then
+    source /etc/profile.d/utf8.sh
+else
+    echo export LC_ALL=C.UTF-8 >> /etc/profile.d/utf8.sh
+    echo export LANG=C.UTF-8 >> /etc/profile.d/utf8.sh
+    source /etc/profile.d/utf8.sh
+fi
 
 export ARCH=$($READIES/platform --arch)
 export OS=$($READIES/platform --os)


### PR DESCRIPTION
cuda 10.2, and force remove dangling images. This is in addition to pruning after. All in an attempt to reduce the size for CI.