### PR TITLE
tag fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -575,7 +575,7 @@ workflows:
                 - xenial
                 - bionic
               lite:
-                - "REDISAI_LITE=0 publish"
+                - "REDISAI_LITE=0 publish PUSH_GENERAL=1 OFFICIAL=1"
                 - "REDISAI_LITE=1"
               target:
                 - "CPU=1"


### PR DESCRIPTION
Adding the docker tags on HEAD (i.e git tags), then fixing a force publish to dockerhub. This change is required in order to enable READIES to handle its tag + push flow.