### PR TITLE
Fix platform build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /build
 COPY --from=redis /usr/local/ /usr/local/
 
 COPY ./opt/ opt/
-COPY ./tests/flow/tests_setup/test_requirements.txt tests/flow/
+COPY ./tests/flow/tests_setup/test_requirements.txt tests/flow/tests_setup/
 
 RUN FORCE=1 ./opt/readies/bin/getpy3
 RUN ./opt/system-setup.py

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -31,7 +31,7 @@ WORKDIR /build
 COPY --from=redis /usr/local/ /usr/local/
 
 COPY ./opt/ opt/
-COPY ./tests/flow/tests_setup/test_requirements.txt tests/flow
+COPY ./tests/flow/tests_setup/test_requirements.txt tests/flow/tests_setup/
 
 RUN ./opt/readies/bin/getpy3
 RUN ./opt/system-setup.py

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -37,7 +37,7 @@ COPY --from=redis /usr/local/ /usr/local/
 RUN echo export LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda-11.0/lib64:$LD_LIBRARY_PATH > /etc/profile.d/cuda.sh
 
 COPY ./opt/ opt/
-COPY ./tests/flow/tests_setup/test_requirements.txt tests/flow/
+COPY ./tests/flow/tests_setup/test_requirements.txt tests/flow/tests_setup/
 
 RUN FORCE=1 ./opt/readies/bin/getpy3
 RUN ./opt/system-setup.py


### PR DESCRIPTION
Platform build fix after refactor tests dir (merged into master with DAG EXECUTE command PR) - the test_requirments.txt file has moved to a new dir - tests_setup. The fix is updating the destination path when copying test_requirments.txt in dockerfiles (the ones that weren't updated yet)