### PR TITLE
download official onnx releases

### DIFF
--- a/get_deps.sh
+++ b/get_deps.sh
@@ -220,7 +220,7 @@ fi # WITH_PT
 
 ############################################################################# ONNX
 
-ORT_URL_BASE=https://s3.amazonaws.com/redismodules/onnxruntime
+ORT_URL_BASE=https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}
 ORT_BUILD=""
 if [[ $OS == linux ]]; then
     ORT_OS=linux
@@ -236,7 +236,6 @@ elif [[ $OS == macos ]]; then
     ORT_OS=osx
     ORT_ARCH=x86_64
     ORT_BUILD=""
-    ORT_URL_BASE=https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}
 fi
 
 ORT_ARCHIVE=onnxruntime-${ORT_OS}-${ORT_ARCH}${ORT_BUILD}-${ORT_VERSION}.tgz


### PR DESCRIPTION
Greetings, 
Image used: `redislabs/redisai:1.2.7-gpu-bionic`

During my testing of RedisAI, I found that when running ONNX models, GPU could not be used, and every attempt failed. RedisAI would use the CPU instead.
When adding a model with ```con.modelset('test', 'ONNX', 'GPU', m1)``` RedisAI produced an error as bellow.
```bash
redisai-redisai-1  | 2023-12-09 14:01:51.062001467 [E:onnxruntime:RedisAI, provider_bridge_ort.cc:964 Ensure] Failed to load library libonnxruntime_providers_shared.so with error: libonnxruntime_providers_shared.so: cannot open shared object file: No such file or directory
```
Looking at the container and the libraries located there I get this:
```bash
root@32f5fdc976e8:/# du -h /var/opt/redislabs/artifacts/redisai-gpu-onnxruntime.linux-bionic-x64.1.2.7.tgz
5.6M	/var/opt/redislabs/artifacts/redisai-gpu-onnxruntime.linux-bionic-x64.1.2.7.tgz
```
After analyzing the code and performing some debugging, I discovered that `get_deps.sh` script downloads onnxruntime binaries from `https://s3.amazonaws.com/redismodules/onnxruntime`. Specifically, it fetches the file `https://s3.amazonaws.com/redismodules/onnxruntime/onnxruntime-linux-x64-gpu-1.11.1.tgz`, which has a size of approximately 5MB. I noticed that this file size is significantly smaller than the official GPU release for ONNX Runtime available at `https://github.com/microsoft/onnxruntime/releases/download/v1.11.1/onnxruntime-linux-x64-gpu-1.11.1.tgz`, which exceeds 100MB in size.

To make the RedisAI container run on GPU, I replaced the onnxruntime files by voluming the onnx directory. After this change, the container was able to run on GPU.

Based on my investigation, it appears that the root cause of the issue was the wrong onnxruntime file uploaded to the RedisAI AWS host. To fix this, I changed the `ORT_URL_BASE` in `$OS == linux` to download from onnxruntime's Github page. This change enabled the container to run on GPU for ONNX models properly.
 
here's a PR with the required changes.

