### PR TITLE
Update ORT_ARCH for Mac OS X

### DIFF
--- a/get_deps.sh
+++ b/get_deps.sh
@@ -234,7 +234,7 @@ if [[ $OS == linux ]]; then
     fi
 elif [[ $OS == macos ]]; then
     ORT_OS=osx
-    ORT_ARCH=x64
+    ORT_ARCH=x86_64
     ORT_BUILD=""
     ORT_URL_BASE=https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}
 fi


### PR DESCRIPTION
As of v1.10.0 of the ONNX Runtime, Microsoft changed the string associated with the processor architecture in the name of the Mac OS X release tarball. The variable ORT_ARCH now correctly specifies x86_64 instead of x64, allowing Mac OS X users to retrieve the necessary dependency.