### PR TITLE
support redis 6

### DIFF
--- a/ramp-light.yml
+++ b/ramp-light.yml
@@ -6,7 +6,7 @@ homepage: https://oss.redislabs.com/redisai/
 license: Redis Source Available License v1.0
 command_line_args: "BACKENDSPATH /var/opt/redislabs/modules/ai-light/{{NUMVER}}/deps"
 # command_line_args: "BACKENDSPATH /var/opt/redislabs/modules/ai/{{NUMVER}}/deps/backends"
-min_redis_version: "5.0.7"
+min_redis_version: "6.0.0"
 min_redis_pack_version: "6.0.12"
 capabilities:
     - types

--- a/ramp-rce.yml
+++ b/ramp-rce.yml
@@ -6,7 +6,7 @@ homepage: https://oss.redislabs.com/redisai/
 license: Redis Source Available License v1.0
 command_line_args: "BACKENDSPATH /var/opt/redislabs/modules/ai-light/{{NUMVER}}/deps"
 # command_line_args: "BACKENDSPATH /var/opt/redislabs/modules/ai/{{NUMVER}}/deps/backends"
-min_redis_version: "5.0.7"
+min_redis_version: "6.0.0"
 min_redis_pack_version: "6.0.12"
 capabilities:
     - types

--- a/ramp.yml
+++ b/ramp.yml
@@ -6,7 +6,7 @@ homepage: https://oss.redislabs.com/redisai/
 license: Redis Source Available License v1.0
 command_line_args: "BACKENDSPATH /var/opt/redislabs/modules/ai/{{NUMVER}}/deps"
 # command_line_args: "BACKENDSPATH /var/opt/redislabs/modules/ai/{{NUMVER}}/deps/backends"
-min_redis_version: "5.0.7"
+min_redis_version: "6.0.0"
 min_redis_pack_version: "6.2.2"
 capabilities:
     - types

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -1281,17 +1281,14 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                         rlecMajorVersion, rlecMinorVersion, rlecPatchVersion, rlecBuild);
     }
 
-    if (redisMajorVersion < 5 ||
-        (redisMajorVersion == 5 && redisMinorVersion == 0 && redisPatchVersion < 7)) {
+    if (redisMajorVersion < 6) {
         RedisModule_Log(ctx, "warning",
-                        "RedisAI requires Redis version equal or greater than 5.0.7");
+                        "RedisAI requires Redis version equal or greater than 6.0.0");
         return REDISMODULE_ERR;
     }
 
-    if (redisMajorVersion >= 6) {
-        if (RedisModule_RegisterInfoFunc(ctx, RAI_moduleInfoFunc) == REDISMODULE_ERR)
-            return REDISMODULE_ERR;
-    }
+    if (RedisModule_RegisterInfoFunc(ctx, RAI_moduleInfoFunc) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
 
     RedisModule_Log(ctx, "notice", "RedisAI version %d, git_sha=%s", REDISAI_MODULE_VERSION,
                     REDISAI_GIT_SHA);


### PR DESCRIPTION
This PR limits support for Redis 6 and above.
Affected versions: 1.2 (will be merge into 1.2.5)
Closes #831