### PR TITLE
MOD-2082 Add intershard_tls_pass support

### DIFF
--- a/ramp.yml
+++ b/ramp.yml
@@ -18,6 +18,7 @@ capabilities:
     - clustering
     - backup_restore
     - intershard_tls
+    - intershard_tls_pass
 exclude_commands:
     - ai.modelstore
     - ai.modelset


### PR DESCRIPTION
RedisAI supports intershard_tls_pass by default since it doesn't have cross shards communication