### PR TITLE
added -fcommon to compile flag for gcc10 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ ENDIF()
 
 #----------------------------------------------------------------------------------------------
 
-SET(CMAKE_CC_COMMON_FLAGS "-fPIC")
+SET(CMAKE_CC_COMMON_FLAGS "-fPIC -fcommon")
 IF (USE_PROFILE)
     SET(CMAKE_CC_COMMON_FLAGS "${CMAKE_CC_COMMON_FLAGS} -g -ggdb -fno-omit-frame-pointer")
 ENDIF()


### PR DESCRIPTION
This PR adds `-fcommon` to gcc compile flag, to avoid errors on multiple definitions of the same variable.
see https://gcc.gnu.org/gcc-10/porting_to.html
however, this is just a workaround and we should have a proper, in-depth solution