### PR TITLE
Fix ai._modelscan and ai_scriptscan commands 

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -378,7 +378,7 @@ OK
 ```
 
 ## AI._MODELSCAN
-The **AI._MODELSCAN** command returns all the models in the database.
+The **AI._MODELSCAN** command returns all the models in the database. When using Redis open source cluster, the command shall return all the models that are stored in the local shard. 
 
 !!! warning "Experimental API"
     `AI._MODELSCAN` is an EXPERIMENTAL command that may be removed in future versions.
@@ -703,7 +703,7 @@ redis> AI.TENSORGET result VALUES
     The execution of scripts may generate intermediate tensors that are not allocated by the Redis allocator, but by whatever allocator is used in the backends (which may act on main memory or GPU memory, depending on the device), thus not being limited by `maxmemory` configuration settings of Redis.
 
 ## AI._SCRIPTSCAN
-The **AI._SCRIPTSCAN** command returns all the scripts in the database.
+The **AI._SCRIPTSCAN** command returns all the scripts in the database. When using Redis open source cluster, the command shall return all the scripts that are stored in the local shard. 
 
 !!! warning "Experimental API"
     `AI._SCRIPTSCAN` is an EXPERIMENTAL command that may be removed in future versions.

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -1375,7 +1375,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "ai._modelscan", RedisAI_ModelScan_RedisCommand, "readonly",
-                                  1, 1, 1) == REDISMODULE_ERR)
+                                  0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "ai.scriptset", RedisAI_ScriptSet_RedisCommand,
@@ -1387,7 +1387,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "ai.scriptget", RedisAI_ScriptGet_RedisCommand, "readonly",
-                                  1, 1, 1) == REDISMODULE_ERR)
+                                  0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "ai.scriptdel", RedisAI_ScriptDel_RedisCommand, "write", 1,


### PR DESCRIPTION
Change these commands registration so they will work on enterprise: since these commands has no arguments except from the command name, the indices mentioned in `RedisModule_CreateCommand` call must be 0.
Add a further documentation that explains that these commands will only return the models/scripts saved in the local shard.