### PR TITLE
Fix device name validation in "modelstore" command

### DIFF
--- a/src/backends/util.c
+++ b/src/backends/util.c
@@ -1,21 +1,24 @@
+#include <stdlib.h>
+#include <errno.h>
 #include "backends/util.h"
 
-int parseDeviceStr(const char *devicestr, RAI_Device *device, int64_t *deviceid) {
-    // if (strcasecmp(devicestr, "CPU") == 0) {
-    if (strncasecmp(devicestr, "CPU", 3) == 0) {
+int parseDeviceStr(const char *device_str, RAI_Device *device, int64_t *device_id) {
+    if (strncasecmp(device_str, "CPU", 3) == 0) {
         *device = RAI_DEVICE_CPU;
-        *deviceid = -1;
-    } else if (strcasecmp(devicestr, "GPU") == 0) {
+        *device_id = -1;
+    } else if (strcasecmp(device_str, "GPU") == 0) {
         *device = RAI_DEVICE_GPU;
-        *deviceid = -1;
-    } else if (strncasecmp(devicestr, "GPU:", 4) == 0) {
+        *device_id = -1;
+    } else if (strncasecmp(device_str, "GPU:", 4) == 0) {
         *device = RAI_DEVICE_GPU;
-        long long id;
-        sscanf(devicestr, "GPU:%lld", &id);
-        *deviceid = id;
+        // Convert the id string into a number, returns zero if no valid conversion could be
+        // preformed, and sets errno in case of overflow.
+        long long id = strtoll(device_str + 4, NULL, 0);
+        if (errno == ERANGE)
+            return 0;
+        *device_id = id;
     } else {
         return 0;
     }
-
     return 1;
 }

--- a/src/backends/util.h
+++ b/src/backends/util.h
@@ -6,4 +6,4 @@
 
 #include "config/config.h"
 
-int parseDeviceStr(const char *devicestr, RAI_Device *device, int64_t *deviceid);
+int parseDeviceStr(const char *device_str, RAI_Device *device, int64_t *device_id);

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -173,12 +173,14 @@ int RedisAI_ModelStore_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **arg
     const char *devicestr;
     AC_GetString(&ac, &devicestr, NULL, 0);
     bool valid_device = false;
+    size_t device_prefix_len = strlen("GPU:"); // can also be "CPU:"
     if (strcasecmp(devicestr, "CPU") == 0 || strcasecmp(devicestr, "GPU") == 0) {
         valid_device = true;
-    } else if ((strncasecmp(devicestr, "GPU:", 4) == 0 || strncasecmp(devicestr, "CPU:", 4) == 0) &&
-               strlen(devicestr) <= 10) {
+    } else if ((strncasecmp(devicestr, "GPU:", device_prefix_len) == 0 ||
+                strncasecmp(devicestr, "CPU:", device_prefix_len) == 0) &&
+               strlen(devicestr) < 10) {
         bool digits_only = true;
-        for (size_t i = 5; i < strlen(devicestr); i++) {
+        for (size_t i = device_prefix_len; i < strlen(devicestr); i++) {
             if (devicestr[i] < '0' || devicestr[i] > '9') {
                 digits_only = false;
                 break;

--- a/tests/flow/tests_commands.py
+++ b/tests/flow/tests_commands.py
@@ -19,13 +19,22 @@ def test_modelstore_errors(env):
     con = get_connection(env, '{1}')
     model_pb = load_file_content('pt-minimal.pt')
 
-    # Check that the basic arguments are valid (model's key, device, backend, blob)
+    # Check the validity of backend name and number of arguments
     check_error_message(env, con, "wrong number of arguments for 'AI.MODELSTORE' command",
                         'AI.MODELSTORE', 'm{1}', 'TORCH', 'BLOB', model_pb)
     check_error_message(env, con, "unsupported backend",
                         'AI.MODELSTORE', 'm{1}', 'PORCH', DEVICE, 'BLOB', model_pb)
+
+    # Check for valid device argument (should only be "CPU:<n>" or "GPU:<n>, where <n> is a number
+    # (contains digits only, up to 5).
     check_error_message(env, con, "Invalid DEVICE",
                         'AI.MODELSTORE', 'm{1}', 'TORCH', 'bad_device', 'BLOB', model_pb)
+    check_error_message(env, con, "Invalid DEVICE",
+                        'AI.MODELSTORE', 'm{1}', 'TORCH', 'CPU::', 'BLOB', model_pb)
+    check_error_message(env, con, "Invalid DEVICE",
+                        'AI.MODELSTORE', 'm{1}', 'TORCH', 'CPU:1.8', 'BLOB', model_pb)
+    check_error_message(env, con, "Invalid DEVICE",
+                        'AI.MODELSTORE', 'm{1}', 'TORCH', 'CPU:123456', 'BLOB', model_pb)
 
     # Check for validity of batching arguments.
     check_error_message(env, con, "Invalid argument for BATCHSIZE",


### PR DESCRIPTION
The fifth character was not validated.
Also, for scriptstore and the deprecated modelset and scriptset, the only validation occurs in `parseDeviceStr` (which is from within the backends, after parsing stage). This PR replaces `sscanf` with `strtoll` in `parseDeviceStr`, to have safe exit in case of invalid device id string in these commands.