### PR TITLE
Fix to support AI-LIGHT with redis 6.0.6

### DIFF
--- a/src/execution/DAG/dag.c
+++ b/src/execution/DAG/dag.c
@@ -39,6 +39,7 @@
 #include "util/dict.h"
 #include "util/queue.h"
 #include "util/string_utils.h"
+#include "execution/utils.h"
 #include "execution/run_info.h"
 #include "execution/background_workers.h"
 #include "execution/parsing/dag_parser.h"
@@ -685,9 +686,11 @@ void DAG_ReplyAndUnblock(RedisAI_OnFinishCtx *ctx, void *private_data) {
 
     RedisAI_RunInfo *rinfo = (RedisAI_RunInfo *)ctx;
     if (rinfo->client) {
-        if (RedisModule_GetServerVersion() >=
-            0x060200) { // The following command is supported only from redis 6.2
-            RedisModule_BlockedClientMeasureTimeEnd(rinfo->client);
+        int redis_version[3];
+        getRedisVersion(redis_version);
+        if (redis_version[0] >= 6 &&
+            redis_version[1] >= 2) { // The following command is supported only from redis 6.2
+            RedisModule_BlockedClientMeasureTimeStart(rinfo->client);
         }
         RedisModule_UnblockClient(rinfo->client, rinfo);
     }

--- a/src/execution/DAG/dag.c
+++ b/src/execution/DAG/dag.c
@@ -686,11 +686,11 @@ void DAG_ReplyAndUnblock(RedisAI_OnFinishCtx *ctx, void *private_data) {
 
     RedisAI_RunInfo *rinfo = (RedisAI_RunInfo *)ctx;
     if (rinfo->client) {
-        int redis_version[3];
-        getRedisVersion(redis_version);
-        if (redis_version[0] >= 6 &&
-            redis_version[1] >= 2) { // The following command is supported only from redis 6.2
-            RedisModule_BlockedClientMeasureTimeStart(rinfo->client);
+        int major, minor, patch;
+        RedisAI_GetRedisVersion(&major, &minor, &patch);
+        // The following command is supported only from redis 6.2
+        if (major > 6 || (major == 6 && minor >= 2)) {
+            RedisModule_BlockedClientMeasureTimeEnd(rinfo->client);
         }
         RedisModule_UnblockClient(rinfo->client, rinfo);
     }

--- a/src/execution/command_parser.c
+++ b/src/execution/command_parser.c
@@ -72,10 +72,10 @@ int RedisAI_ExecuteCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         RedisModule_UnblockClient(rinfo->client, rinfo);
         return REDISMODULE_ERR;
     }
-    int redis_version[3];
-    getRedisVersion(redis_version);
-    if (redis_version[0] >= 6 &&
-        redis_version[1] >= 2) { // The following command is supported only from redis 6.2
+    int major, minor, patch;
+    RedisAI_GetRedisVersion(&major, &minor, &patch);
+    // The following command is supported only from redis 6.2
+    if (major > 6 || (major == 6 && minor >= 2)) {
         RedisModule_BlockedClientMeasureTimeStart(rinfo->client);
     }
     return REDISMODULE_OK;

--- a/src/execution/command_parser.c
+++ b/src/execution/command_parser.c
@@ -1,5 +1,6 @@
 #include "command_parser.h"
 #include "redismodule.h"
+#include "execution/utils.h"
 #include "execution/run_info.h"
 #include "execution/DAG/dag.h"
 #include "execution/parsing/dag_parser.h"
@@ -71,8 +72,10 @@ int RedisAI_ExecuteCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         RedisModule_UnblockClient(rinfo->client, rinfo);
         return REDISMODULE_ERR;
     }
-    if (RedisModule_GetServerVersion() >=
-        0x060200) { // The following command is supported only from redis 6.2
+    int redis_version[3];
+    getRedisVersion(redis_version);
+    if (redis_version[0] >= 6 &&
+        redis_version[1] >= 2) { // The following command is supported only from redis 6.2
         RedisModule_BlockedClientMeasureTimeStart(rinfo->client);
     }
     return REDISMODULE_OK;

--- a/src/execution/utils.c
+++ b/src/execution/utils.c
@@ -10,7 +10,7 @@ int rlecMinorVersion;
 int rlecPatchVersion;
 int rlecBuild;
 
-void getRedisVersion() {
+void setRedisVersion() {
     RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
     RedisModuleCallReply *reply = RedisModule_Call(ctx, "info", "c", "server");
     assert(RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_STRING);
@@ -37,6 +37,12 @@ void getRedisVersion() {
 
     RedisModule_FreeCallReply(reply);
     RedisModule_FreeThreadSafeContext(ctx);
+}
+
+void getRedisVersion(int *version_holder) {
+    version_holder[0] = redisMajorVersion;
+    version_holder[1] = redisMinorVersion;
+    version_holder[2] = redisPatchVersion;
 }
 
 bool IsEnterprise() { return rlecMajorVersion != -1; }

--- a/src/execution/utils.c
+++ b/src/execution/utils.c
@@ -10,7 +10,7 @@ int rlecMinorVersion;
 int rlecPatchVersion;
 int rlecBuild;
 
-void setRedisVersion() {
+void RedisAI_SetRedisVersion() {
     RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
     RedisModuleCallReply *reply = RedisModule_Call(ctx, "info", "c", "server");
     assert(RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_STRING);
@@ -39,10 +39,10 @@ void setRedisVersion() {
     RedisModule_FreeThreadSafeContext(ctx);
 }
 
-void getRedisVersion(int *version_holder) {
-    version_holder[0] = redisMajorVersion;
-    version_holder[1] = redisMinorVersion;
-    version_holder[2] = redisPatchVersion;
+void RedisAI_GetRedisVersion(int *major, int *minor, int *patch) {
+    *major = redisMajorVersion;
+    *minor = redisMinorVersion;
+    *patch = redisPatchVersion;
 }
 
 bool IsEnterprise() { return rlecMajorVersion != -1; }

--- a/src/execution/utils.h
+++ b/src/execution/utils.h
@@ -11,7 +11,13 @@ bool VerifyKeyInThisShard(RedisModuleCtx *ctx, RedisModuleString *key_str);
 /**
  * Use this function when loading the model. Stores the version in global variables.
  */
-void getRedisVersion();
+void setRedisVersion();
+
+/**
+ * Returns redis version in the pre-allocated version_holder array as following: (major, minor,
+ * patch).
+ */
+void getRedisVersion(int *version_holder);
 
 /**
  * Returns true if Redis is running in enterprise mode.

--- a/src/execution/utils.h
+++ b/src/execution/utils.h
@@ -11,13 +11,12 @@ bool VerifyKeyInThisShard(RedisModuleCtx *ctx, RedisModuleString *key_str);
 /**
  * Use this function when loading the model. Stores the version in global variables.
  */
-void setRedisVersion();
+void RedisAI_SetRedisVersion();
 
 /**
- * Returns redis version in the pre-allocated version_holder array as following: (major, minor,
- * patch).
+ * Returns redis version in the major, minor, and patch placeholders.
  */
-void getRedisVersion(int *version_holder);
+void RedisAI_GetRedisVersion(int *major, int *minor, int *patch);
 
 /**
  * Returns true if Redis is running in enterprise mode.

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -1274,7 +1274,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 #endif
 
-    setRedisVersion();
+    RedisAI_SetRedisVersion();
     RedisModule_Log(ctx, "notice", "Redis version found by RedisAI: %d.%d.%d - %s",
                     redisMajorVersion, redisMinorVersion, redisPatchVersion,
                     IsEnterprise() ? "enterprise" : "oss");

--- a/src/redisai.c
+++ b/src/redisai.c
@@ -1274,7 +1274,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 #endif
 
-    getRedisVersion();
+    setRedisVersion();
     RedisModule_Log(ctx, "notice", "Redis version found by RedisAI: %d.%d.%d - %s",
                     redisMajorVersion, redisMinorVersion, redisPatchVersion,
                     IsEnterprise() ? "enterprise" : "oss");


### PR DESCRIPTION
Add `getRedisVersion` util, and use it instead of RM_getServerVersion which is not supported in old versions.