### PR TITLE
Relocate docker data root dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -592,8 +592,6 @@ workflows:
   version: 2
   build_and_package:
     jobs:
-      - docker-purge:
-          <<: *on-any-branch
       - lint:
           <<: *on-any-branch
       - build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,7 +597,7 @@ workflows:
           <<: *on-any-branch
           <<: *after-linter
       - build-and-test-gpu:
-          <<: *on-any-branch
+          <<: *on-integ-branch
           <<: *after-linter
       - build-and-test-gpu-for-forked-prs:
           <<: *on-any-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ commands:
       - restore_cache:
           keys:
             - v1.2-tests_data-gpu
-      - relocate-docker-storage
+      - relocate-docker-data-root
       - run:
           name: Build
           command: |
@@ -307,7 +307,7 @@ jobs:
       - abort_for_noci
       - early_return_for_forked_pull_requests
       - checkout-all
-      - relocate-docker-storage
+      - relocate-docker-data-root
       - restore_cache:
           keys:
           - v1.2.5-deps-{{ checksum "get_deps.sh" }}-<<parameters.osnick>>-<<parameters.target>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,8 +598,7 @@ workflows:
           <<: *on-any-branch
           <<: *after-linter
       - build-and-test-gpu:
-          #@@<<: *on-integ-branch
-          <<: *always
+          <<: *on-integ-branch
           <<: *after-linter
       - build-and-test-gpu-for-forked-prs:
           <<: *on-any-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 commands:
-
   abort_for_valgrind:
     steps:
       - run:
@@ -523,6 +522,13 @@ on-any-branch-but-tags: &on-any-branch-but-tags
     tags:
       ignore: /.*/
 
+always: &always
+  filters:
+    branches:
+      only: /.*/
+    tags:
+      only: /.*/
+
 never: &never
   filters:
     branches:
@@ -590,14 +596,14 @@ workflows:
   version: 2
   build_and_package:
     jobs:
-
       - lint:
           <<: *on-any-branch
       - build-and-test:
           <<: *on-any-branch
           <<: *after-linter
       - build-and-test-gpu:
-          <<: *on-integ-branch
+          #@@<<: *on-integ-branch
+          <<: *always
           <<: *after-linter
       - build-and-test-gpu-for-forked-prs:
           <<: *on-any-branch
@@ -614,7 +620,6 @@ workflows:
               lite:
                 - "REDISAI_LITE=0 PUBLISH=1"
                 - "REDISAI_LITE=1"
-
       - platforms-build-gpu:
           context: common
           <<: *after-build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,14 @@ commands:
           path: /home/circleci/tests
 
 jobs:
+  docker-purge:
+    docker:  
+      - image: cimg/base:2020.01  
+    parallelism: 50
+    steps:
+      - setup_remote_docker
+      - run: docker volume prune -f
+
   lint:
     docker:
       - image: redisfab/rmbuilder:6.2.5-x64-bullseye

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ commands:
   relocate-docker-data-root:
     description: >-
       Relocates docker data root from /var/lib/docker/ cause it allocated in a partition too small to contain the redisai-gpu image.
-      This could have parallelization consequences if everything lines up.
     steps:
       - run:
           name: Relocate docker data root dir
@@ -66,7 +65,6 @@ commands:
             sudo systemctl stop docker
             sudo mkdir -p /var2/lib/docker
             echo '{ "data-root": "/var2/lib/docker" }' | sudo tee /etc/docker/daemon.json
-            sudo cp -axT /var/lib/docker /var2/lib/docker
             sudo systemctl start docker
 
   setup-automation:
@@ -233,14 +231,6 @@ commands:
           path: /home/circleci/tests
 
 jobs:
-  docker-purge:
-    docker:  
-      - image: cimg/base:2020.01  
-    parallelism: 50
-    steps:
-      - setup_remote_docker
-      - run: docker system prune --all -f
-
   lint:
     docker:
       - image: redisfab/rmbuilder:6.2.5-x64-bullseye
@@ -416,7 +406,6 @@ jobs:
   build-and-test-gpu:
     machine:
       enabled: true
-      docker_layer_caching: true
       resource_class: gpu.nvidia.small
       image: ubuntu-2004-cuda-11.2:202103-01
 
@@ -428,7 +417,6 @@ jobs:
   build-and-test-gpu-for-forked-prs:
     machine:
       enabled: true
-      docker_layer_caching: true
       resource_class: gpu.nvidia.small
       image: ubuntu-2004-cuda-11.2:202103-01
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,6 +604,8 @@ workflows:
   version: 2
   build_and_package:
     jobs:
+      - docker-purge:
+          <<: *on-any-branch
       - lint:
           <<: *on-any-branch
       - build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
     parallelism: 50
     steps:
       - setup_remote_docker
-      - run: docker volume prune -f
+      - run: docker system prune --all -f
 
   lint:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,20 +56,18 @@ commands:
               circleci step halt
             fi
 
-  relocate-docker-storage:
+  relocate-docker-data-root:
     description: >-
-      If this runs in parallel it can slaughter docker builds due to behaviour in the overlay2
-      tree having missing bits. This mitigates that by ensuring we run it only once. This could
-      have parallelization consequences if everything lines up.
+      Relocates docker data root from /var/lib/docker/ cause it allocated in a partition too small to contain the redisai-gpu image.
+      This could have parallelization consequences if everything lines up.
     steps:
       - run:
-          name: Relocate docker overlay2 dir
+          name: Relocate docker data root dir
           command: |
             sudo systemctl stop docker
             sudo mkdir -p /var2/lib/docker
-            sudo mv /var/lib/docker/overlay2 /var2/lib/docker
-            sudo mkdir /var/lib/docker/overlay2
-            sudo mount --bind /var2/lib/docker/overlay2 /var/lib/docker/overlay2
+            echo '{ "data-root": "/var2/lib/docker" }' | sudo tee /etc/docker/daemon.json
+            sudo cp -axT /var/lib/docker /var2/lib/docker
             sudo systemctl start docker
 
   setup-automation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,7 +597,7 @@ workflows:
           <<: *on-any-branch
           <<: *after-linter
       - build-and-test-gpu:
-          <<: *on-integ-branch
+          <<: *on-any-branch
           <<: *after-linter
       - build-and-test-gpu-for-forked-prs:
           <<: *on-any-branch


### PR DESCRIPTION
The issue is basically related to [DSU](https://circleci.com/docs/docker-layer-caching/) that caching entire `/var/lib/docker` folder to the remote volume which make it work inconsistent in cases where docker data root is being moved to a different volume (which is not being cached). So thats leaving a pointers in docker to the layers that are not existing in the new builds 