### PR TITLE
Fix clusterdown failure

### DIFF
--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -248,4 +248,12 @@ def get_info_section(con, section):
 
 
 def get_connection(env, routing_hint):
+
+    # When running in cluster env, if a shard is not responsive for too long, it is marked as down by the other shards.
+    # Hence, we increase this timeout (for all shards) when running valgrind on cluster
+    if VALGRIND and env.isCluster():
+        connections_list = env.getOSSMasterNodesConnectionList()
+        for con in connections_list:
+            con.execute_command('CONFIG', 'set', 'cluster-node-timeout', '60000')
+
     return env.getConnectionByKey(routing_hint, None)

--- a/tests/flow/includes.py
+++ b/tests/flow/includes.py
@@ -248,12 +248,4 @@ def get_info_section(con, section):
 
 
 def get_connection(env, routing_hint):
-
-    # When running in cluster env, if a shard is not responsive for too long, it is marked as down by the other shards.
-    # Hence, we increase this timeout (for all shards) when running valgrind on cluster
-    if VALGRIND and env.isCluster():
-        connections_list = env.getOSSMasterNodesConnectionList()
-        for con in connections_list:
-            con.execute_command('CONFIG', 'set', 'cluster-node-timeout', '60000')
-
     return env.getConnectionByKey(routing_hint, None)

--- a/tests/flow/tests_setup/tests.sh
+++ b/tests/flow/tests_setup/tests.sh
@@ -74,7 +74,8 @@ valgrind_config() {
 
 	RLTEST_ARGS+="\
 		--use-valgrind \
-		--vg-suppressions $VALGRIND_SUPRESSIONS"
+		--vg-suppressions $VALGRIND_SUPRESSIONS
+		--cluster_node_timeout 60000"
 }
 
 valgrind_summary() {


### PR DESCRIPTION
When running in cluster env, if a shard is not responsive for too long, it is marked as down by the other shards. In some cases, the shard that was marked as down will consider the cluster as down before it is executing a command - and then it will fail. 
Hence, we increase this timeout (for all shards) when running valgrind on cluster