### PR TITLE
publishing only when REDISAI_LITE=0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
             bash <(curl -fsSL https://get.docker.com)
             pushd opt/build/docker
             docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            make <<parameters.target>> OSNICK=<<parameters.osnick>> <<parameters.lite>> ARTIFACTS=1 VERBOSE=1 build publish
+            make build <<parameters.target>> OSNICK=<<parameters.osnick>> ARTIFACTS=1 VERBOSE=1 <<parameters.lite>>
             popd > /dev/null
             logstar=bin/artifacts/tests-logs-cpu.tgz
             logsdir=tests/logs/cpu
@@ -521,7 +521,7 @@ workflows:
                 - xenial
                 - bionic
               lite:
-                - "REDISAI_LITE=0"
+                - "REDISAI_LITE=0 publish"
                 - "REDISAI_LITE=1"
               target:
                 - "CPU=1"


### PR DESCRIPTION
Formerly, all of our builds were serial, and during build we tagged the docker image. Once we moved to parallel we created an instability where the last build was the last item pushed to dockerhub with the same time. In reality, we only want to publish, when we are not building REDISAI_LITE. 

This PR changes the logic in circle, so that when we build without REDISAI_LITE (i.e REDISAI_LITE=0) we also publish to dockerhub.