### PR TITLE
Use debug symbols

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -586,7 +586,7 @@ workflows:
           <<: *after-linter
       - platforms-build-cpu:
           context: common
-          <<: *on-any-branch
+          <<: *on-dev-branches
           <<: *after-build-and-test
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,16 +139,16 @@ commands:
           key: v1.2.5-deps-{{ checksum "get_deps.sh" }}-cpu
       - run:
           name: Build
-          command: make -C opt all SHOW=1
+          command: make -C opt all SHOW=1 DEBUG=1
       - run:
           name: Test
           command: |
-            make -C opt test SHOW=1
+            make -C opt test SHOW=1 DEBUG=1
           no_output_timeout: 20m
       - run:
           name: Package
           command: |
-            make -C opt pack SHOW=1
+            make -C opt pack SHOW=1 DEBUG=1
             (cd bin/artifacts; tar -cf snapshots-<<parameters.platform>>.tar snapshots/)
       - persist_to_workspace:
           root: bin/
@@ -586,8 +586,8 @@ workflows:
           <<: *after-linter
       - platforms-build-cpu:
           context: common
+          <<: *on-any-branch
           <<: *after-build-and-test
-          <<: *on-master-version-tags-and-dockertests
           matrix:
             parameters:
               osnick:
@@ -624,7 +624,7 @@ workflows:
       - deploy-snapshot:
           context: common
           <<: *after-platform-builds
-          <<: *on-master-version-tags-and-dockertests
+          <<: *on-any-branch
       - deploy-release:
           context: common
           <<: *after-platform-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,16 +139,16 @@ commands:
           key: v1.2.5-deps-{{ checksum "get_deps.sh" }}-cpu
       - run:
           name: Build
-          command: make -C opt all SHOW=1 DEBUG=1
+          command: make -C opt all SHOW=1
       - run:
           name: Test
           command: |
-            make -C opt test SHOW=1 DEBUG=1
+            make -C opt test SHOW=1
           no_output_timeout: 20m
       - run:
           name: Package
           command: |
-            make -C opt pack SHOW=1 DEBUG=1
+            make -C opt pack SHOW=1
             (cd bin/artifacts; tar -cf snapshots-<<parameters.platform>>.tar snapshots/)
       - persist_to_workspace:
           root: bin/
@@ -579,7 +579,7 @@ workflows:
           <<: *on-any-branch
           <<: *after-linter
       - build-and-test-gpu:
-          <<: *on-any-branch
+          <<: *on-integ-branch
           <<: *after-linter
       - build-and-test-gpu-for-forked-prs:
           <<: *on-any-branch
@@ -587,7 +587,7 @@ workflows:
       - platforms-build-cpu:
           context: common
           <<: *after-build-and-test
-          <<: *on-any-branch
+          <<: *on-master-version-tags-and-dockertests
           matrix:
             parameters:
               osnick:
@@ -600,7 +600,7 @@ workflows:
       - platforms-build-gpu:
           context: common
           <<: *after-build-and-test
-          <<: *on-any-branch
+          <<: *on-master-version-tags-and-dockertests
           matrix:
             parameters:
               osnick:
@@ -624,7 +624,7 @@ workflows:
       - deploy-snapshot:
           context: common
           <<: *after-platform-builds
-          <<: *on-any-branch
+          <<: *on-master-version-tags-and-dockertests
       - deploy-release:
           context: common
           <<: *after-platform-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -586,8 +586,8 @@ workflows:
           <<: *after-linter
       - platforms-build-cpu:
           context: common
-          <<: *on-dev-branches
           <<: *after-build-and-test
+          <<: *on-any-branch
           matrix:
             parameters:
               osnick:
@@ -600,7 +600,7 @@ workflows:
       - platforms-build-gpu:
           context: common
           <<: *after-build-and-test
-          <<: *on-master-version-tags-and-dockertests
+          <<: *on-any-branch
           matrix:
             parameters:
               osnick:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,7 +579,7 @@ workflows:
           <<: *on-any-branch
           <<: *after-linter
       - build-and-test-gpu:
-          <<: *on-integ-branch
+          <<: *on-any-branch
           <<: *after-linter
       - build-and-test-gpu-for-forked-prs:
           <<: *on-any-branch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@ ENDIF()
 
 #----------------------------------------------------------------------------------------------
 
-SET(CMAKE_CC_COMMON_FLAGS "-fPIC -fcommon")
+SET(CMAKE_CC_COMMON_FLAGS "-fPIC -fcommon -g -ggdb")
 IF (USE_PROFILE)
-    SET(CMAKE_CC_COMMON_FLAGS "${CMAKE_CC_COMMON_FLAGS} -g -ggdb -fno-omit-frame-pointer")
+    SET(CMAKE_CC_COMMON_FLAGS "${CMAKE_CC_COMMON_FLAGS} -fno-omit-frame-pointer")
 ENDIF()
 
 IF (USE_COVERAGE)
@@ -42,7 +42,7 @@ set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 
 # Add -fno-omit-frame-pointer to avoid seeing incomplete stack traces
-set(CMAKE_COMMON_FLAGS_DEBUG "-g -ggdb -fno-omit-frame-pointer -D_DEBUG -DVALGRIND -include \
+set(CMAKE_COMMON_FLAGS_DEBUG "-fno-omit-frame-pointer -D_DEBUG -DVALGRIND -include \
     ${CMAKE_CURRENT_SOURCE_DIR}/src/config/gdb_config.h -I${CMAKE_CURRENT_SOURCE_DIR}/opt")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${CMAKE_COMMON_FLAGS_DEBUG}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_COMMON_FLAGS_DEBUG}")


### PR DESCRIPTION
Add `-g` and `-ggdb` flags to the compiler, so we have the ability to get the debug symbols using gdb from the module's binary in production.