### PR TITLE
Add 'no longer supported' banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 [![Forum](https://img.shields.io/badge/Forum-RedisAI-blue)](https://forum.redislabs.com/c/modules/redisai)
 [![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/rTQm7UZ)
 
+> [!CAUTION]
+> **RedisAI is no longer actively maintained or supported.**
+>
+> We are grateful to the RedisAI community for their interest and support.
+
 # RedisAI
 RedisAI is a Redis module for executing Deep Learning/Machine Learning models and managing their data. Its purpose is being a "workhorse" for model serving, by providing out-of-the-box support for popular DL/ML frameworks and unparalleled performance. **RedisAI both maximizes computation throughput and reduces latency by adhering to the principle of data locality**, as well as simplifies the deployment and serving of graphs by leveraging on Redis' production-proven infrastructure.
 


### PR DESCRIPTION
Add banner to show the current status of RedisAI to make it clear to the community that it is no longer actively maintained or supported.