### PR TITLE
parallel platforms with remote dockers, matrix validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ commands:
             bash <(curl -fsSL https://get.docker.com)
             pushd opt/build/docker
             docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            make <<parameters.target>> OSNICK=<<parameters.platform>> <<parameters.lite>> ARTIFACTS=1 VERBOSE=1 build publish
+            make <<parameters.target>> OSNICK=<<parameters.osnick>> <<parameters.lite>> ARTIFACTS=1 VERBOSE=1 build publish
             popd > /dev/null
             logstar=bin/artifacts/tests-logs-cpu.tgz
             logsdir=tests/logs/cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
     parameters:
       lite:
         type: string
-      platform:
+      osnick:
         type: string
       target:
         type: string
@@ -565,7 +565,7 @@ workflows:
           <<: *on-master-and-version-tags
           matrix:
             parameters:
-              platform:
+              osnic:
                 - xenial
                 - bionic
               lite:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,8 @@ commands:
   platforms-build-matrix-steps:
     parameters:
       lite:
-        type: integer
-        default: 0
+        type: string
+        default: "LITE=1"
       platform:
         type: string
         default: "bionic"
@@ -142,36 +142,31 @@ commands:
       - abort_for_docs
       - abort_for_noci
       - early_return_for_forked_pull_requests
-#      - setup_remote_docker
-#      - checkout-all
-#      - setup-automation
+      - setup_remote_docker
+      - checkout-all
+      - setup-automation
       - run:
           name: Build for platform
           command: |
-            echo OSNICK=<<parameters.platform>> LITE=<<parameters.lite>> TARGET=<<parameters.target>>
-#            bash <(curl -fsSL https://get.docker.com)
-#            pushd opt/build/docker
-#            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-#            for osnick in bionic xenial; do
-#                make CPU=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
-#                make CPU=1 LITE=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
-#                docker image prune -f
-#            done
-#            popd > /dev/null
-#            logstar=bin/artifacts/tests-logs-cpu.tgz
-#            logsdir=tests/logs/cpu
-#            mkdir -p $logsdir
-#            if [[ -e $logstar ]]; then tar -C $logsdir -xzf $logstar; fi
-#            (cd bin/artifacts; tar -cf snapshots.tar snapshots/)
+            bash <(curl -fsSL https://get.docker.com)
+            pushd opt/build/docker
+            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
+            make <<parameters.target>> OSNICK=<<parameters.platform>> <<parameters.lite>> ARTIFACTS=1 VERBOSE=1 build publish
+            popd > /dev/null
+            logstar=bin/artifacts/tests-logs-cpu.tgz
+            logsdir=tests/logs/cpu
+            mkdir -p $logsdir
+            if [[ -e $logstar ]]; then tar -C $logsdir -xzf $logstar; fi
+            (cd bin/artifacts; tar -cf snapshots.tar snapshots/)
           no_output_timeout: 40m
-#      - persist_to_workspace:
-#          root: bin/
-#          paths:
-#            - artifacts/*.zip
-#            - artifacts/*.tgz
-#            - artifacts/*.tar
-#      - store_artifacts:
-#          path: test/logs
+      - persist_to_workspace:
+          root: bin/
+          paths:
+            - artifacts/*.zip
+            - artifacts/*.tgz
+            - artifacts/*.tar
+      - store_artifacts:
+          path: test/logs
 
   platforms-build-steps-cpu:
     steps:
@@ -301,7 +296,7 @@ jobs:
   platforms-build:
     parameters:
       lite:
-        type: integer
+        type: string
       platform:
         type: string
       target:
@@ -651,8 +646,8 @@ workflows:
           matrix:
             parameters:
               lite:
-                - 0
-                - 1
+                - "LITE=0"
+                - "LITE=1"
               target:
                 - "CPU=0"
                 - "GPU=0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,44 +127,6 @@ commands:
       - store_artifacts:
           path: tests/logs
 
-  platforms-build-matrix-steps:
-    parameters:
-      lite:
-        type: string
-      osnick:
-        type: string
-      target:
-        type: string
-    steps:
-      - abort_for_docs
-      - abort_for_noci
-      - early_return_for_forked_pull_requests
-      - setup_remote_docker
-      - checkout-all
-      - setup-automation
-      - run:
-          name: Build for platform
-          command: |
-            bash <(curl -fsSL https://get.docker.com)
-            pushd opt/build/docker
-            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            make <<parameters.target>> OSNICK=<<parameters.osnick>> <<parameters.lite>> ARTIFACTS=1 VERBOSE=1 build publish
-            popd > /dev/null
-            logstar=bin/artifacts/tests-logs-cpu.tgz
-            logsdir=tests/logs/cpu
-            mkdir -p $logsdir
-            if [[ -e $logstar ]]; then tar -C $logsdir -xzf $logstar; fi
-            (cd bin/artifacts; tar -cf snapshots.tar snapshots/)
-          no_output_timeout: 40m
-      - persist_to_workspace:
-          root: bin/
-          paths:
-            - artifacts/*.zip
-            - artifacts/*.tgz
-            - artifacts/*.tar
-      - store_artifacts:
-          path: test/logs
-
 jobs:
   lint:
     docker:
@@ -186,15 +148,13 @@ jobs:
       - build-steps:
           platform: debian
 
-  # this build runs on a fixed machine, due to a storage need
-  # nothing about it necessitates the machine itself, other than the need for more disk.
   platforms-build:
     parameters:
-      lite:
+      lite:  # LITE value during make
         type: string
-      osnick:
+      osnick:  # OSNICK value for the base platform of the docker
         type: string
-      target:
+      target:  # CPU|GPU
         type: string
     docker:
       - image: redisfab/rmbuilder:6.2.1-x64-buster
@@ -565,7 +525,7 @@ workflows:
           <<: *on-master-and-version-tags
           matrix:
             parameters:
-              osnic:
+              osnick:
                 - xenial
                 - bionic
               lite:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
     parameters:
       lite:
         type: string
-      platform:
+      osnick:
         type: string
       target:
         type: string
@@ -211,7 +211,7 @@ jobs:
             bash <(curl -fsSL https://get.docker.com)
             pushd opt/build/docker
             docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            make <<parameters.target>> OSNICK=<<parameters.platform>> <<parameters.lite>> ARTIFACTS=1 VERBOSE=1 build publish
+            make <<parameters.target>> OSNICK=<<parameters.osnick>> <<parameters.lite>> ARTIFACTS=1 VERBOSE=1 build publish
             popd > /dev/null
             logstar=bin/artifacts/tests-logs-cpu.tgz
             logsdir=tests/logs/cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,89 +165,6 @@ commands:
       - store_artifacts:
           path: test/logs
 
-  platforms-build-steps-cpu:
-    steps:
-      - abort_for_docs
-      - abort_for_noci
-      - early_return_for_forked_pull_requests
-      - setup_remote_docker
-      - checkout-all
-      - setup-automation
-      - run:
-          name: Build for platform
-          command: |
-            bash <(curl -fsSL https://get.docker.com)
-            pushd opt/build/docker
-            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            for osnick in bionic xenial; do
-                make CPU=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
-                make CPU=1 LITE=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
-                docker image prune -f
-            done
-            popd > /dev/null
-            logstar=bin/artifacts/tests-logs-cpu.tgz
-            logsdir=tests/logs/cpu
-            mkdir -p $logsdir
-            if [[ -e $logstar ]]; then tar -C $logsdir -xzf $logstar; fi
-            (cd bin/artifacts; tar -cf snapshots.tar snapshots/)
-          no_output_timeout: 40m
-      - persist_to_workspace:
-          root: bin/
-          paths:
-            - artifacts/*.zip
-            - artifacts/*.tgz
-            - artifacts/*.tar
-      - store_artifacts:
-          path: test/logs
-
-  platforms-build-steps-gpu:
-    steps:
-      - abort_for_docs
-      - abort_for_noci
-      - early_return_for_forked_pull_requests
-      - checkout-all
-      - setup-automation
-      - run:
-          name: Build for platform
-          command: |
-            pushd opt/build/docker
-            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            for osnick in bionic xenial; do
-                make GPU=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
-                make GPU=1 LITE=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
-                docker image prune -f
-            done
-            popd > /dev/null
-            logstar=bin/artifacts/tests-logs-cpu.tgz
-            logsdir=tests/logs/cpu
-            mkdir -p $logsdir
-            if [[ -e $logstar ]]; then tar -C $logsdir -xzf $logstar; fi
-            (cd bin/artifacts; tar -cf snapshots.tar snapshots/)
-          no_output_timeout: 40m
-      - persist_to_workspace:
-          root: bin/
-          paths:
-            - artifacts/*.zip
-            - artifacts/*.tgz
-            - artifacts/*.tar
-      - store_artifacts:
-          path: test/logs
-
-
-  deploy-steps:
-    parameters:
-      from:
-        type: string
-    steps:
-      - abort_for_docs
-      - abort_for_noci
-      - early_return_for_forked_pull_requests
-      - run:
-          name: Deploy to S3
-          command: |
-            du -ah --apparent-size artifacts/*
-            aws s3 cp artifacts/ s3://redismodules/$PACKAGE_NAME/ --acl public-read --recursive --exclude "*" --include "*.zip" --include "*.tgz"
-
 jobs:
   lint:
     docker:
@@ -268,25 +185,6 @@ jobs:
     steps:
       - build-steps:
           platform: debian
-
-#  # this build runs on a fixed machine, due to a storage need
-#  # nothing about it necessitates the machine itself, other than the need for more disk.
-#  platforms-build-gpu:
-#    machine:
-#      enabled: true
-#      docker_layer_caching: true
-#      resource_class: medium
-#      image: ubuntu-2004:202101-01
-#    steps:
-#      - platforms-build-steps-gpu
-
-  # this build runs on a fixed machine, due to a storage need
-  # nothing about it necessitates the machine itself, other than the need for more disk.
-  platforms-build-cpu:
-    docker:
-      - image: redisfab/rmbuilder:6.2.1-x64-buster
-    steps:
-      - platforms-build-steps-cpu
 
   # this build runs on a fixed machine, due to a storage need
   # nothing about it necessitates the machine itself, other than the need for more disk.
@@ -649,77 +547,63 @@ after-build-and-test: &after-build-and-test
 
 after-platform-builds: &after-platform-builds
   requires:
-    - platforms-build-cpu
-    - platforms-build-gpu
+    - platforms-build
 
 #### define workflows
 workflows:
   version: 2
   build_and_package:
     jobs:
-#      - platforms-build-cpu:
-#          <<: *on-any-branch
-#      - platforms-build-cpu-lite:
-#          <<: *on-any-branch
-#      - platforms-build-gpu:
-#          <<: *on-any-branch
-#      - platforms-build-gpu-lite:
-#          <<: *on-any-branch
-      - platforms-build:
+
+      - lint:
           <<: *on-any-branch
+      - build-and-test:
+          <<: *on-any-branch-but-tags
+          <<: *after-linter
+      - platforms-build:
+          <<: *after-build-and-test
+          <<: *on-master-and-version-tags
           matrix:
             parameters:
+              platform:
+                - xenial
+                - bionic
               lite:
                 - "LITE=0"
                 - "LITE=1"
               target:
                 - "CPU=1"
                 - "GPU=1"
-              platform:
-                - xenial
-                - bionic
-
-#      - lint:
-#          <<: *on-any-branch
-#      - build-and-test:
-#          <<: *on-any-branch-but-tags
-#          <<: *after-linter
-#      - platforms-build-cpu:
-#          <<: *after-build-and-test
-#          <<: *on-master-and-version-tags
-#      - platforms-build-gpu:
-#          <<: *after-build-and-test
-#          <<: *on-master-and-version-tags
-#      - coverage:
-#          context: common
-#          <<: *on-dev-branches
-#          <<: *after-linter
-#      - valgrind:
-#          name: valgrind-cluster
-#          test_args: GEN=0 AOF=0
-#          <<: *on-integ-branch
-#          <<: *after-linter
-#      - valgrind:
-#          name: valgrind-aof
-#          test_args: GEN=0 CLUSTER=0
-#          <<: *on-integ-branch
-#          <<: *after-linter
-#      - build-and-test-gpu:
-#          <<: *on-integ-branch
-#          <<: *after-linter
-#      - deploy-snapshot:
-#          context: common
-#          <<: *after-platform-builds
-#          <<: *on-integ-branch
-#      - deploy-release:
-#          context: common
-#          <<: *after-platform-builds
-#          <<: *on-version-tags
-#      - release-automation:
-#          context: common
-#          <<: *on-version-tags
-#          requires:
-#            - deploy-release
+      - coverage:
+          context: common
+          <<: *on-dev-branches
+          <<: *after-linter
+      - valgrind:
+          name: valgrind-cluster
+          test_args: GEN=0 AOF=0
+          <<: *on-integ-branch
+          <<: *after-linter
+      - valgrind:
+          name: valgrind-aof
+          test_args: GEN=0 CLUSTER=0
+          <<: *on-integ-branch
+          <<: *after-linter
+      - build-and-test-gpu:
+          <<: *on-integ-branch
+          <<: *after-linter
+      - deploy-snapshot:
+          context: common
+          <<: *after-platform-builds
+          <<: *on-integ-branch
+      - deploy-release:
+          context: common
+          <<: *after-platform-builds
+          <<: *on-version-tags
+      - release-automation:
+          context: common
+          <<: *on-version-tags
+          requires:
+            - deploy-release
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,13 +131,10 @@ commands:
     parameters:
       lite:
         type: string
-        default: "LITE=1"
       platform:
         type: string
-        default: "bionic"
       target:
         type: string
-        default: "CPU=1"
     steps:
       - abort_for_docs
       - abort_for_noci
@@ -304,7 +301,34 @@ jobs:
     docker:
       - image: redisfab/rmbuilder:6.2.1-x64-buster
     steps:
-      - platforms-build-matrix-steps
+      - abort_for_docs
+      - abort_for_noci
+      - early_return_for_forked_pull_requests
+      - setup_remote_docker
+      - checkout-all
+      - setup-automation
+      - run:
+          name: Build for platform
+          command: |
+            bash <(curl -fsSL https://get.docker.com)
+            pushd opt/build/docker
+            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
+            make <<parameters.target>> OSNICK=<<parameters.platform>> <<parameters.lite>> ARTIFACTS=1 VERBOSE=1 build publish
+            popd > /dev/null
+            logstar=bin/artifacts/tests-logs-cpu.tgz
+            logsdir=tests/logs/cpu
+            mkdir -p $logsdir
+            if [[ -e $logstar ]]; then tar -C $logsdir -xzf $logstar; fi
+            (cd bin/artifacts; tar -cf snapshots.tar snapshots/)
+          no_output_timeout: 40m
+      - persist_to_workspace:
+          root: bin/
+          paths:
+            - artifacts/*.zip
+            - artifacts/*.tgz
+            - artifacts/*.tar
+      - store_artifacts:
+          path: test/logs
 
   coverage:
     docker:
@@ -649,8 +673,8 @@ workflows:
                 - "LITE=0"
                 - "LITE=1"
               target:
-                - "CPU=0"
-                - "GPU=0"
+                - "CPU=1"
+                - "GPU=1"
               platform:
                 - xenial
                 - bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,52 @@ commands:
       - store_artifacts:
           path: tests/logs
 
+  platforms-build-matrix-steps:
+    parameters:
+      lite:
+        type: integer
+        default: 0
+      platform:
+        type: string
+        default: "bionic"
+      target:
+        type: string
+        default: "CPU=1"
+    steps:
+      - abort_for_docs
+      - abort_for_noci
+      - early_return_for_forked_pull_requests
+#      - setup_remote_docker
+#      - checkout-all
+#      - setup-automation
+      - run:
+          name: Build for platform
+          command: |
+            echo OSNICK=<<parameters.platform>> LITE=<<parameters.lite>> TARGET=<<parameters.target>>
+#            bash <(curl -fsSL https://get.docker.com)
+#            pushd opt/build/docker
+#            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
+#            for osnick in bionic xenial; do
+#                make CPU=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
+#                make CPU=1 LITE=1 OSNICK=$osnick ARTIFACTS=1 VERBOSE=1 build publish
+#                docker image prune -f
+#            done
+#            popd > /dev/null
+#            logstar=bin/artifacts/tests-logs-cpu.tgz
+#            logsdir=tests/logs/cpu
+#            mkdir -p $logsdir
+#            if [[ -e $logstar ]]; then tar -C $logsdir -xzf $logstar; fi
+#            (cd bin/artifacts; tar -cf snapshots.tar snapshots/)
+          no_output_timeout: 40m
+#      - persist_to_workspace:
+#          root: bin/
+#          paths:
+#            - artifacts/*.zip
+#            - artifacts/*.tgz
+#            - artifacts/*.tar
+#      - store_artifacts:
+#          path: test/logs
+
   platforms-build-steps-cpu:
     steps:
       - abort_for_docs
@@ -231,16 +277,16 @@ jobs:
       - build-steps:
           platform: debian
 
-  # this build runs on a fixed machine, due to a storage need
-  # nothing about it necessitates the machine itself, other than the need for more disk.
-  platforms-build-gpu:
-    machine:
-      enabled: true
-      docker_layer_caching: true
-      resource_class: medium
-      image: ubuntu-2004:202101-01
-    steps:
-      - platforms-build-steps-gpu
+#  # this build runs on a fixed machine, due to a storage need
+#  # nothing about it necessitates the machine itself, other than the need for more disk.
+#  platforms-build-gpu:
+#    machine:
+#      enabled: true
+#      docker_layer_caching: true
+#      resource_class: medium
+#      image: ubuntu-2004:202101-01
+#    steps:
+#      - platforms-build-steps-gpu
 
   # this build runs on a fixed machine, due to a storage need
   # nothing about it necessitates the machine itself, other than the need for more disk.
@@ -249,6 +295,21 @@ jobs:
       - image: redisfab/rmbuilder:6.2.1-x64-buster
     steps:
       - platforms-build-steps-cpu
+
+  # this build runs on a fixed machine, due to a storage need
+  # nothing about it necessitates the machine itself, other than the need for more disk.
+  platforms-build:
+    parameters:
+      lite:
+        type: integer
+      platform:
+        type: string
+      target:
+        type: string
+    docker:
+      - image: redisfab/rmbuilder:6.2.1-x64-buster
+    steps:
+      - platforms-build-matrix-steps
 
   coverage:
     docker:
@@ -577,47 +638,69 @@ workflows:
   version: 2
   build_and_package:
     jobs:
-      - lint:
+#      - platforms-build-cpu:
+#          <<: *on-any-branch
+#      - platforms-build-cpu-lite:
+#          <<: *on-any-branch
+#      - platforms-build-gpu:
+#          <<: *on-any-branch
+#      - platforms-build-gpu-lite:
+#          <<: *on-any-branch
+      - platforms-build:
           <<: *on-any-branch
-      - build-and-test:
-          <<: *on-any-branch-but-tags
-          <<: *after-linter
-      - platforms-build-cpu:
-          <<: *after-build-and-test
-          <<: *on-master-and-version-tags
-      - platforms-build-gpu:
-          <<: *after-build-and-test
-          <<: *on-master-and-version-tags
-      - coverage:
-          context: common
-          <<: *on-dev-branches
-          <<: *after-linter
-      - valgrind:
-          name: valgrind-cluster
-          test_args: GEN=0 AOF=0
-          <<: *on-integ-branch
-          <<: *after-linter
-      - valgrind:
-          name: valgrind-aof
-          test_args: GEN=0 CLUSTER=0
-          <<: *on-integ-branch
-          <<: *after-linter
-      - build-and-test-gpu:
-          <<: *on-integ-branch
-          <<: *after-linter
-      - deploy-snapshot:
-          context: common
-          <<: *after-platform-builds
-          <<: *on-integ-branch
-      - deploy-release:
-          context: common
-          <<: *after-platform-builds
-          <<: *on-version-tags
-      - release-automation:
-          context: common
-          <<: *on-version-tags
-          requires:
-            - deploy-release
+          matrix:
+            parameters:
+              lite:
+                - 0
+                - 1
+              target:
+                - "CPU=0"
+                - "GPU=0"
+              platform:
+                - xenial
+                - bionic
+
+#      - lint:
+#          <<: *on-any-branch
+#      - build-and-test:
+#          <<: *on-any-branch-but-tags
+#          <<: *after-linter
+#      - platforms-build-cpu:
+#          <<: *after-build-and-test
+#          <<: *on-master-and-version-tags
+#      - platforms-build-gpu:
+#          <<: *after-build-and-test
+#          <<: *on-master-and-version-tags
+#      - coverage:
+#          context: common
+#          <<: *on-dev-branches
+#          <<: *after-linter
+#      - valgrind:
+#          name: valgrind-cluster
+#          test_args: GEN=0 AOF=0
+#          <<: *on-integ-branch
+#          <<: *after-linter
+#      - valgrind:
+#          name: valgrind-aof
+#          test_args: GEN=0 CLUSTER=0
+#          <<: *on-integ-branch
+#          <<: *after-linter
+#      - build-and-test-gpu:
+#          <<: *on-integ-branch
+#          <<: *after-linter
+#      - deploy-snapshot:
+#          context: common
+#          <<: *after-platform-builds
+#          <<: *on-integ-branch
+#      - deploy-release:
+#          context: common
+#          <<: *after-platform-builds
+#          <<: *on-version-tags
+#      - release-automation:
+#          context: common
+#          <<: *on-version-tags
+#          requires:
+#            - deploy-release
 
   nightly:
     triggers:


### PR DESCRIPTION
Changing CI to build all platforms, in parallel, for the platforms build. This also makes adding more in the future relatively easy, by editing the matrix variable.  We build a matrix of matrices - and run against those, in parallel.  We're also no longer using machines to build GPU docker images - but continue to for the **build_and_test_gpu** of course.